### PR TITLE
tree-view: simplify reducer function

### DIFF
--- a/examples/tree-view/reducers/index.js
+++ b/examples/tree-view/reducers/index.js
@@ -5,11 +5,7 @@ function childIds(state, action) {
     case ADD_CHILD:
       return [ ...state, action.childId ]
     case REMOVE_CHILD:
-      const index = state.indexOf(action.childId)
-      return [
-        ...state.slice(0, index),
-        ...state.slice(index + 1)
-      ]
+      return state.filter(id => id !== action.childId)
     default:
       return state
   }


### PR DESCRIPTION
Spread operator is really not necessary here. It can be replaced with a simple filter function. Fortunately `.filter()` returns new array instance as it required by Redux and here it has a perfect fit.

Even more, [filter works here faster](http://jsperf.com/array-remove-in-es6): because doesn't create temporary arrays.