### PR TITLE
RFC: remove React Transform from examples

### DIFF
--- a/examples/async/.babelrc
+++ b/examples/async/.babelrc
@@ -1,8 +1,3 @@
 {
-  "presets": ["es2015", "react"],
-  "env": {
-    "development": {
-      "presets": ["react-hmre"]
-    }
-  }
+  "presets": ["es2015", "react"]
 }

--- a/examples/async/index.js
+++ b/examples/async/index.js
@@ -1,15 +1,43 @@
 import 'babel-polyfill'
 import React from 'react'
-import { render } from 'react-dom'
+import ReactDOM from 'react-dom'
 import { Provider } from 'react-redux'
-import App from './containers/App'
 import configureStore from './store/configureStore'
 
 const store = configureStore()
+const rootEl = document.getElementById('root')
 
-render(
-  <Provider store={store}>
-    <App />
-  </Provider>,
-  document.getElementById('root')
-)
+let render = () => {
+  const App = require('./containers/App').default
+  ReactDOM.render(
+    <Provider store={store}>
+      <App />
+    </Provider>,
+    rootEl
+  )
+}
+
+if (module.hot) {
+  // Support hot reloading of components
+  // and display an overlay for runtime errors
+  const renderApp = render
+  const renderError = (error) => {
+    const RedBox = require('redbox-react')
+    ReactDOM.render(
+      <RedBox error={error} />,
+      rootEl
+    )
+  }
+  render = () => {
+    try {
+      renderApp()
+    } catch (error) {
+      renderError(error)
+    }
+  }
+  module.hot.accept('./containers/App', () => {
+    setTimeout(render)
+  })
+}
+
+render()

--- a/examples/async/package.json
+++ b/examples/async/package.json
@@ -40,10 +40,10 @@
     "babel-loader": "^6.2.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
-    "babel-preset-react-hmre": "^1.0.1",
     "expect": "^1.6.0",
     "express": "^4.13.3",
     "node-libs-browser": "^0.5.2",
+    "redbox-react": "^1.2.2",
     "webpack": "^1.9.11",
     "webpack-dev-middleware": "^1.2.0",
     "webpack-hot-middleware": "^2.2.0"

--- a/examples/async/webpack.config.js
+++ b/examples/async/webpack.config.js
@@ -15,7 +15,6 @@ module.exports = {
   plugins: [
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.HotModuleReplacementPlugin(),
-    new webpack.NoErrorsPlugin()
   ],
   module: {
     loaders: [


### PR DESCRIPTION
Inspired by @thejameskyle’s rant on Twitter (no offense taken :smile: ), I propose to remove `babel-preset-react-hmre` from examples for the following reasons:

1. Both plugin transform and proxy wrapping are rather invasive and have edge cases
2. It’s **experimental tech** and beginners shouldn’t have to deal with its warts
3. It doesn’t currently reload functional components or container functions like `mapStateToProps`
4. In Redux we rarely care about preserving component local state when hot reloading! Preserving store state is usually enough.

This is a proof of concept of “vanilla” hot reloading (for now, only for a single example).

It has the following traits.

## Pros

1. It is absolutely non-invasive and doesn’t change semantics of your code
2. It hot reloads any components, whether classes or functions
3. It preserves the store state on hot reload
4. It still handles errors on mount and hot reloading “fixes” them
5. It works for functions like `mapStateToProps`

## Cons

1. It does *not* preserve the local state of components
2. It does *not* preserve the DOM so the components are remounted

What do you think? Should we proceed with this and do this for every example?