### PR TITLE
docs: fix surrounding text after changes in #1477

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -54,7 +54,7 @@ function todos(state = [], action) {
     case 'COMPLETE_TODO':
       // Return a new array
       return state.map((todo, index) => {
-        if(index === action.index) {
+        if (index === action.index) {
           // Copy the object before mutating
           return Object.assign({}, todo, {
             completed: true
@@ -73,7 +73,7 @@ It’s more code, but it’s exactly what makes Redux predictable and efficient.
 ```js
 // Before:
 return state.map((todo, index) => {
-  if(index === action.index) {
+  if (index === action.index) {
     return Object.assign({}, todo, {
       completed: true
     })
@@ -100,7 +100,7 @@ You can also enable the [object spread operator proposal](recipes/UsingObjectSpr
 ```js
 // Before:
 return state.map((todo, index) => {
-  if(index === action.index) {
+  if (index === action.index) {
     return Object.assign({}, todo, {
       completed: true
     })
@@ -110,7 +110,7 @@ return state.map((todo, index) => {
 
 // After:
 return state.map((todo, index) => {
-  if(index === action.index) {
+  if (index === action.index) {
     return { ...todo, completed: true }
   }
   return todo

--- a/docs/basics/Reducers.md
+++ b/docs/basics/Reducers.md
@@ -158,7 +158,7 @@ case COMPLETE_TODO:
   })
 ```
 
-Because we want to update a specific item in the array without resorting to mutations, we have to slice it before and after the item. If you find yourself often writing such operations, it’s a good idea to use a helper like [react-addons-update](https://facebook.github.io/react/docs/update.html), [updeep](https://github.com/substantial/updeep), or even a library like [Immutable](http://facebook.github.io/immutable-js/) that has native support for deep updates. Just remember to never assign to anything inside the `state` unless you clone it first.
+Because we want to update a specific item in the array without resorting to mutations, we have to create a new array with the same items except the item at the index. If you find yourself often writing such operations, it’s a good idea to use a helper like [react-addons-update](https://facebook.github.io/react/docs/update.html), [updeep](https://github.com/substantial/updeep), or even a library like [Immutable](http://facebook.github.io/immutable-js/) that has native support for deep updates. Just remember to never assign to anything inside the `state` unless you clone it first.
 
 ## Splitting Reducers
 

--- a/docs/basics/Reducers.md
+++ b/docs/basics/Reducers.md
@@ -148,7 +148,7 @@ Finally, the implementation of the `COMPLETE_TODO` handler shouldn’t come as a
 case COMPLETE_TODO:
   return Object.assign({}, state, {
     todos: state.todos.map((todo, index) => {
-      if(index === action.index) {
+      if (index === action.index) {
         return Object.assign({}, todo, {
           completed: true
         })
@@ -213,7 +213,7 @@ function todos(state = [], action) {
       ]
     case COMPLETE_TODO:
       return state.map(todo, index) => {
-        if(index === action.index) {
+        if (index === action.index) {
           return Object.assign({}, todo, {
             completed: true
           })
@@ -272,7 +272,7 @@ function todos(state = [], action) {
       ]
     case COMPLETE_TODO:
       return state.map((todo, index) => {
-        if(index === action.index) {
+        if (index === action.index) {
           return Object.assign({}, todo, {
             completed: true
           })
@@ -394,7 +394,7 @@ function todos(state = [], action) {
       ]
     case COMPLETE_TODO:
       return state.map((todo, index) => {
-        if(index === action.index) {
+        if (index === action.index) {
           return Object.assign({}, todo, {
             completed: true
           })

--- a/docs/introduction/ThreePrinciples.md
+++ b/docs/introduction/ThreePrinciples.md
@@ -75,7 +75,7 @@ function todos(state = [], action) {
       ]
     case 'COMPLETE_TODO':
       return state.map((todo, index) => {
-        if(index === action.index) {
+        if (index === action.index) {
           return Object.assign({}, todo, {
             completed: true
           })


### PR DESCRIPTION
Just found out that some text mentions that reducer uses `slice` to create a new array. Once we changed it in #1477, we should change surrounding text as well.

Does new text look good for you?

I really should more carefully read the text before sending that PR. Sorry about that.