### PR TITLE
Update docs - Writing tests - Async actions text example

### DIFF
--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -134,13 +134,11 @@ describe('async actions', () => {
     const store = mockStore({ todos: [] })
 
     store.dispatch(actions.fetchTodos())
-      .then(() => {
-        const actions = store.getActions()
-
-        expect(actions[0].type).toEqual(types.FETCH_TODOS_REQUEST)
-
-        done()
+      .then(() => { // return of async actions
+        expect(store.getActions()).toEqual(expectedActions)
       })
+      .then(done) // test passed
+      .catch(done) // test failed
   })
 })
 ```


### PR DESCRIPTION
TLDR: **This PR fixes the test in Async Actions documentation to correctly pass/fail**

The docs (but not the [website](http://redux.js.org/docs/recipes/WritingTests.html)) were recently updated for v2 of [redux-mock-store](https://github.com/arnaudbenard/redux-mock-store) by the creator @arnaudbenard himself in #1515.

However best I can tell the changes do not appear to be correctly testing the async actions.

They appear to be:
- Not testing that the fetch was called.
- Not testing the entire action, only the type.
- Only testing 'FETCH_TODOS_REQUEST' instead of 'FETCH_TODOS_REQUEST' and 'FETCH_TODOS_SUCCESS'.

This PR fixes the test to correctly pass/fail.

Please let me know if I am mistaken.

I would also be great if the website was updated with master when you get the chance, so that people aren't trying to follow the docs with the old api.