### PR TITLE
Updated Ecosystem, reference to salsita/redux-side-effects

### DIFF
--- a/docs/introduction/Ecosystem.md
+++ b/docs/introduction/Ecosystem.md
@@ -80,7 +80,7 @@ On this page we will only feature a few of them that the Redux maintainers have 
 * [redux-search](https://github.com/treasure-data/redux-search) — Automatically index resources in a web worker and search them without blocking
 * [redux-electron-store](https://github.com/samiskin/redux-electron-store) — Store enhancers that synchronize Redux stores across Electron processes
 * [redux-loop](https://github.com/raisemarketplace/redux-loop) — Sequence effects purely and naturally by returning them from your reducers
-* [redux-side-effects](https://github.com/salsita/redux-side-effects) - Utilize Generators for declarative yielding of side effects from your pure reducers
+* [redux-side-effects](https://github.com/salsita/redux-side-effects) — Utilize Generators for declarative yielding of side effects from your pure reducers
 
 ### Utilities
 

--- a/docs/introduction/Ecosystem.md
+++ b/docs/introduction/Ecosystem.md
@@ -80,6 +80,7 @@ On this page we will only feature a few of them that the Redux maintainers have 
 * [redux-search](https://github.com/treasure-data/redux-search) — Automatically index resources in a web worker and search them without blocking
 * [redux-electron-store](https://github.com/samiskin/redux-electron-store) — Store enhancers that synchronize Redux stores across Electron processes
 * [redux-loop](https://github.com/raisemarketplace/redux-loop) — Sequence effects purely and naturally by returning them from your reducers
+* [redux-side-effects](https://github.com/salsita/redux-side-effects) - Utilize Generators for declarative yielding of side effects from your pure reducers
 
 ### Utilities
 


### PR DESCRIPTION
Updated Ecosystem with `redux-side-effects` yet another approach for side effects.

**Why it should be part of the Ecosystem?**
- Package is another approach which is trying to simulate Elmish approach to Side Effects
- Package is conceptually very similar to `redux-loop` but using a different mechanics (Generators). Some people may consider the API less "awkward"
- Package follows strict development process
- Package follows SemVer
- Package is being used in production apps for more than a half year.
- We try to cover all the functionality with Unit tests
- API is stable now
- [Surface area is pretty small](https://github.com/salsita/redux-side-effects/blob/master/src/createEffectCapableStore.js#L28-L33)