### PR TITLE
Corrected assertion

### DIFF
--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -61,7 +61,7 @@ describe('actions', () => {
       type: types.ADD_TODO,
       text
     }
-    expect(actions.addTodo(text)).toEqual(expectedAction)
+    expect(actions.addTodo(text)).to.deep.equal(expectedAction)
   })
 })
 ```


### PR DESCRIPTION
toEqual doesn't exist in Chai. to.equal does though. Perhaps this assumed a different assertion library? 

Regardless, must use deep.equal in Chai to compare objects - otherwise Chai will do a reference type comparison, so the existing example would fail.