### PR TITLE
Remove `distinctState` from todos reducer

### DIFF
--- a/examples/todos-with-undo/reducers/todos.js
+++ b/examples/todos-with-undo/reducers/todos.js
@@ -1,4 +1,4 @@
-import undoable, { distinctState } from 'redux-undo'
+import undoable from 'redux-undo'
 
 const todo = (state, action) => {
   switch (action.type) {
@@ -37,8 +37,6 @@ const todos = (state = [], action) => {
   }
 }
 
-const undoableTodos = undoable(todos, {
-  filter: distinctState()
-})
+const undoableTodos = undoable(todos)
 
 export default undoableTodos


### PR DESCRIPTION
`distinctState has been deprecated in the latest redux-undo (1.0-beta4). It will break the code with the latest redux-undo. 