### PR TITLE
todos app: moved App.js from components folder to containers folder 

### DIFF
--- a/examples/todos/containers/App.js
+++ b/examples/todos/containers/App.js
@@ -1,7 +1,7 @@
 import React from 'react'
-import Footer from './Footer'
-import AddTodo from '../containers/AddTodo'
-import VisibleTodoList from '../containers/VisibleTodoList'
+import Footer from '../components/Footer'
+import AddTodo from './AddTodo'
+import VisibleTodoList from './VisibleTodoList'
 
 const App = () => (
   <div>

--- a/examples/todos/index.js
+++ b/examples/todos/index.js
@@ -4,7 +4,7 @@ import { render } from 'react-dom'
 import { Provider } from 'react-redux'
 import { createStore } from 'redux'
 import todoApp from './reducers'
-import App from './components/App'
+import App from './containers/App'
 
 let store = createStore(todoApp)
 


### PR DESCRIPTION
This is trying to make it consistent for folder structure. In todos example, App.js is moved from components folder to containers folder, to be consistent with other examples. Thanks.