### PR TITLE
no need to use 'store' namespace

### DIFF
--- a/src/applyMiddleware.js
+++ b/src/applyMiddleware.js
@@ -27,7 +27,7 @@ export default function applyMiddleware(...middlewares) {
       dispatch: (action) => dispatch(action)
     }
     chain = middlewares.map(middleware => middleware(middlewareAPI))
-    dispatch = compose(...chain)(store.dispatch)
+    dispatch = compose(...chain)(dispatch)
 
     return {
       ...store,


### PR DESCRIPTION
no need to use 'store' namespace