### PR TITLE
Update example for conditional applyMiddleware

### DIFF
--- a/docs/api/applyMiddleware.md
+++ b/docs/api/applyMiddleware.md
@@ -233,7 +233,7 @@ export default connect(
   const store = createStore(
     reducer,
     initialState,
-    applyMiddleware(middleware)
+    applyMiddleware(...middleware)
   )
   ```
 


### PR DESCRIPTION
The example of the tip for apply a middleware threw some errors to me. The reason is because an array was passed to applyMiddleware.

We should pass each elem of the array as an argument first to get it to work.