### PR TITLE
TypeScript definitions improvements

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -75,6 +75,10 @@ export function combineReducers<S>(reducers: ReducersMapObject): Reducer<S>;
 
 /* store */
 
+export interface MiddlewareDispatch {
+    <TMiddlewareAction, TMiddlewareActionResult>(action: TMiddlewareAction): TMiddlewareActionResult;
+}
+
 /**
  * A *dispatching function* (or simply *dispatch function*) is a function that
  * accepts an action or an async action; it then may or may not dispatch one
@@ -93,7 +97,9 @@ export function combineReducers<S>(reducers: ReducersMapObject): Reducer<S>;
  * transform, delay, ignore, or otherwise interpret actions or async actions
  * before passing them to the next middleware.
  */
-export type Dispatch = (action: any) => any;
+export interface Dispatch extends MiddlewareDispatch {
+    (action: Action): Action;
+}
 
 /**
  * Function to remove listener added by `Store.subscribe()`.
@@ -265,7 +271,7 @@ export interface MiddlewareAPI<S> {
  * asynchronous API call into a series of synchronous actions.
  */
 export interface Middleware {
-  <S>(api: MiddlewareAPI<S>): (next: Dispatch) => (action: any) => any;
+  <S>(api: MiddlewareAPI<S>): (next: MiddlewareDispatch) => MiddlewareDispatch;
 }
 
 /**

--- a/test/typescript/dispatch.ts
+++ b/test/typescript/dispatch.ts
@@ -9,4 +9,4 @@ const dispatchResult: Action = dispatch({type: 'TYPE'});
 
 type Thunk<O> = () => O;
 
-const dispatchThunkResult: number = dispatch(() => 42);
+const dispatchThunkResult: number = dispatch<Thunk<number>, number>(() => 42);


### PR DESCRIPTION
This PR follows https://github.com/reactjs/redux/pull/1413. I will open up some wounds here, so please excuse me if I missed any of the points in the previous conversation.

**Signature of dispatch**

The problem that I still have is with the signature of `dispatch`. `any` just isn't type-safe at all. It will propagate silently in the app without the developer even realizing. w.r.t what @pajn and @joshuacc said, there is a difference between consciously making a choice to type-cast and getting `any` by default. With this in mind, it's even better to use `{}` instead of `any` (which btw is what type parameters default to anyway). 

Given the nature of `dispatch` and it being wrapped by middlewares, it isn't possible to properly type it to account for every possibility. (goes with what @xogeny said in previous PR) The default behavior should be to receive `Action` and return `Action`. When middlewares are involved, the middleware decides what the action is and what is returned. Unless someone finds of a way to augment the dispatch signature to work auto-magically with specific middlewares, I think it's better to let the user cast explicitly, because it is something known only by him, given the combination of middlewares that he applied.

I understand that explicit cast is more verbose and some may even be tempted to say it's even annoying, but think of it this way: it isn't any different than using `Promise` or `Map` or `Set`. Only the user know what exactly he's dispatching and what he expects to be returned.

**Signature of StoreCreator and StoreEnhancer**

I'm not sure I fully understand how these work, but the signature looks different to me than what results from the source code: https://github.com/reactjs/redux/blob/master/src/createStore.js#L49

Should be something like:
```typescript
    interface StoreEnhancer<TState> {
         (createStore: StoreCreator<TState>): (reducer: Reducer<TState>, initialState?: TState) => Store<TState>;
    }
```
In this case `StoreEnhancer` should be generic. This leads to another problem. If it's typed as a generic interface, then `StoreCreator` should be generic as well, in which case we can no longer type the `createStore` variable. The only way I see to fix this would be to create to interfaces that are basically copy-pastes of each other:
```typescript
export interface StoreCreatorInferrable {
  <S>(reducer: Reducer<S>, enhancer?: StoreEnhancer): Store<S>;
  <S>(reducer: Reducer<S>, initialState: S,
      enhancer?: StoreEnhancer): Store<S>;
}
export interface StoreCreator<S> {
  (reducer: Reducer<S>, enhancer?: StoreEnhancer<S>): Store<S>;
  (reducer: Reducer<S>, initialState: S,
      enhancer?: StoreEnhancer<S>): Store<S>;
}
```