### PR TITLE
Move ActionTypes to a private export

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -1,4 +1,4 @@
-import { ActionTypes } from './createStore'
+import ActionTypes from './utils/actionTypes'
 import isPlainObject from 'lodash/isPlainObject'
 import warning from './utils/warning'
 

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -1,14 +1,5 @@
 import isPlainObject from 'lodash/isPlainObject'
-
-/**
- * These are private action types reserved by Redux.
- * For any unknown actions, you must return the current state.
- * If the current state is undefined, you must return the initial state.
- * Do not reference these action types directly in your code.
- */
-export var ActionTypes = {
-  INIT: '@@redux/INIT'
-}
+import ActionTypes from './utils/actionTypes'
 
 /**
  * Creates a Redux store that holds the state tree.

--- a/src/utils/actionTypes.js
+++ b/src/utils/actionTypes.js
@@ -1,0 +1,11 @@
+/**
+ * These are private action types reserved by Redux.
+ * For any unknown actions, you must return the current state.
+ * If the current state is undefined, you must return the initial state.
+ * Do not reference these action types directly in your code.
+ */
+var ActionTypes = {
+  INIT: '@@redux/INIT'
+}
+
+export default ActionTypes

--- a/test/combineReducers.spec.js
+++ b/test/combineReducers.spec.js
@@ -1,6 +1,7 @@
 import expect from 'expect'
 import { combineReducers } from '../src'
-import createStore, { ActionTypes } from '../src/createStore'
+import createStore from '../src/createStore'
+import ActionTypes from '../src/utils/actionTypes'
 
 describe('Utils', () => {
   describe('combineReducers', () => {


### PR DESCRIPTION
This is #1343 rebased on the `next` branch.