### PR TITLE
Use react-router-redux@4

### DIFF
--- a/examples/real-world/containers/App.js
+++ b/examples/real-world/containers/App.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from 'react'
 import { connect } from 'react-redux'
-import { push } from 'react-router-redux'
+import { browserHistory } from 'react-router'
 import Explore from '../components/Explore'
 import { resetErrorMessage } from '../actions'
 
@@ -17,7 +17,7 @@ class App extends Component {
   }
 
   handleChange(nextValue) {
-    this.props.push(`/${nextValue}`)
+    browserHistory.push(`/${nextValue}`)
   }
 
   renderErrorMessage() {
@@ -56,20 +56,18 @@ App.propTypes = {
   // Injected by React Redux
   errorMessage: PropTypes.string,
   resetErrorMessage: PropTypes.func.isRequired,
-  push: PropTypes.func.isRequired,
   inputValue: PropTypes.string.isRequired,
   // Injected by React Router
   children: PropTypes.node
 }
 
-function mapStateToProps(state) {
+function mapStateToProps(state, ownProps) {
   return {
     errorMessage: state.errorMessage,
-    inputValue: state.routing.location.pathname.substring(1)
+    inputValue: ownProps.location.pathname.substring(1)
   }
 }
 
 export default connect(mapStateToProps, {
-  resetErrorMessage,
-  push
+  resetErrorMessage
 })(App)

--- a/examples/real-world/containers/RepoPage.js
+++ b/examples/real-world/containers/RepoPage.js
@@ -72,8 +72,8 @@ RepoPage.propTypes = {
   loadStargazers: PropTypes.func.isRequired
 }
 
-function mapStateToProps(state, props) {
-  const { login, name } = props.params
+function mapStateToProps(state, ownProps) {
+  const { login, name } = ownProps.params
   const {
     pagination: { stargazersByRepo },
     entities: { users, repos }

--- a/examples/real-world/containers/Root.dev.js
+++ b/examples/real-world/containers/Root.dev.js
@@ -2,15 +2,15 @@ import React, { Component, PropTypes } from 'react'
 import { Provider } from 'react-redux'
 import routes from '../routes'
 import DevTools from './DevTools'
-import { Router, browserHistory } from 'react-router'
+import { Router } from 'react-router'
 
 export default class Root extends Component {
   render() {
-    const { store } = this.props
+    const { store, history } = this.props
     return (
       <Provider store={store}>
         <div>
-          <Router history={browserHistory} routes={routes} />
+          <Router history={history} routes={routes} />
           <DevTools />
         </div>
       </Provider>

--- a/examples/real-world/containers/Root.prod.js
+++ b/examples/real-world/containers/Root.prod.js
@@ -1,14 +1,14 @@
 import React, { Component, PropTypes } from 'react'
 import { Provider } from 'react-redux'
 import routes from '../routes'
-import { Router, browserHistory } from 'react-router'
+import { Router } from 'react-router'
 
 export default class Root extends Component {
   render() {
-    const { store } = this.props
+    const { store, history } = this.props
     return (
       <Provider store={store}>
-        <Router history={browserHistory} routes={routes} />
+        <Router history={history} routes={routes} />
       </Provider>
     )
   }

--- a/examples/real-world/containers/UserPage.js
+++ b/examples/real-world/containers/UserPage.js
@@ -72,8 +72,8 @@ UserPage.propTypes = {
   loadStarred: PropTypes.func.isRequired
 }
 
-function mapStateToProps(state, props) {
-  const { login } = props.params
+function mapStateToProps(state, ownProps) {
+  const { login } = ownProps.params
   const {
     pagination: { starredByUser },
     entities: { users, repos }

--- a/examples/real-world/index.js
+++ b/examples/real-world/index.js
@@ -1,12 +1,15 @@
 import 'babel-polyfill'
 import React from 'react'
 import { render } from 'react-dom'
+import { browserHistory } from 'react-router'
+import { syncHistoryWithStore } from 'react-router-redux'
 import Root from './containers/Root'
 import configureStore from './store/configureStore'
 
 const store = configureStore()
+const history = syncHistoryWithStore(browserHistory, store)
 
 render(
-  <Root store={store} />,
+  <Root store={store} history={history} />,
   document.getElementById('root')
 )

--- a/examples/real-world/package.json
+++ b/examples/real-world/package.json
@@ -23,8 +23,8 @@
     "react": "^0.14.7",
     "react-dom": "^0.14.7",
     "react-redux": "^4.2.1",
-    "react-router": "2.0.0-rc5",
-    "react-router-redux": "^2.1.0",
+    "react-router": "2.0.0",
+    "react-router-redux": "^4.0.0-rc.1",
     "redux": "^3.2.1",
     "redux-logger": "^2.4.0",
     "redux-thunk": "^1.0.3"

--- a/examples/real-world/reducers/index.js
+++ b/examples/real-world/reducers/index.js
@@ -1,7 +1,7 @@
 import * as ActionTypes from '../actions'
 import merge from 'lodash/merge'
 import paginate from './paginate'
-import { routeReducer } from 'react-router-redux'
+import { routerReducer as routing } from 'react-router-redux'
 import { combineReducers } from 'redux'
 
 // Updates an entity cache in response to any action with response.entities.
@@ -50,8 +50,7 @@ const rootReducer = combineReducers({
   entities,
   pagination,
   errorMessage,
-  routing: routeReducer
+  routing
 })
-
 
 export default rootReducer

--- a/examples/real-world/store/configureStore.dev.js
+++ b/examples/real-world/store/configureStore.dev.js
@@ -1,26 +1,19 @@
 import { createStore, applyMiddleware, compose } from 'redux'
-import { syncHistory } from 'react-router-redux'
-import { browserHistory } from 'react-router'
-import DevTools from '../containers/DevTools'
 import thunk from 'redux-thunk'
-import api from '../middleware/api'
 import createLogger from 'redux-logger'
+import api from '../middleware/api'
 import rootReducer from '../reducers'
-
-const reduxRouterMiddleware = syncHistory(browserHistory)
+import DevTools from '../containers/DevTools'
 
 export default function configureStore(initialState) {
   const store = createStore(
     rootReducer,
     initialState,
     compose(
-      applyMiddleware(thunk, api, reduxRouterMiddleware, createLogger()),
+      applyMiddleware(thunk, api, createLogger()),
       DevTools.instrument()
     )
   )
-
-  // Required for replaying actions from devtools to work
-  reduxRouterMiddleware.listenForReplays(store)
 
   if (module.hot) {
     // Enable Webpack hot module replacement for reducers

--- a/examples/real-world/store/configureStore.prod.js
+++ b/examples/real-world/store/configureStore.prod.js
@@ -1,6 +1,4 @@
 import { createStore, applyMiddleware } from 'redux'
-import { syncHistory } from 'react-router-redux'
-import { browserHistory } from 'react-router'
 import thunk from 'redux-thunk'
 import api from '../middleware/api'
 import rootReducer from '../reducers'
@@ -9,6 +7,6 @@ export default function configureStore(initialState) {
   return createStore(
     rootReducer,
     initialState,
-    applyMiddleware(thunk, api, syncHistory(browserHistory))
+    applyMiddleware(thunk, api)
   )
 }


### PR DESCRIPTION
React Router Redux recently incorporated the changes originally suggested in #1362. The RC of 4.x is out, so I encourage you to start migrating from the old versions.

The 4.x release is motivated by the desire to fix a few long-standing hard-to-fix bugs, become closer to Redux way of doing things, and by API changes in React Router 2.0. I know this is a lot of churn but it comes out of the lessons we learned from the real world usage. After this change, the project should be much more stable.

In case you haven’t been following, here is what changed:

### You May Remove the Middleware

Since React Router 2.0 gives us convenient history singletons (`hashHistory` and `browserHistory`), the middleware to handle history actions is no longer necessary. **It still exists** for those who prefer to `dispatch(push())` rather than `history.push()`. In fact it is [as straightforward as middleware gets](https://github.com/reactjs/react-router-redux/blob/master/src/middleware.js). 

Feel free to use it if you still like it. However we encourage you to just use the singletons provided by React Router instead:

```diff
-import { syncHistory } from 'react-router-redux'
-import { browserHistory } from 'react-router'
 import thunk from 'redux-thunk'
 import createLogger from 'redux-logger'
 import api from '../middleware/api'
 import rootReducer from '../reducers'
 import DevTools from '../containers/DevTools'

-const reduxRouterMiddleware = syncHistory(browserHistory)
 
 export default function configureStore(initialState) {
   const store = createStore(
     rootReducer,
     initialState,
     compose(
-      applyMiddleware(thunk, api, reduxRouterMiddleware, createLogger()),
+      applyMiddleware(thunk, api, createLogger()),
       DevTools.instrument()
     )
   )
 
-  // Required for replaying actions from devtools to work
-  reduxRouterMiddleware.listenForReplays(store)
-
```

```diff
 import React, { Component, PropTypes } from 'react'
 import { connect } from 'react-redux'
-import { push } from 'react-router-redux'
+import { browserHistory } from 'react-router'
 import Explore from '../components/Explore'
 import { resetErrorMessage } from '../actions'
 
 @@ -17,7 +17,7 @@ class App extends Component {
   handleChange(nextValue) {
-    this.props.push(`/${nextValue}`)
+    browserHistory.push(`/${nextValue}`)
   }

 // ...

 export default connect(mapStateToProps, {
-  resetErrorMessage,
-  push
+  resetErrorMessage
 })(App)
 ```

Many people said that they used those action creators so they are logged for analytics. This no longer installing middleware or using those action creators. With 4.x, when you `push()` to a history, **a special action will still be dispatched on every history change**, so you can log that instead. And of course you can always `browserHistory.listen(location => ...)` yourself.

Why would you still want the middleware then? I’ve heard that it can be helpful for [some use cases](https://github.com/reactjs/redux/pull/1362#issuecomment-180054088) but unless you know you need it, don’t use it.

I removed the usage of middleware in this example.

### Prefer to Read the Routing State from Props

This example used to read routing state from `state.routing`. This was actually a bad idea and something that React Router Redux README had a warning for. If you use asynchronous transitions in React Router, you might get into infinite loops if you read `state.routing` in components. Why? The location in `state.routing` describes *the location before any transitions*—the one obtained from the URL bar. Router is stateful and lets you do async work before showing the related UI, but this is why **you should always be reading the location from the `props` supplied to you by the router**.

This is why do this:

```diff
-function mapStateToProps(state) {
+function mapStateToProps(state, ownProps) {
   return {
     errorMessage: state.errorMessage,
-    inputValue: state.routing.location.pathname.substring(1)
+    inputValue: ownProps.location.pathname.substring(1)
   }
 }
 ```

We still keep the routing state in `state.routing` (the reducer key is up to you) so you can read it from your custom middleware (for example, for analytics). However you will notice that the actual location is in `state.routing.locationBeforeTransitions`. This is our way of warning you that this is *not* the location you want to use in your UI.

### Synchronizing with the Store

So why use this library at all then? It only buys you a few things:

* It keeps the current location as reported by history in your Redux store so you may read it
* It makes Redux store “the source of truth” for the router, so replay in Redux DevTools “just works”
* It provides an optional middleware and action creators for those who enjoy them

If you don’t care about these features, just don’t use it, and use React Router 2.0 directly.

If you do care, the last thing you need to change is to **wrap your history before passing it to the router**. This is how we translate history changes into Redux actions, and make the store a source of truth for the router. You only need to do it once wherever you render the `<Router>`:

```diff
+import { browserHistory } from 'react-router'
+import { syncHistoryWithStore } from 'react-router-redux'
 import Root from './containers/Root'
 import configureStore from './store/configureStore'
 
 const store = configureStore()
+const history = syncHistoryWithStore(browserHistory, store)
 
 render(
-  <Root store={store} />,
+  <Root store={store} history={history} />,
   document.getElementById('root')
 )
```

This is it. See the [master branch of React Router Redux](https://github.com/reactjs/react-router-redux/tree/master) for a normal and a server rendering example.