### PR TITLE
Adjust editorconfig to not trim trailing whitespaces in Markdown files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
 indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
As a reaction to [@gaearon’s tweet](https://twitter.com/dan_abramov/status/700406516810182656). ;)