### PR TITLE
Solved recursion issue, now "dispatch" directly calls reducer

### DIFF
--- a/src/applyMiddleware.js
+++ b/src/applyMiddleware.js
@@ -24,7 +24,7 @@ export default function applyMiddleware(...middlewares) {
 
     var middlewareAPI = {
       getState: store.getState,
-      dispatch: (action) => dispatch(action)
+      dispatch: (action) => store.dispatch(action)
     }
     chain = middlewares.map(middleware => middleware(middlewareAPI))
     dispatch = compose(...chain)(store.dispatch)


### PR DESCRIPTION
Solved recursion issue, now "dispatch" directly calls reducer from middleware. This can be used to bypass middleware chain for some actions. We just need to call dispatch instead of next in that case