### PR TITLE
Fix unknown action type handling

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -57,21 +57,9 @@ function assertReducerSanity(reducers) {
     if (typeof initialState === 'undefined') {
       throw new Error(
         `Reducer "${key}" returned undefined during initialization. ` +
-        `If the state passed to the reducer is undefined, you must ` +
-        `explicitly return the initial state. The initial state may ` +
-        `not be undefined.`
-      )
-    }
-
-    var type = '@@redux/PROBE_UNKNOWN_ACTION_' + Math.random().toString(36).substring(7).split('').join('.')
-    if (typeof reducer(undefined, { type }) === 'undefined') {
-      throw new Error(
-        `Reducer "${key}" returned undefined when probed with a random type. ` +
-        `Don't try to handle ${ActionTypes.INIT} or other actions in "redux/*" ` +
-        `namespace. They are considered private. Instead, you must return the ` +
-        `current state for any unknown actions, unless it is undefined, ` +
-        `in which case you must return the initial state, regardless of the ` +
-        `action type. The initial state may not be undefined.`
+        `If the state passed to the reducer is undefined or the action passed to the reducer ` +
+        `has an unknown type, you must explicitly return the initial state. The initial state ` +
+        `may not be undefined.`
       )
     }
   })

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -7,7 +7,7 @@ import isPlainObject from './utils/isPlainObject'
  * Do not reference these action types directly in your code.
  */
 export var ActionTypes = {
-  INIT: '@@redux/INIT'
+  INIT: '@@redux/INIT_' + Math.random().toString(36).substring(7).split('').join('.')
 }
 
 /**

--- a/test/combineReducers.spec.js
+++ b/test/combineReducers.spec.js
@@ -1,6 +1,6 @@
 import expect from 'expect'
 import { combineReducers } from '../src'
-import createStore, { ActionTypes } from '../src/createStore'
+import createStore from '../src/createStore'
 
 describe('Utils', () => {
   describe('combineReducers', () => {
@@ -66,7 +66,8 @@ describe('Utils', () => {
       )
     })
 
-    it('throws an error on first call if a reducer returns undefined initializing', () => {
+    it('throws an error on first call if a reducer could potentially return undefined when ' +
+       'undefined state is passed to it', () => {
       const reducer = combineReducers({
         counter(state, action) {
           switch (action.type) {
@@ -79,9 +80,24 @@ describe('Utils', () => {
           }
         }
       })
-      expect(() => reducer({ })).toThrow(
-        /"counter".*initialization/
-      )
+
+      expect(() => reducer(0, { type: 'increment' })).toThrow(/"counter".*initialization/)
+    })
+
+    it('throws an error on first call if a reducer could potentially return undefined for ' +
+       'unknown action types', () => {
+      const reducer = combineReducers({
+        counter(state = 0, action) {
+          switch (action.type) {
+            case 'increment':
+              return state + 1
+            case 'decrement':
+              return state - 1
+          }
+        }
+      })
+
+      expect(() => reducer(0, { type: 'increment' })).toThrow(/"counter".*initialization/)
     })
 
     it('catches error thrown in reducer when initializing and re-throw', () => {
@@ -149,27 +165,6 @@ describe('Utils', () => {
 
       const initialState = reducer(undefined, '@@INIT')
       expect(reducer(initialState, { type: 'increment' })).toNotBe(initialState)
-    })
-
-    it('throws an error on first call if a reducer attempts to handle a private action', () => {
-      const reducer = combineReducers({
-        counter(state, action) {
-          switch (action.type) {
-            case 'increment':
-              return state + 1
-            case 'decrement':
-              return state - 1
-            // Never do this in your code:
-            case ActionTypes.INIT:
-              return 0
-            default:
-              return undefined
-          }
-        }
-      })
-      expect(() => reducer()).toThrow(
-        /"counter".*private/
-      )
     })
 
     it('warns if no reducers are passed to combineReducers', () => {


### PR DESCRIPTION
As discussed in #1054, and if I understand correctly, the private action handling test is not really possible if the user has access `ActionTypes.INIT`. 

So, I changed the way `combineReducers` inits reducers by making it do a random probe and `undefined` state checks simultaneously.

I modified the tests to make sure `combineReducers` implementation throws if the given reducer could potentially return `undefined` either for an `undefined` state or an unknown action type.