### PR TITLE
counter example: write actual test on incrementIfOdd action

### DIFF
--- a/examples/counter/test/actions/counter.spec.js
+++ b/examples/counter/test/actions/counter.spec.js
@@ -31,6 +31,12 @@ function mockStore(getState, expectedActions, onLastAction) {
           onLastAction()
         }
         return action
+      },
+
+      verifyNoPendingActions() {
+        if(expectedActions.length > 0) {
+          throw new Error('There is undispatched actions:\n  ' + JSON.stringify(expectedActions))
+        }
       }
     }
   }
@@ -59,11 +65,11 @@ describe('actions', () => {
     store.dispatch(actions.incrementIfOdd())
   })
 
-  it('incrementIfOdd shouldnt create increment action if counter is even', (done) => {
+  it('incrementIfOdd shouldnt create increment action if counter is even', () => {
     const expectedActions = []
     const store = mockStore({ counter: 2 }, expectedActions)
     store.dispatch(actions.incrementIfOdd())
-    done()
+    store.verifyNoPendingActions()
   })
 
   it('incrementAsync should create increment action', (done) => {


### PR DESCRIPTION
Now the test on `incrementIfOdd` doesn't test it actually. `expectedActions` can contain anything, but it will not be checked because `store.dispatch` is never called. So, it would be good to call some assertion to be sure that all actions had been matched.

Also, the `verifyNoPendingActions` helper can be useful in other tests to get more descriptive message rather than `timeout of 2000ms exceeded`