### PR TITLE
docs: replace slice calls to map

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -53,14 +53,15 @@ function todos(state = [], action) {
       ]
     case 'COMPLETE_TODO':
       // Return a new array
-      return [
-        ...state.slice(0, action.index),
-        // Copy the object before mutating
-        Object.assign({}, state[action.index], {
-          completed: true
-        }),
-        ...state.slice(action.index + 1)
-      ]
+      return state.map((todo, index) => {
+        if(index === action.index) {
+          // Copy the object before mutating
+          return Object.assign({}, todo, {
+            completed: true
+          })
+        }
+        return todo
+      })
     default:
       return state
   }
@@ -71,13 +72,14 @@ It’s more code, but it’s exactly what makes Redux predictable and efficient.
 
 ```js
 // Before:
-return [
-  ...state.slice(0, action.index),
-  Object.assign({}, state[action.index], {
-    completed: true
-  }),
-  ...state.slice(action.index + 1)
-]
+return state.map((todo, index) => {
+  if(index === action.index) {
+    return Object.assign({}, todo, {
+      completed: true
+    })
+  }
+  return todo
+})
 
 // After
 return update(state, {
@@ -97,20 +99,22 @@ You can also enable the [object spread operator proposal](recipes/UsingObjectSpr
 
 ```js
 // Before:
-return [
-  ...state.slice(0, action.index),
-  Object.assign({}, state[action.index], {
-    completed: true
-  }),
-  ...state.slice(action.index + 1)
-]
+return state.map((todo, index) => {
+  if(index === action.index) {
+    return Object.assign({}, todo, {
+      completed: true
+    })
+  }
+  return todo
+})
 
 // After:
-return [
-  ...state.slice(0, action.index),
-  { ...state[action.index], completed: true },
-  ...state.slice(action.index + 1)
-]
+return state.map((todo, index) => {
+  if(index === action.index) {
+    return { ...todo, completed: true }
+  }
+  return todo
+})
 ```
 
 Note that experimental language features are subject to change.

--- a/docs/basics/Reducers.md
+++ b/docs/basics/Reducers.md
@@ -147,13 +147,14 @@ Finally, the implementation of the `COMPLETE_TODO` handler shouldn’t come as a
 ```js
 case COMPLETE_TODO:
   return Object.assign({}, state, {
-    todos: [
-      ...state.todos.slice(0, action.index),
-      Object.assign({}, state.todos[action.index], {
-        completed: true
-      }),
-      ...state.todos.slice(action.index + 1)
-    ]
+    todos: state.todos.map((todo, index) => {
+      if(index === action.index) {
+        return Object.assign({}, todo, {
+          completed: true
+        })
+      }
+      return todo
+    })
   })
 ```
 
@@ -182,13 +183,14 @@ function todoApp(state = initialState, action) {
       })
     case COMPLETE_TODO:
       return Object.assign({}, state, {
-        todos: [
-          ...state.todos.slice(0, action.index),
-          Object.assign({}, state.todos[action.index], {
-            completed: true
-          }),
-          ...state.todos.slice(action.index + 1)
-        ]
+        todos: state.todos.map((todo, index) => {
+          if(index === action.index) {
+            return Object.assign({}, todo, {
+              completed: true
+            })
+          }
+          return todo
+        })
       })
     default:
       return state
@@ -210,13 +212,14 @@ function todos(state = [], action) {
         }
       ]
     case COMPLETE_TODO:
-      return [
-        ...state.slice(0, action.index),
-        Object.assign({}, state[action.index], {
-          completed: true
-        }),
-        ...state.slice(action.index + 1)
-      ]
+      return state.map(todo, index) => {
+        if(index === action.index) {
+          return Object.assign({}, todo, {
+            completed: true
+          })
+        }
+        return todo
+      }
     default:
       return state
   }
@@ -268,13 +271,14 @@ function todos(state = [], action) {
         }
       ]
     case COMPLETE_TODO:
-      return [
-        ...state.slice(0, action.index),
-        Object.assign({}, state[action.index], {
-          completed: true
-        }),
-        ...state.slice(action.index + 1)
-      ]
+      return state.map((todo, index) => {
+        if(index === action.index) {
+          return Object.assign({}, todo, {
+            completed: true
+          })
+        }
+        return todo
+      })
     default:
       return state
   }
@@ -389,13 +393,14 @@ function todos(state = [], action) {
         }
       ]
     case COMPLETE_TODO:
-      return [
-        ...state.slice(0, action.index),
-        Object.assign({}, state[action.index], {
-          completed: true
-        }),
-        ...state.slice(action.index + 1)
-      ]
+      return state.map((todo, index) => {
+        if(index === action.index) {
+          return Object.assign({}, todo, {
+            completed: true
+          })
+        }
+        return todo
+      })
     default:
       return state
   }

--- a/docs/introduction/ThreePrinciples.md
+++ b/docs/introduction/ThreePrinciples.md
@@ -18,7 +18,7 @@ console.log(store.getState())
     {
       text: 'Consider using Redux',
       completed: true,
-    }, 
+    },
     {
       text: 'Keep all state in a single tree',
       completed: false
@@ -74,13 +74,14 @@ function todos(state = [], action) {
         }
       ]
     case 'COMPLETE_TODO':
-      return [
-        ...state.slice(0, action.index),
-        Object.assign({}, state[action.index], {
-          completed: true
-        }),
-        ...state.slice(action.index + 1)
-      ]
+      return state.map((todo, index) => {
+        if(index === action.index) {
+          return Object.assign({}, todo, {
+            completed: true
+          })
+        }
+        return todo
+      })
     default:
       return state
   }


### PR DESCRIPTION
As it was discussed in https://github.com/reactjs/redux/pull/1468, ES5 array methods like `map` and `filter` are recommended approach rather than array slicing.