### PR TITLE
Fix Object.assign on callAPIMiddleware

### DIFF
--- a/docs/recipes/ReducingBoilerplate.md
+++ b/docs/recipes/ReducingBoilerplate.md
@@ -377,16 +377,16 @@ function callAPIMiddleware({ dispatch, getState }) {
 
     const [ requestType, successType, failureType ] = types
 
-    dispatch(Object.assign({}, payload, {
+    dispatch(Object.assign({}, {payload}, {
       type: requestType
     }))
 
     return callAPI().then(
-      response => dispatch(Object.assign({}, payload, {
+      response => dispatch(Object.assign({}, {payload}, {
         response,
         type: successType
       })),
-      error => dispatch(Object.assign({}, payload, {
+      error => dispatch(Object.assign({}, {payload}, {
         error,
         type: failureType
       }))


### PR DESCRIPTION
The payload property wasn't being passed to Object.assign.