### PR TITLE
New Take on adding Flow Types

### DIFF
--- a/examples/flow-counter/.babelrc
+++ b/examples/flow-counter/.babelrc
@@ -1,0 +1,17 @@
+{
+  "stage": 2,
+  "env": {
+    "development": {
+      "plugins": [
+        "react-transform"
+      ],
+      "extra": {
+        "react-transform": [{
+          "target":  "react-transform-hmr",
+          "imports": ["react"],
+          "locals":  ["module"]
+        }]
+      }
+    }
+  }
+}

--- a/examples/flow-counter/.flowconfig
+++ b/examples/flow-counter/.flowconfig
@@ -1,0 +1,16 @@
+[ignore]
+.*/node_modules/
+# .*/node_modules/webpack/.*
+# .*/node_modules/redux/examples/.*
+# .*/node_modules/redux/lib/.*
+# Ignoring analyzing redux for now since I can't find a way for it to not also select redux-thunk (need a better regex)
+# module.name_mapper='^\(redux\)$' -> '\1/src/index'
+
+[include]
+
+[libs]
+interfaces/
+
+
+[options]
+module.system=node

--- a/examples/flow-counter/.flowconfig
+++ b/examples/flow-counter/.flowconfig
@@ -1,10 +1,5 @@
 [ignore]
 .*/node_modules/
-# .*/node_modules/webpack/.*
-# .*/node_modules/redux/examples/.*
-# .*/node_modules/redux/lib/.*
-# Ignoring analyzing redux for now since I can't find a way for it to not also select redux-thunk (need a better regex)
-# module.name_mapper='^\(redux\)$' -> '\1/src/index'
 
 [include]
 

--- a/examples/flow-counter/actions/counter.js
+++ b/examples/flow-counter/actions/counter.js
@@ -1,7 +1,8 @@
 /* @flow */
 
 import type { Action, AppState } from '../types';
-import type { Thunk } from 'redux-thunk';
+
+type Thunk<S, D> = reduxThunk$Thunk<S, D>;
 
 export const INCREMENT_COUNTER = 'INCREMENT_COUNTER';
 export const DECREMENT_COUNTER = 'DECREMENT_COUNTER';

--- a/examples/flow-counter/actions/counter.js
+++ b/examples/flow-counter/actions/counter.js
@@ -1,0 +1,39 @@
+/* @flow */
+
+import type { Action, AppState } from '../types';
+import type { Thunk } from 'redux-thunk';
+
+export const INCREMENT_COUNTER = 'INCREMENT_COUNTER';
+export const DECREMENT_COUNTER = 'DECREMENT_COUNTER';
+
+export function increment() : Action {
+  return {
+    type: INCREMENT_COUNTER
+  };
+}
+
+export function decrement() : Action {
+  return {
+    type: DECREMENT_COUNTER
+  };
+}
+
+export function incrementIfOdd() : Thunk<AppState, Action> {
+  return (dispatch, getState) => {
+    let { counter } = getState();
+
+    if (counter % 2 === 0) {
+      return;
+    }
+
+    dispatch(increment());
+  };
+}
+
+export function incrementAsync(delay: number = 1000) : Thunk<AppState, Action> {
+  return dispatch => {
+    setTimeout(() => {
+      dispatch(increment());
+    }, delay);
+  };
+}

