### PR TITLE
Pass storeState as a third argument to reducers when using combineReducers

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -126,7 +126,7 @@ export default function combineReducers(reducers) {
       var key = finalReducerKeys[i]
       var reducer = finalReducers[key]
       var previousStateForKey = state[key]
-      var nextStateForKey = reducer(previousStateForKey, action)
+      var nextStateForKey = reducer(previousStateForKey, action, state)
       if (typeof nextStateForKey === 'undefined') {
         var errorMessage = getUndefinedStateErrorMessage(key, action)
         throw new Error(errorMessage)


### PR DESCRIPTION
This pull request makes reducers have the following signature:
`(state, action[, storeState]) => nextState`

I first proposed this idea here:
https://productpains.com/post/redux/full-single-state-atom-not-passed-to-reducers

The more I think about it, the more I realize that having access to only the reducer's slice of state severely impacts the architecture of apps. It results in lots of business logic being forced into Action Creators. This means Action Creators are now becoming decision-makers in _how_ state gets updated, rather than fulfilling their purpose of simply formatting an action object. When Action Creators own the business logic of what gets sent, actions end up being more like imperative commands tailored to a specific reducer as opposed to a description of an event that any reducer can react to as it sees fit. This goes against one of Redux's main strengths of decoupling actions from the reducer functions that handle them.

Testing becomes more difficult as now you're having to test your Action Creators for logic that's dependent on state and now buried in the returned action object. Testing reducers is a breeze since they are pure functions and you're testing input state vs. output state.

It also prevents you from reusing Reselect selectors inside of your reducers.

I still think having the sliced state as the first argument passed to a reducer is the right design choice for convenience, as that prevents you from having to slice it yourself and ensure you're returning the correct slice again from the function. However, that convenience should not be the reason for logic being forced into other parts of the application. Having access to the full store state as an additional argument will let reducers keep the separation of concerns clear.