### PR TITLE
provide the updated parent state to each reducer

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -126,7 +126,7 @@ export default function combineReducers(reducers) {
       var key = finalReducerKeys[i]
       var reducer = finalReducers[key]
       var previousStateForKey = state[key]
-      var nextStateForKey = reducer(previousStateForKey, action)
+      var nextStateForKey = reducer(previousStateForKey, action, nextState)
       if (typeof nextStateForKey === 'undefined') {
         var errorMessage = getUndefinedStateErrorMessage(key, action)
         throw new Error(errorMessage)


### PR DESCRIPTION
hi folks!

In my app I've found that some reducers occasionally need access to other parts of the state in order to compute their own state.

My fork just passes in the parent state for each reducer to (optionally) use.

This probably isn't the best way to do this as `combineReducers` aims to keep each slice of the store logically independent. I'm curious to hear how other folks have solved this.