--- a/examples/flow-counter/components/Counter.js
+++ b/examples/flow-counter/components/Counter.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 
 export type CounterProps = {
   counter: number,

--- a/examples/flow-counter/components/Counter.js
+++ b/examples/flow-counter/components/Counter.js
@@ -1,0 +1,32 @@
+/* @flow */
+
+import React, { Component, PropTypes } from 'react';
+
+export type CounterProps = {
+  counter: number,
+  increment: () => any,
+  decrement: () => any,
+  incrementIfOdd: () => any,
+  incrementAsync: () => any,
+};
+
+class Counter extends Component<any, CounterProps, any> {
+  render() : ReactElement<any, any, any> {
+    let { increment, incrementIfOdd, incrementAsync, decrement, counter } = this.props;
+    return (
+      <p>
+        Clicked: {counter} times
+        {' '}
+        <button onClick={increment}>+</button>
+        {' '}
+        <button onClick={decrement}>-</button>
+        {' '}
+        <button onClick={incrementIfOdd}>Increment if odd</button>
+        {' '}
+        <button onClick={() => incrementAsync()}>Increment async</button>
+      </p>
+    );
+  }
+}
+
+export default Counter;

--- a/examples/flow-counter/components/Counter.js
+++ b/examples/flow-counter/components/Counter.js
@@ -10,7 +10,7 @@ export type CounterProps = {
   incrementAsync: () => any,
 };
 
-class Counter extends Component<any, CounterProps, any> {
+class Counter extends Component<{}, CounterProps, {}> {
   render() : ReactElement<any, any, any> {
     let { increment, incrementIfOdd, incrementAsync, decrement, counter } = this.props;
     return (

--- a/examples/flow-counter/containers/App.js
+++ b/examples/flow-counter/containers/App.js
@@ -1,0 +1,36 @@
+/* @flow */
+
+import { connect } from 'react-redux';
+import Counter from '../components/Counter';
+import type { CounterProps } from '../components/Counter';
+import { increment, decrement, incrementIfOdd, incrementAsync } from '../actions/counter';
+import { AppState, Dispatchable } from '../types';
+import type { Dispatch } from 'redux';
+import type { Component } from 'react';
+
+type StateProps = AppState;
+
+function mapStateToProps(state : AppState) : StateProps {
+  return {
+    counter: state.counter
+  };
+}
+
+type DispatchProps = {
+  increment: () => any,
+  decrement: () => any,
+  incrementIfOdd: () => any,
+  incrementAsync: () => any
+}
+
+function mapDispatchToProps(dispatch: Dispatch<Dispatchable>) : DispatchProps {
+  return {
+    increment: (...args) => dispatch(increment(...args)),
+    decrement: (...args) => dispatch(decrement(...args)),
+    incrementIfOdd: (...args) => dispatch(incrementIfOdd(...args)),
+    incrementAsync: (...args) => dispatch(incrementAsync(...args)),
+  };
+}
+// TODO: Cannot make this to correctly type check that the resulting props match
+// the Counter prop types
+export default connect(mapStateToProps, mapDispatchToProps)(Counter);

--- a/examples/flow-counter/containers/App.js
+++ b/examples/flow-counter/containers/App.js
@@ -2,11 +2,9 @@
 
 import { connect } from 'react-redux';
 import Counter from '../components/Counter';
-import type { CounterProps } from '../components/Counter';
 import { increment, decrement, incrementIfOdd, incrementAsync } from '../actions/counter';
-import { AppState, Dispatchable } from '../types';
+import type { AppState, Dispatchable } from '../types';
 import type { Dispatch } from 'redux';
-import type { Component } from 'react';
 
 type StateProps = AppState;
 
@@ -25,12 +23,11 @@ type DispatchProps = {
 
 function mapDispatchToProps(dispatch: Dispatch<Dispatchable>) : DispatchProps {
   return {
-    increment: (...args) => dispatch(increment(...args)),
-    decrement: (...args) => dispatch(decrement(...args)),
-    incrementIfOdd: (...args) => dispatch(incrementIfOdd(...args)),
-    incrementAsync: (...args) => dispatch(incrementAsync(...args)),
+    increment: () => dispatch(increment()),
+    decrement: () => dispatch(decrement()),
+    incrementIfOdd: () => dispatch(incrementIfOdd()),
+    incrementAsync: () => dispatch(incrementAsync()),
   };
 }
-// TODO: Cannot make this to correctly type check that the resulting props match
-// the Counter prop types
+
 export default connect(mapStateToProps, mapDispatchToProps)(Counter);

--- a/examples/flow-counter/index.html
+++ b/examples/flow-counter/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redux counter example</title>
+  </head>
+  <body>
+    <div id="root">
+    </div>
+    <script src="/static/bundle.js"></script>
+  </body>
+</html>

--- a/examples/flow-counter/index.js
+++ b/examples/flow-counter/index.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import App from './containers/App';
+import configureStore from './store/configureStore';
+
+const store = configureStore();
+
+React.render(
+  <Provider store={store}>
+    {() => <App />}
+  </Provider>,
+  document.getElementById('root')
+);

--- a/examples/flow-counter/index.js
+++ b/examples/flow-counter/index.js
@@ -1,3 +1,5 @@
+/* @flow */
+
 import React from 'react';
 import { Provider } from 'react-redux';
 import App from './containers/App';
@@ -6,8 +8,8 @@ import configureStore from './store/configureStore';
 const store = configureStore();
 
 React.render(
-  <Provider store={store}>
-    {() => <App />}
-  </Provider>,
+  // Flow limitation: Does not detect children type if we don't explicitly
+  // set the `children` prop
+  <Provider store={store} children={() => <App />} />,
   document.getElementById('root')
 );

--- a/examples/flow-counter/interfaces/react-redux.js
+++ b/examples/flow-counter/interfaces/react-redux.js
@@ -1,10 +1,6 @@
-import type { Component } from 'react';
-import type { Dispatch, Store } from 'redux';
-
-
 declare module 'react-redux' {
   declare type MapStateToProps<State, Props> = (state: State) => Props;
-  declare type MapDispatchToProps<Dispatchable, Props> = (dispatch: Dispatch<Dispatchable>) => Props;
+  declare type MapDispatchToProps<Dispatchable, Props> = (dispatch: redux$Dispatch<Dispatchable>) => Props;
 
   declare function connect<State, Dispatchable, StateProps, ComponentProps, DispatchProps: $Diff<ComponentProps, StateProps>, ComponentDefaultProps, ComponentState>(
     mapStateToProps: MapStateToProps<State, StateProps>,
@@ -12,9 +8,6 @@ declare module 'react-redux' {
   ) : (component: ReactClass<ComponentDefaultProps, ComponentProps, ComponentState>) => ReactClass<ComponentDefaultProps, ComponentProps, ComponentState>;
 
   declare type ProviderProps<S, D> = {
-    // TODO: For some super weird reason I need to use this global declaration of the store,
-    // otherwise this doesn't run type checks (never throws an error).
-    // If I use the Store type imported from 'redux' here, it will treat it as "any"
     store: redux$Store<S, D>,
     children?: () => ReactElement<any, any, any>
   };

--- a/examples/flow-counter/interfaces/react-redux.js
+++ b/examples/flow-counter/interfaces/react-redux.js
@@ -1,5 +1,5 @@
-import type { Dispatch } from 'redux';
 import type { Component } from 'react';
+import type { Dispatch, Store } from 'redux';
 
 declare module 'react-redux' {
   declare type MapStateToProps<State, Props> = (state: State) => Props;
@@ -9,4 +9,14 @@ declare module 'react-redux' {
     mapStateToProps: MapStateToProps<State, StateProps>,
     mapDispatchToProps: MapDispatchToProps<Dispatchable, DispatchProps>
   ) : (component: Component<DefaultProps, ComponentProps, ComponentState>) => Component<DefaultProps, ComponentProps, ComponentState>;
+
+  declare type ProviderProps<S, D> = {
+    // TODO: For some super weird reason I need to use this global declaration of the store,
+    // otherwise this doesn't run type checks (never throws an error).
+    // If I use the Store type imported from 'redux' here, it will treat it as "any"
+    store: redux$Store<S, D>,
+    children?: () => ReactElement<any, any, any>
+  };
+
+  declare class Provider<S, D> extends ReactComponent<{}, ProviderProps<S, D>, {}> {}
 }

--- a/examples/flow-counter/interfaces/react-redux.js
+++ b/examples/flow-counter/interfaces/react-redux.js
@@ -1,14 +1,15 @@
 import type { Component } from 'react';
 import type { Dispatch, Store } from 'redux';
 
+
 declare module 'react-redux' {
   declare type MapStateToProps<State, Props> = (state: State) => Props;
   declare type MapDispatchToProps<Dispatchable, Props> = (dispatch: Dispatch<Dispatchable>) => Props;
 
-  declare function connect<State, Dispatchable, ComponentProps, DefaultProps, ComponentState, StateProps, DispatchProps: $Diff<ComponentProps, StateProps>>(
+  declare function connect<State, Dispatchable, StateProps, ComponentProps, DispatchProps: $Diff<ComponentProps, StateProps>, ComponentDefaultProps, ComponentState>(
     mapStateToProps: MapStateToProps<State, StateProps>,
     mapDispatchToProps: MapDispatchToProps<Dispatchable, DispatchProps>
-  ) : (component: Component<DefaultProps, ComponentProps, ComponentState>) => Component<DefaultProps, ComponentProps, ComponentState>;
+  ) : (component: ReactClass<ComponentDefaultProps, ComponentProps, ComponentState>) => ReactClass<ComponentDefaultProps, ComponentProps, ComponentState>;
 
   declare type ProviderProps<S, D> = {
     // TODO: For some super weird reason I need to use this global declaration of the store,

--- a/examples/flow-counter/interfaces/react-redux.js
+++ b/examples/flow-counter/interfaces/react-redux.js
@@ -1,0 +1,12 @@
+import type { Dispatch } from 'redux';
+import type { Component } from 'react';
+
+declare module 'react-redux' {
+  declare type MapStateToProps<State, Props> = (state: State) => Props;
+  declare type MapDispatchToProps<Dispatchable, Props> = (dispatch: Dispatch<Dispatchable>) => Props;
+
+  declare function connect<State, Dispatchable, ComponentProps, DefaultProps, ComponentState, StateProps, DispatchProps: $Diff<ComponentProps, StateProps>>(
+    mapStateToProps: MapStateToProps<State, StateProps>,
+    mapDispatchToProps: MapDispatchToProps<Dispatchable, DispatchProps>
+  ) : (component: Component<DefaultProps, ComponentProps, ComponentState>) => Component<DefaultProps, ComponentProps, ComponentState>;
+}

--- a/examples/flow-counter/interfaces/redux-thunk.js
+++ b/examples/flow-counter/interfaces/redux-thunk.js
@@ -1,0 +1,13 @@
+import type { Middleware, MiddlewareAPI, Dispatch, Store } from 'redux';
+
+declare module 'redux-thunk' {
+  declare type Thunk<State, Dispatchable> = (dispatch: Dispatch<Dispatchable>, getState: () => State) => ?Dispatchable;
+  declare type ThunkMiddlewareDispatchable<State, Dispatchable> = Thunk<State, Dispatchable> | Dispatchable;
+
+  // Cannot find a way to export the default function with the correct type signature
+  // declare var exports: {
+  //   <State, Dispatchable>(
+  //     api: MiddlewareAPI<State, ThunkMiddlewareDispatchable<State, Dispatchable>>
+  //   ) : (next: Dispatch<Dispatchable>) => Dispatch<ThunkMiddlewareDispatchable<State, Dispatchable>>
+  // };
+}

--- a/examples/flow-counter/interfaces/redux-thunk.js
+++ b/examples/flow-counter/interfaces/redux-thunk.js
@@ -1,4 +1,4 @@
-import type { Middleware, MiddlewareAPI, Dispatch, Store } from 'redux';
+import type { MiddlewareAPI, Dispatch } from 'redux';
 
 // For now declaring these types globally with a namespace, so I can
 // export the default function in the module

--- a/examples/flow-counter/interfaces/redux-thunk.js
+++ b/examples/flow-counter/interfaces/redux-thunk.js
@@ -1,13 +1,25 @@
 import type { Middleware, MiddlewareAPI, Dispatch, Store } from 'redux';
 
-declare module 'redux-thunk' {
-  declare type Thunk<State, Dispatchable> = (dispatch: Dispatch<Dispatchable>, getState: () => State) => ?Dispatchable;
-  declare type ThunkMiddlewareDispatchable<State, Dispatchable> = Thunk<State, Dispatchable> | Dispatchable;
+// For now declaring these types globally with a namespace, so I can
+// export the default function in the module
+declare type reduxThunk$Thunk<State, Dispatchable> = (dispatch: Dispatch<Dispatchable>, getState: () => State) => ?Dispatchable;
+declare type reduxThunk$ThunkMiddlewareDispatchable<State, Dispatchable> = reduxThunk$Thunk<State, Dispatchable> | Dispatchable;
 
-  // Cannot find a way to export the default function with the correct type signature
-  // declare var exports: {
-  //   <State, Dispatchable>(
-  //     api: MiddlewareAPI<State, ThunkMiddlewareDispatchable<State, Dispatchable>>
-  //   ) : (next: Dispatch<Dispatchable>) => Dispatch<ThunkMiddlewareDispatchable<State, Dispatchable>>
-  // };
+declare module 'redux-thunk' {
+  declare var exports: {
+    <State, Dispatchable>(
+      api: MiddlewareAPI<State, reduxThunk$ThunkMiddlewareDispatchable<State, Dispatchable>>
+    ) : (next: Dispatch<Dispatchable>) => Dispatch<reduxThunk$ThunkMiddlewareDispatchable<State, Dispatchable>>
+  };
 }
+
+// function thunk<State, Dispatchable: Object>(_ref: MiddlewareAPI<State, ThunkMiddlewareDispatchable<State, Dispatchable>>) : (next: Dispatch<Dispatchable>) => Dispatch<ThunkMiddlewareDispatchable<State, Dispatchable>> {
+//   var dispatch = _ref.dispatch;
+//   var getState = _ref.getState;
+//
+//   return function (next) {
+//     return function (action: ThunkMiddlewareDispatchable<State, Dispatchable>) : ?ThunkMiddlewareDispatchable<State, Dispatchable> {
+//       return typeof action === 'function' ? action(dispatch, getState) : next(action);
+//     };
+//   };
+// }

--- a/examples/flow-counter/interfaces/redux-thunk.js
+++ b/examples/flow-counter/interfaces/redux-thunk.js
@@ -1,15 +1,13 @@
-import type { MiddlewareAPI, Dispatch } from 'redux';
-
 // For now declaring these types globally with a namespace, so I can
 // export the default function in the module
-declare type reduxThunk$Thunk<State, Dispatchable> = (dispatch: Dispatch<Dispatchable>, getState: () => State) => ?Dispatchable;
+declare type reduxThunk$Thunk<State, Dispatchable> = (dispatch: redux$Dispatch<Dispatchable>, getState: () => State) => ?Dispatchable;
 declare type reduxThunk$ThunkMiddlewareDispatchable<State, Dispatchable> = reduxThunk$Thunk<State, Dispatchable> | Dispatchable;
 
 declare module 'redux-thunk' {
   declare var exports: {
     <State, Dispatchable>(
-      api: MiddlewareAPI<State, reduxThunk$ThunkMiddlewareDispatchable<State, Dispatchable>>
-    ) : (next: Dispatch<Dispatchable>) => Dispatch<reduxThunk$ThunkMiddlewareDispatchable<State, Dispatchable>>
+      api: redux$MiddlewareAPI<State, reduxThunk$ThunkMiddlewareDispatchable<State, Dispatchable>>
+    ) : (next: redux$Dispatch<Dispatchable>) => redux$Dispatch<reduxThunk$ThunkMiddlewareDispatchable<State, Dispatchable>>
   };
 }
 

--- a/examples/flow-counter/interfaces/redux.js
+++ b/examples/flow-counter/interfaces/redux.js
@@ -1,0 +1,27 @@
+declare module "redux" {
+  declare type ReduxInitAction = {type: '@@redux/INIT'};
+  declare type ReduxAction<Action> = ReduxInitAction | Action;
+
+  declare type Reducer<State, Action> = (state?: State, action: ReduxAction<Action>) => State;
+  declare type Dispatch<Dispatchable> = (action: Dispatchable) => ?Dispatchable;
+
+  declare type Store<State, Action, Dispatchable> = {
+    dispatch: Dispatch<Dispatchable>,
+    subscribe: (listener: () => void) => (() => void),
+    getState: () => State,
+    replaceReducer: any
+  };
+
+  declare type CreateStore<State, Action, Dispatchable> = (reducer: Reducer<State, Action>, initialState?: State) => Store<State, Action, Dispatchable>
+  declare function createStore<State, Action>(reducer: Reducer<State, Action>, initialState?: State) : Store<State, Action, ReduxAction<Action>>;
+
+  declare type MiddlewareAPI<State, Dispatchable> = {
+    dispatch: Dispatch<Dispatchable>,
+    getState: () => State,
+  };
+
+  declare type Middleware<State, Dispatchable, DispatchableNext> = (api: MiddlewareAPI<State, Dispatchable>) => (next: Dispatch<DispatchableNext>) => Dispatch<Dispatchable>;
+
+  declare function applyMiddleware<State, Action, Dispatchable, DispatchableNext>(middleware: Middleware<State, Dispatchable, DispatchableNext>)
+    : (next: CreateStore<State, Action, DispatchableNext>) => CreateStore<State, Action, Dispatchable>;
+}

--- a/examples/flow-counter/interfaces/redux.js
+++ b/examples/flow-counter/interfaces/redux.js
@@ -7,6 +7,17 @@ declare type redux$Store<State, Dispatchable> = {
   replaceReducer: any
 };
 
+declare type redux$MiddlewareAPI<State, Dispatchable> = {
+  dispatch: redux$Dispatch<Dispatchable>,
+  getState: () => State,
+};
+
+declare type redux$Middleware<State, Dispatchable, DispatchableNext> = (
+  api: redux$MiddlewareAPI<State, Dispatchable>
+) => (
+  next: redux$Dispatch<DispatchableNext>
+) => redux$Dispatch<Dispatchable>;
+
 declare module "redux" {
   declare type ReduxInitAction = { type: '@@redux/INIT' };
   declare type ReduxAction<Action> = ReduxInitAction | Action;
@@ -19,12 +30,9 @@ declare module "redux" {
   declare type CreateStore<State, Action, Dispatchable> = (reducer: Reducer<State, Action>, initialState?: State) => Store<State, Dispatchable>
   declare function createStore<State, Action>(reducer: Reducer<State, Action>, initialState?: State) : Store<State, ReduxAction<Action>>;
 
-  declare type MiddlewareAPI<State, Dispatchable> = {
-    dispatch: Dispatch<Dispatchable>,
-    getState: () => State,
-  };
+  declare type MiddlewareAPI<State, Dispatchable> = redux$MiddlewareAPI<State, Dispatchable>;
 
-  declare type Middleware<State, Dispatchable, DispatchableNext> = (api: MiddlewareAPI<State, Dispatchable>) => (next: Dispatch<DispatchableNext>) => Dispatch<Dispatchable>;
+  declare type Middleware<State, Dispatchable, DispatchableNext> = redux$Middleware<State, Dispatchable, DispatchableNext>;
 
   declare function applyMiddleware<State, Action, Dispatchable, DispatchableNext>(middleware: Middleware<State, Dispatchable, DispatchableNext>)
     : (next: CreateStore<State, Action, DispatchableNext>) => CreateStore<State, Action, Dispatchable>;

--- a/examples/flow-counter/interfaces/redux.js
+++ b/examples/flow-counter/interfaces/redux.js
@@ -1,19 +1,23 @@
+declare type redux$Dispatch<Dispatchable> = (action: Dispatchable) => ?Dispatchable;
+
+declare type redux$Store<State, Dispatchable> = {
+  dispatch: redux$Dispatch<Dispatchable>,
+  subscribe: (listener: () => void) => (() => void),
+  getState: () => State,
+  replaceReducer: any
+};
+
 declare module "redux" {
-  declare type ReduxInitAction = {type: '@@redux/INIT'};
+  declare type ReduxInitAction = { type: '@@redux/INIT' };
   declare type ReduxAction<Action> = ReduxInitAction | Action;
 
   declare type Reducer<State, Action> = (state?: State, action: ReduxAction<Action>) => State;
-  declare type Dispatch<Dispatchable> = (action: Dispatchable) => ?Dispatchable;
+  declare type Dispatch<Dispatchable> = redux$Dispatch<Dispatchable>;
 
-  declare type Store<State, Action, Dispatchable> = {
-    dispatch: Dispatch<Dispatchable>,
-    subscribe: (listener: () => void) => (() => void),
-    getState: () => State,
-    replaceReducer: any
-  };
+  declare type Store<State, Dispatchable> = redux$Store<State, Dispatchable>;
 
-  declare type CreateStore<State, Action, Dispatchable> = (reducer: Reducer<State, Action>, initialState?: State) => Store<State, Action, Dispatchable>
-  declare function createStore<State, Action>(reducer: Reducer<State, Action>, initialState?: State) : Store<State, Action, ReduxAction<Action>>;
+  declare type CreateStore<State, Action, Dispatchable> = (reducer: Reducer<State, Action>, initialState?: State) => Store<State, Dispatchable>
+  declare function createStore<State, Action>(reducer: Reducer<State, Action>, initialState?: State) : Store<State, ReduxAction<Action>>;
 
   declare type MiddlewareAPI<State, Dispatchable> = {
     dispatch: Dispatch<Dispatchable>,

--- a/examples/flow-counter/package.json
+++ b/examples/flow-counter/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "redux-flow-counter-example",
+  "version": "0.0.0",
+  "description": "Redux Flow counter example",
+  "scripts": {
+    "start": "node server.js",
+    "test": "NODE_ENV=test mocha --recursive --compilers js:babel-core/register",
+    "test:watch": "npm test -- --watch"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rackt/redux.git"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/rackt/redux/issues"
+  },
+  "homepage": "http://rackt.github.io/redux",
+  "dependencies": {
+    "react": "^0.13.3",
+    "react-redux": "^2.1.2",
+    "redux": "file:../../",
+    "redux-thunk": "^0.1.0"
+  },
+  "devDependencies": {
+    "babel-core": "^5.6.18",
+    "babel-loader": "^5.1.4",
+    "babel-plugin-react-transform": "^1.0.3",
+    "expect": "^1.6.0",
+    "express": "^4.13.3",
+    "jsdom": "^5.6.1",
+    "mocha": "^2.2.5",
+    "mocha-jsdom": "^1.0.0",
+    "node-libs-browser": "^0.5.2",
+    "react-transform-hmr": "^1.0.0",
+    "webpack": "^1.9.11",
+    "webpack-dev-middleware": "^1.2.0",
+    "webpack-hot-middleware": "^2.2.0"
+  }
+}

--- a/examples/flow-counter/reducers/counter.js
+++ b/examples/flow-counter/reducers/counter.js
@@ -1,0 +1,14 @@
+/* @flow */
+
+import type { CounterState, Action } from '../types';
+
+export default function counter(state?: CounterState = 0, action: Action) : CounterState {
+  switch (action.type) {
+  case 'INCREMENT_COUNTER':
+    return state + 1;
+  case 'DECREMENT_COUNTER':
+    return state - 1;
+  default:
+    return state;
+  }
+}

--- a/examples/flow-counter/reducers/index.js
+++ b/examples/flow-counter/reducers/index.js
@@ -1,0 +1,10 @@
+/* @flow */
+
+import counter from './counter';
+import type { AppState, Action } from '../types';
+
+export default function rootReducer(state?: AppState, action : Action) : AppState {
+  return {
+    counter: counter(state && state.counter, action)
+  };
+}

--- a/examples/flow-counter/server.js
+++ b/examples/flow-counter/server.js
@@ -1,0 +1,23 @@
+var webpack = require('webpack');
+var webpackDevMiddleware = require('webpack-dev-middleware');
+var webpackHotMiddleware = require('webpack-hot-middleware');
+var config = require('./webpack.config');
+
+var app = new require('express')();
+var port = 3000;
+
+var compiler = webpack(config);
+app.use(webpackDevMiddleware(compiler, { noInfo: true, publicPath: config.output.publicPath }));
+app.use(webpackHotMiddleware(compiler));
+
+app.get("/", function(req, res) {
+  res.sendFile(__dirname + '/index.html');
+});
+
+app.listen(port, function(error) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.info("==> 🌎  Listening on port %s. Open up http://localhost:%s/ in your browser.", port, port);
+  }
+});

--- a/examples/flow-counter/store/configureStore.js
+++ b/examples/flow-counter/store/configureStore.js
@@ -1,0 +1,39 @@
+/* @flow */
+
+import { createStore, applyMiddleware } from 'redux';
+import type { Middleware, MiddlewareAPI, Dispatch, Store, ReduxAction } from 'redux';
+// import thunk from 'redux-thunk';
+import type { Thunk, ThunkMiddlewareDispatchable } from 'redux-thunk';
+import reducer from '../reducers';
+import type { AppState, Action } from '../types';
+
+// Re-defining redux-thunk here first to show how to type it, and also
+// because I don't know how to put the type in the declaration module.
+function thunk<State, Dispatchable: Object>(_ref: MiddlewareAPI<State, ThunkMiddlewareDispatchable<State, Dispatchable>>) : (next: Dispatch<Dispatchable>) => Dispatch<ThunkMiddlewareDispatchable<State, Dispatchable>> {
+  var dispatch = _ref.dispatch;
+  var getState = _ref.getState;
+
+  return function (next) {
+    return function (action: ThunkMiddlewareDispatchable<State, Dispatchable>) : ?ThunkMiddlewareDispatchable<State, Dispatchable> {
+      return typeof action === 'function' ? action(dispatch, getState) : next(action);
+    };
+  };
+}
+
+const createStoreWithMiddleware = applyMiddleware(
+  thunk
+)(createStore);
+
+export default function configureStore(initialState?: AppState) {
+  const store = createStoreWithMiddleware(reducer, initialState);
+
+  if (module.hot) {
+    // Enable Webpack hot module replacement for reducers
+    module.hot.accept('../reducers', () => {
+      const nextReducer = require('../reducers');
+      store.replaceReducer(nextReducer);
+    });
+  }
+
+  return store;
+}

--- a/examples/flow-counter/store/configureStore.js
+++ b/examples/flow-counter/store/configureStore.js
@@ -1,24 +1,12 @@
 /* @flow */
 
 import { createStore, applyMiddleware } from 'redux';
-import type { Middleware, MiddlewareAPI, Dispatch, Store, ReduxAction } from 'redux';
-// import thunk from 'redux-thunk';
-import type { Thunk, ThunkMiddlewareDispatchable } from 'redux-thunk';
+import thunk from 'redux-thunk';
+// import type { ThunkMiddlewareDispatchable } from 'redux-thunk';
 import reducer from '../reducers';
 import type { AppState, Action } from '../types';
 
-// Re-defining redux-thunk here first to show how to type it, and also
-// because I don't know how to put the type in the declaration module.
-function thunk<State, Dispatchable: Object>(_ref: MiddlewareAPI<State, ThunkMiddlewareDispatchable<State, Dispatchable>>) : (next: Dispatch<Dispatchable>) => Dispatch<ThunkMiddlewareDispatchable<State, Dispatchable>> {
-  var dispatch = _ref.dispatch;
-  var getState = _ref.getState;
-
-  return function (next) {
-    return function (action: ThunkMiddlewareDispatchable<State, Dispatchable>) : ?ThunkMiddlewareDispatchable<State, Dispatchable> {
-      return typeof action === 'function' ? action(dispatch, getState) : next(action);
-    };
-  };
-}
+type ThunkMiddlewareDispatchable<S, D> = reduxThunk$ThunkMiddlewareDispatchable<S, D>;
 
 const createStoreWithMiddleware = applyMiddleware(
   thunk

--- a/examples/flow-counter/test/actions/counter.spec.js
+++ b/examples/flow-counter/test/actions/counter.spec.js
@@ -1,0 +1,41 @@
+import expect from 'expect';
+import * as actions from '../../actions/counter';
+
+describe('actions', () => {
+  it('increment should create increment action', () => {
+    expect(actions.increment()).toEqual({ type: actions.INCREMENT_COUNTER });
+  });
+
+  it('decrement should create decrement action', () => {
+    expect(actions.decrement()).toEqual({ type: actions.DECREMENT_COUNTER });
+  });
+
+  it('incrementIfOdd should create increment action', () => {
+    const fn = actions.incrementIfOdd();
+    expect(fn).toBeA('function');
+    const dispatch = expect.createSpy();
+    const getState = () => ({ counter: 1 });
+    fn(dispatch, getState);
+    expect(dispatch).toHaveBeenCalledWith({ type: actions.INCREMENT_COUNTER });
+  });
+
+  it('incrementIfOdd shouldnt create increment action if counter is even', () => {
+    const fn = actions.incrementIfOdd();
+    const dispatch = expect.createSpy();
+    const getState = () => ({ counter: 2 });
+    fn(dispatch, getState);
+    expect(dispatch.calls.length).toBe(0);
+  });
+
+  // There's no nice way to test this at the moment...
+  it('incrementAsync', (done) => {
+    const fn = actions.incrementAsync(1);
+    expect(fn).toBeA('function');
+    const dispatch = expect.createSpy();
+    fn(dispatch);
+    setTimeout(() => {
+      expect(dispatch).toHaveBeenCalledWith({ type: actions.INCREMENT_COUNTER });
+      done();
+    }, 5);
+  });
+});

--- a/examples/flow-counter/test/components/Counter.spec.js
+++ b/examples/flow-counter/test/components/Counter.spec.js
@@ -1,0 +1,57 @@
+import expect from 'expect';
+import jsdomReact from '../jsdomReact';
+import React from 'react/addons';
+import Counter from '../../components/Counter';
+
+const { TestUtils } = React.addons;
+
+function setup() {
+  const actions = {
+    increment: expect.createSpy(),
+    incrementIfOdd: expect.createSpy(),
+    incrementAsync: expect.createSpy(),
+    decrement: expect.createSpy()
+  };
+  const component = TestUtils.renderIntoDocument(<Counter counter={1} {...actions} />);
+  return {
+    component: component,
+    actions: actions,
+    buttons: TestUtils.scryRenderedDOMComponentsWithTag(component, 'button').map(button => {
+      return button.getDOMNode();
+    }),
+    p: TestUtils.findRenderedDOMComponentWithTag(component, 'p').getDOMNode()
+  };
+}
+
+describe('Counter component', () => {
+  jsdomReact();
+
+  it('should display count', () => {
+    const { p } = setup();
+    expect(p.textContent).toMatch(/^Clicked: 1 times/);
+  });
+
+  it('first button should call increment', () => {
+    const { buttons, actions } = setup();
+    TestUtils.Simulate.click(buttons[0]);
+    expect(actions.increment).toHaveBeenCalled();
+  });
+
+  it('second button should call decrement', () => {
+    const { buttons, actions } = setup();
+    TestUtils.Simulate.click(buttons[1]);
+    expect(actions.decrement).toHaveBeenCalled();
+  });
+
+  it('third button should call incrementIfOdd', () => {
+    const { buttons, actions } = setup();
+    TestUtils.Simulate.click(buttons[2]);
+    expect(actions.incrementIfOdd).toHaveBeenCalled();
+  });
+
+  it('fourth button should call incrementAsync', () => {
+    const { buttons, actions } = setup();
+    TestUtils.Simulate.click(buttons[3]);
+    expect(actions.incrementAsync).toHaveBeenCalled();
+  });
+});

--- a/examples/flow-counter/test/containers/App.spec.js
+++ b/examples/flow-counter/test/containers/App.spec.js
@@ -1,0 +1,59 @@
+import expect from 'expect';
+import jsdomReact from '../jsdomReact';
+import React from 'react/addons';
+import { Provider } from 'react-redux';
+import App from '../../containers/App';
+import configureStore from '../../store/configureStore';
+
+const { TestUtils } = React.addons;
+
+function setup(initialState) {
+  const store = configureStore(initialState);
+  const app = TestUtils.renderIntoDocument(
+    <Provider store={store}>
+      {() => <App />}
+    </Provider>
+  );
+  return {
+    app: app,
+    buttons: TestUtils.scryRenderedDOMComponentsWithTag(app, 'button').map(button => {
+      return button.getDOMNode();
+    }),
+    p: TestUtils.findRenderedDOMComponentWithTag(app, 'p').getDOMNode()
+  };
+}
+
+describe('containers', () => {
+  jsdomReact();
+
+  describe('App', () => {
+    it('should display initial count', () => {
+      const { p } = setup();
+      expect(p.textContent).toMatch(/^Clicked: 0 times/);
+    });
+
+    it('should display updated count after increment button click', () => {
+      const { buttons, p } = setup();
+      TestUtils.Simulate.click(buttons[0]);
+      expect(p.textContent).toMatch(/^Clicked: 1 times/);
+    });
+
+    it('should display updated count after decrement button click', () => {
+      const { buttons, p } = setup();
+      TestUtils.Simulate.click(buttons[1]);
+      expect(p.textContent).toMatch(/^Clicked: -1 times/);
+    });
+
+    it('shouldnt change if even and if odd button clicked', () => {
+      const { buttons, p } = setup();
+      TestUtils.Simulate.click(buttons[2]);
+      expect(p.textContent).toMatch(/^Clicked: 0 times/);
+    });
+
+    it('should change if odd and if odd button clicked', () => {
+      const { buttons, p } = setup({ counter: 1 });
+      TestUtils.Simulate.click(buttons[2]);
+      expect(p.textContent).toMatch(/^Clicked: 2 times/);
+    });
+  });
+});

--- a/examples/flow-counter/test/jsdomReact.js
+++ b/examples/flow-counter/test/jsdomReact.js
@@ -1,0 +1,7 @@
+import ExecutionEnvironment from 'react/lib/ExecutionEnvironment';
+import jsdom from 'mocha-jsdom';
+
+export default function jsdomReact() {
+  jsdom();
+  ExecutionEnvironment.canUseDOM = true;
+}

--- a/examples/flow-counter/test/reducers/counter.spec.js
+++ b/examples/flow-counter/test/reducers/counter.spec.js
@@ -1,0 +1,23 @@
+import expect from 'expect';
+import counter from '../../reducers/counter';
+import { INCREMENT_COUNTER, DECREMENT_COUNTER } from '../../actions/counter';
+
+describe('reducers', () => {
+  describe('counter', () => {
+    it('should handle initial state', () => {
+      expect(counter(undefined, {})).toBe(0);
+    });
+
+    it('should handle INCREMENT_COUNTER', () => {
+      expect(counter(1, { type: INCREMENT_COUNTER })).toBe(2);
+    });
+
+    it('should handle DECREMENT_COUNTER', () => {
+      expect(counter(1, { type: DECREMENT_COUNTER })).toBe(0);
+    });
+
+    it('should handle unknown action type', () => {
+      expect(counter(1, { type: 'unknown' })).toBe(1);
+    });
+  });
+});

--- a/examples/flow-counter/types.js
+++ b/examples/flow-counter/types.js
@@ -1,0 +1,18 @@
+/* @flow */
+
+import type { ThunkMiddlewareDispatchable } from 'redux-thunk';
+import type { ReduxAction } from 'redux';
+
+export type CounterState = number;
+
+export type AppState = {
+  counter: CounterState
+}
+
+// Need to explicitly put this here due to a bug in Flow: https://github.com/facebook/flow/issues/582
+export type Action =
+  { type: '@@redux/INIT'} |
+  { type: 'INCREMENT_COUNTER' } |
+  { type: 'DECREMENT_COUNTER' };
+
+export type Dispatchable = ThunkMiddlewareDispatchable<AppState, ReduxAction<Action>>;

--- a/examples/flow-counter/types.js
+++ b/examples/flow-counter/types.js
@@ -1,8 +1,7 @@
 /* @flow */
 
-// import type { ThunkMiddlewareDispatchable } from 'redux-thunk';
 import type { ReduxAction } from 'redux';
-
+// import type { ThunkMiddlewareDispatchable } from 'redux-thunk';
 type ThunkMiddlewareDispatchable<S, D> = reduxThunk$ThunkMiddlewareDispatchable<S, D>;
 
 export type CounterState = number;
@@ -17,4 +16,4 @@ type AppAction =
 
 export type Action = ReduxAction<AppAction>;
 
-export type Dispatchable = ThunkMiddlewareDispatchable<AppState, ReduxAction<Action>>;
+export type Dispatchable = ThunkMiddlewareDispatchable<AppState, Action>;

--- a/examples/flow-counter/types.js
+++ b/examples/flow-counter/types.js
@@ -1,7 +1,9 @@
 /* @flow */
 
-import type { ThunkMiddlewareDispatchable } from 'redux-thunk';
+// import type { ThunkMiddlewareDispatchable } from 'redux-thunk';
 import type { ReduxAction } from 'redux';
+
+type ThunkMiddlewareDispatchable<S, D> = reduxThunk$ThunkMiddlewareDispatchable<S, D>;
 
 export type CounterState = number;
 
@@ -9,10 +11,10 @@ export type AppState = {
   counter: CounterState
 }
 
-// Need to explicitly put this here due to a bug in Flow: https://github.com/facebook/flow/issues/582
-export type Action =
-  { type: '@@redux/INIT'} |
+type AppAction =
   { type: 'INCREMENT_COUNTER' } |
   { type: 'DECREMENT_COUNTER' };
+
+export type Action = ReduxAction<AppAction>;
 
 export type Dispatchable = ThunkMiddlewareDispatchable<AppState, ReduxAction<Action>>;

--- a/examples/flow-counter/webpack.config.js
+++ b/examples/flow-counter/webpack.config.js
@@ -1,0 +1,45 @@
+var path = require('path');
+var webpack = require('webpack');
+
+module.exports = {
+  devtool: 'cheap-module-eval-source-map',
+  entry: [
+    'webpack-hot-middleware/client',
+    './index'
+  ],
+  output: {
+    path: path.join(__dirname, 'dist'),
+    filename: 'bundle.js',
+    publicPath: '/static/'
+  },
+  plugins: [
+    new webpack.optimize.OccurenceOrderPlugin(),
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.NoErrorsPlugin()
+  ],
+  module: {
+    loaders: [{
+      test: /\.js$/,
+      loaders: ['babel'],
+      exclude: /node_modules/,
+      include: __dirname
+    }]
+  }
+};
+
+
+// When inside Redux repo, prefer src to compiled version.
+// You can safely delete these lines in your project.
+var reduxSrc = path.join(__dirname, '..', '..', 'src');
+var reduxNodeModules = path.join(__dirname, '..', '..', 'node_modules');
+var fs = require('fs');
+if (fs.existsSync(reduxSrc) && fs.existsSync(reduxNodeModules)) {
+  // Resolve Redux to source
+  module.exports.resolve = { alias: { 'redux': reduxSrc } };
+  // Compile Redux from source
+  module.exports.module.loaders.push({
+    test: /\.js$/,
+    loaders: ['babel'],
+    include: reduxSrc
+  });
+}

--- a/flow/types.js
+++ b/flow/types.js
@@ -1,0 +1,12 @@
+/* @flow */
+
+export type ReduxInitAction = {type: '@@redux/INIT'};
+export type ReduxAction<Action> = ReduxInitAction | Action;
+
+export type Reducer<State, Action> = (state?: State, action: ReduxAction<Action>) => State;
+export type Store<State, Action> = {
+  dispatch: (action: ReduxAction<Action>) => ReduxAction<Action>,
+  subscribe: (listener: () => void) => (() => void),
+  getState: () => ?State,
+  replaceReducer: any
+};

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -1,4 +1,7 @@
+/* @flow */
 import isPlainObject from './utils/isPlainObject';
+
+import type {Reducer, Store} from '../flow/types';
 
 /**
  * These are private action types reserved by Redux.
@@ -30,7 +33,7 @@ export var ActionTypes = {
  * @returns {Store} A Redux store that lets you read the state, dispatch actions
  * and subscribe to changes.
  */
-export default function createStore(reducer, initialState) {
+export default function createStore<State, Action>(reducer: Reducer<State, Action>, initialState?: State) : Store<State, Action> {
   if (typeof reducer !== 'function') {
     throw new Error('Expected the reducer to be a function.');
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+/* @flow */
+
 import createStore from './createStore';
 import combineReducers from './utils/combineReducers';
 import bindActionCreators from './utils/bindActionCreators';

--- a/src/utils/mapValues.js
+++ b/src/utils/mapValues.js
@@ -1,3 +1,4 @@
+/* @flow */
 /**
  * Applies a function to every key-value pair inside an object.
  *
@@ -5,7 +6,7 @@
  * @param {Function} fn The mapper function that receives the value and the key.
  * @returns {Object} A new object that contains the mapped values for the keys.
  */
-export default function mapValues(obj, fn) {
+export default function mapValues<T, U>(obj: { [key: string]: T }, fn: (value: T, key: string) => U) : { [key: string]: U } {
   return Object.keys(obj).reduce((result, key) => {
     result[key] = fn(obj[key], key);
     return result;

--- a/src/utils/pick.js
+++ b/src/utils/pick.js
@@ -1,3 +1,4 @@
+/* @flow */
 /**
  * Picks key-value pairs from an object where values satisfy a predicate.
  *
@@ -5,7 +6,7 @@
  * @param {Function} fn The predicate the values must satisfy to be copied.
  * @returns {Object} The object with the values that satisfied the predicate.
  */
-export default function pick(obj, fn) {
+export default function pick<T>(obj: { [key: string]: T }, fn: (value: T) => bool) : { [key: string]: T } {
   return Object.keys(obj).reduce((result, key) => {
     if (fn(obj[key])) {
       result[key] = obj[key];


### PR DESCRIPTION
Alright, another take, but not yet complete :(

Here I mostly made the counter example work with flow types (even types for redux-thunk and react-redux, with some caveats).

I've opted for just moving on with type declaration modules instead of types in the redux src directly since I've had problems with the `name_mapper` flow option (more details on that particular line). When we solve that, and a couple more problems that hopefully we can all solve together, we can be ready to add Flow types to redux!

And if not, then it will be here for posterity to perhaps try again in a future Flow version.

Pending stuff here:

* [ ] Type src files with Flow as much as possible
* [ ] https://github.com/facebook/flow/issues/844 (fixed, but not yet released)
* [x] ~~https://github.com/facebook/flow/issues/582 (supporting union of unions, not yet fixed) This requires us to include the redux INIT action as part of the action types in userland.~~
* [ ] https://github.com/facebook/flow/issues/880 (export default functions alongside with types). Currently worked around it by defining global types similar to what they are doing here: https://github.com/facebook/flow/blob/master/lib/node.js#L903. Doing this until we have an answer.
* [x] ~~https://github.com/facebook/flow/issues/879 (type signature to signify an object type being a merge from two other object types). No workaround for this for now~~