### PR TITLE
Unnecessary re-evaluation of subscribers & leaking in dispatch

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -172,7 +172,7 @@ export default function createStore(reducer, initialState, enhancer) {
     }
 
     var listeners = currentListeners = nextListeners
-    for (var i = 0; i < listeners.length; i++) {
+    for (var i = 0, l = listeners.length; i < l; i++) {
       listeners[i]()
     }
 


### PR DESCRIPTION
Specifically this line, https://github.com/reactjs/redux/blob/master/src/createStore.js#L175

Just looking through the src this line stuck out to me because if there was no "mutex" in place this is would be a race cond. (Though the mutex doesn't cover the subscriber part, so if it were somehow in a multi-threaded environment, the subscribers could possibly not be in sync here, though even in a single- threaded environment subscribers are still able to be added, explanation further down.)

Right now there is no benefit to re-evaluate the length on every loop and goes against https://github.com/reactjs/redux/blob/master/src/createStore.js#L85 
"The subscriptions are snapshotted just __before__ every `dispatch()` call." (emphasis mine)

So we should cache as things are suppose to be "frozen" anyway.

===
Related to this issue, specifically "The subscriptions are snapshotted just before every `dispatch()` call."

If this is correct spec, this does not happen by the way. New subscribers can be leaked into a dispatch __during__ dispatch (during the mutex lock). As reducers can add subscribers and they _will_ be called when listeners are called. 

This pull does not address that. As I am unsure if this is truly unintended. But I can add to this pull. I am opening it up with minimal changes to get the conversation going on these issues.