### PR TITLE
add engines section to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,9 @@
     "typescript-definition-tester": "0.0.4",
     "webpack": "^1.9.6"
   },
+  "engines": {
+    "node" : ">=4"
+  },
   "npmName": "redux",
   "npmFileMap": [
     {


### PR DESCRIPTION
re: https://github.com/reactjs/redux/issues/1531

this setting *should* emit a warning to users who are still running node <4

...although according to [this](http://www.marcusoft.net/2015/03/packagejson-and-engines-and-enginestrict.html) that isn't exactly true

when running `git clone && npm i` it doesnt work *but* when installing via `npm i redux` it *does*.

¯\_(ツ)_/¯