### PR TITLE
Add missing dependencies to get test:examples to run

### DIFF
--- a/examples/testAll.js
+++ b/examples/testAll.js
@@ -12,6 +12,7 @@ var exampleDirs = fs.readdirSync(__dirname).filter((file) => {
 
 // Ordering is important here. `npm install` must come first.
 var cmdArgs = [
+  { cmd: 'npm', args: [ 'install' ] },
   { cmd: 'npm', args: [ 'test' ] }
 ]
 


### PR DESCRIPTION
Ran into this while trying to add component tests to the todos example. Currently running `npm run test:examples` results in the following error:
```
npm run test:examples

> redux@3.3.1 test:examples /Users/jon/Documents/Coding/Open Source/redux
> cross-env BABEL_ENV=commonjs babel-node examples/testAll.js


> redux-async-example@0.0.0 test /Users/jon/Documents/Coding/Open Source/redux/examples/async
> echo "Error: no test specified"

Error: no test specified

> redux-counter-example@0.0.0 test /Users/jon/Documents/Coding/Open Source/redux/examples/counter
> cross-env NODE_ENV=test mocha --recursive --compilers js:babel-register --require ./test/setup.js

/Users/jon/Documents/Coding/Open Source/redux/node_modules/babel-core/lib/transformation/file/options/option-manager.js:393
          throw new Error("Couldn't find preset " + JSON.stringify(val) + " relative to directory " + JSON.stringify(dirname));
          ^

Error: Couldn't find preset "es2015" relative to directory "/Users/jon/Documents/Coding/Open Source/redux/examples/counter"
    at /Users/jon/Documents/Coding/Open Source/redux/node_modules/babel-core/lib/transformation/file/options/option-manager.js:393:17
    at Array.map (native)
    at OptionManager.resolvePresets (/Users/jon/Documents/Coding/Open Source/redux/node_modules/babel-core/lib/transformation/file/options/option-manager.js:385:20)
    at OptionManager.mergePresets (/Users/jon/Documents/Coding/Open Source/redux/node_modules/babel-core/lib/transformation/file/options/option-manager.js:369:10)
    at OptionManager.mergeOptions (/Users/jon/Documents/Coding/Open Source/redux/node_modules/babel-core/lib/transformation/file/options/option-manager.js:328:14)
    at OptionManager.addConfig (/Users/jon/Documents/Coding/Open Source/redux/node_modules/babel-core/lib/transformation/file/options/option-manager.js:234:10)
    at OptionManager.findConfigs (/Users/jon/Documents/Coding/Open Source/redux/node_modules/babel-core/lib/transformation/file/options/option-manager.js:434:16)
    at OptionManager.init (/Users/jon/Documents/Coding/Open Source/redux/node_modules/babel-core/lib/transformation/file/options/option-manager.js:482:12)
    at compile (/Users/jon/Documents/Coding/Open Source/redux/node_modules/babel-register/lib/node.js:83:45)
    at loader (/Users/jon/Documents/Coding/Open Source/redux/node_modules/babel-register/lib/node.js:128:14)
    at Object.require.extensions.(anonymous function) [as .js] (/Users/jon/Documents/Coding/Open Source/redux/node_modules/babel-register/lib/node.js:138:7)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)
    at /Users/jon/Documents/Coding/Open Source/redux/node_modules/mocha/bin/_mocha:310:3
    at Array.forEach (native)
    at Object.<anonymous> (/Users/jon/Documents/Coding/Open Source/redux/node_modules/mocha/bin/_mocha:309:10)
    at Module._compile (module.js:435:26)
    at Object.Module._extensions..js (module.js:442:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
    at Function.Module.runMain (module.js:467:10)
    at startup (node.js:136:18)
    at node.js:963:3
npm ERR! Test failed.  See above for more details.
/Users/jon/Documents/Coding/Open Source/redux/examples/testAll.js:67
      throw new Error('Building examples exited with non-zero');
      ^

Error: Building examples exited with non-zero
    at Object.<anonymous> (testAll.js:33:13)
    at Module._compile (module.js:435:26)
    at loader (/Users/jon/Documents/Coding/Open Source/redux/node_modules/babel-register/lib/node.js:128:5)
    at Object.require.extensions.(anonymous function) [as .js] (/Users/jon/Documents/Coding/Open Source/redux/node_modules/babel-register/lib/node.js:138:7)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
    at Function.Module.runMain (module.js:467:10)
    at /Users/jon/Documents/Coding/Open Source/redux/node_modules/babel-cli/lib/_babel-node.js:161:27
    at Object.<anonymous> (/Users/jon/Documents/Coding/Open Source/redux/node_modules/babel-cli/lib/_babel-node.js:162:7)
    at Module._compile (module.js:435:26)
```
This PR adds the missing dependencies to get that script to run correctly.