### PR TITLE
Promote AddTodo to proper container component

### DIFF
--- a/examples/todos/components/AddTodoForm.js
+++ b/examples/todos/components/AddTodoForm.js
@@ -1,0 +1,28 @@
+import React from 'react'
+
+
+let AddTodoForm = ({ onSubmit }) => {
+  let input
+
+  return (
+    <div>
+      <form onSubmit={e => {
+        e.preventDefault()
+        if (!input.value.trim()) {
+          return
+        }
+        onSubmit(input.value)
+        input.value = ''
+      }}>
+        <input ref={node => {
+          input = node
+        }} />
+        <button type="submit">
+          Add Todo
+        </button>
+      </form>
+    </div>
+  )
+}
+
+export default AddTodoForm

--- a/examples/todos/containers/AddTodo.js
+++ b/examples/todos/containers/AddTodo.js
@@ -1,30 +1,17 @@
-import React from 'react'
+import AddTodoForm from '../components/AddTodoForm'
+
 import { connect } from 'react-redux'
 import { addTodo } from '../actions'
 
-let AddTodo = ({ dispatch }) => {
-  let input
 
-  return (
-    <div>
-      <form onSubmit={e => {
-        e.preventDefault()
-        if (!input.value.trim()) {
-          return
-        }
-        dispatch(addTodo(input.value))
-        input.value = ''
-      }}>
-        <input ref={node => {
-          input = node
-        }} />
-        <button type="submit">
-          Add Todo
-        </button>
-      </form>
-    </div>
-  )
+const mapDispatchToProps = (dispatch) => {
+  return {
+    onSubmit: (text) => {
+      dispatch(addTodo(text))
+    }
+  }
 }
-AddTodo = connect()(AddTodo)
+
+let AddTodo = connect(null, mapDispatchToProps)(AddTodoForm)
 
 export default AddTodo


### PR DESCRIPTION
In the current todos Example, AddTodo component doesn't follow the Container component pattern properly like others in the example. This was initially very confusing to me. So I've updated it by creating a new component **AddTodoForm** presentation component and making AddTodo a proper container component.