### PR TITLE
Fixes a documentation typo in basics/Reducers

### DIFF
--- a/docs/basics/Reducers.md
+++ b/docs/basics/Reducers.md
@@ -212,14 +212,14 @@ function todos(state = [], action) {
         }
       ]
     case COMPLETE_TODO:
-      return state.map(todo, index) => {
+      return state.map((todo, index) => {
         if (index === action.index) {
           return Object.assign({}, todo, {
             completed: true
           })
         }
         return todo
-      }
+      })
     default:
       return state
   }


### PR DESCRIPTION
Found an error (at least I think it is) when working through the todo tutorial.

```javascript
return state.map(todo, index) => {
  if (index === action.index) {
    return Object.assign({}, todo, {
      completed: true
    })
  }
    return todo
  }
```

...has been changed to...

```javascript
return state.map((todo, index) => {
  if (index === action.index) {
    return Object.assign({}, todo, {
      completed: true
    })
  }
    return todo
  })
```

Hope this helps! :smile: 
