### PR TITLE
Clarify comment in compose.js

### DIFF
--- a/docs/api/compose.md
+++ b/docs/api/compose.md
@@ -7,7 +7,7 @@ You might want to use it to apply several [store enhancers](../Glossary.md#store
 
 #### Arguments
 
-1. (*arguments*): The functions to compose. Each function is expected to accept a single parameter. Its return value will be provided as an argument to the function standing to the left, and so on.
+1. (*arguments*): The functions to compose. Each function is expected to accept a single parameter. Its return value will be provided as an argument to the function standing to the left, and so on. The exception is the right-most argument which can accept multiple parameters, as it will provide the signature for the resulting composed function.
 
 #### Returns
 

--- a/src/compose.js
+++ b/src/compose.js
@@ -1,10 +1,14 @@
 /**
- * Composes single-argument functions from right to left.
+ * Composes single-argument functions from right to left. The rightmost
+ * function can take multiple arguments as it provides the signature for
+ * the resulting composite function.
  *
  * @param {...Function} funcs The functions to compose.
- * @returns {Function} A function obtained by composing functions from right to
- * left. For example, compose(f, g, h) is identical to arg => f(g(h(arg))).
+ * @returns {Function} A function obtained by composing the argument functions
+ * from right to left. For example, compose(f, g, h) is identical to doing
+ * (...args) => f(g(h(...args))).
  */
+ 
 export default function compose(...funcs) {
   return (...args) => {
     if (funcs.length === 0) {


### PR DESCRIPTION
This PR updates the documentation comment in `compose.js` to clarify that the rightmost function can have multiple arguments, as it provides the signature for the resulting composite function.