### PR TITLE
Improve typing of StoreEnhancer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -194,9 +194,8 @@ export interface Store<S> {
  * @template S State object type.
  */
 export interface StoreCreator {
-  <S>(reducer: Reducer<S>, enhancer?: StoreEnhancer): Store<S>;
-  <S>(reducer: Reducer<S>, initialState: S,
-      enhancer?: StoreEnhancer): Store<S>;
+  <S>(reducer: Reducer<S>, enhancer?: StoreEnhancer<S>): Store<S>;
+  <S>(reducer: Reducer<S>, initialState: S, enhancer?: StoreEnhancer<S>): Store<S>;
 }
 
 /**
@@ -217,7 +216,9 @@ export interface StoreCreator {
  * without the app being aware it is happening. Amusingly, the Redux
  * middleware implementation is itself a store enhancer.
  */
-export type StoreEnhancer = (next: StoreCreator) => StoreCreator;
+export type StoreEnhancer<S> = (next: StoreEnhancerStoreCreator<S>) => StoreEnhancerStoreCreator<S>;
+export type GenericStoreEnhancer = <S>(next: StoreEnhancerStoreCreator<S>) => StoreEnhancerStoreCreator<S>;
+export type StoreEnhancerStoreCreator<S> = (reducer: Reducer<S>, initialState: S) => Store<S>;
 
 /**
  * Creates a Redux store that holds the state tree.
@@ -287,7 +288,7 @@ export interface Middleware {
  * @param middlewares The middleware chain to be applied.
  * @returns A store enhancer applying the middleware.
  */
-export function applyMiddleware(...middlewares: Middleware[]): StoreEnhancer;
+export function applyMiddleware(...middlewares: Middleware[]): GenericStoreEnhancer;
 
 
 /* action creators */

--- a/test/typescript/store.ts
+++ b/test/typescript/store.ts
@@ -1,5 +1,5 @@
 import {
-  Store, createStore, Reducer, Action, StoreEnhancer,
+  Store, createStore, Reducer, Action, StoreEnhancer, GenericStoreEnhancer,
   StoreCreator, Unsubscribe
 } from "../../index.d.ts";
 
@@ -21,13 +21,15 @@ const storeWithInitialState: Store<State> = createStore(reducer, {
   todos: []
 });
 
-const enhancer: StoreEnhancer = (next: StoreCreator) => next;
+const genericEnhancer: GenericStoreEnhancer = next => next;
+const specificEnhencer: StoreEnhancer<State> = next => next;
 
-const storeWithEnhancer: Store<State> = createStore(reducer, enhancer);
+const storeWithGenericEnhancer: Store<State> = createStore(reducer, genericEnhancer);
+const storeWithSpecificEnhancer: Store<State> = createStore(reducer, specificEnhencer);
 
 const storeWithInitialStateAndEnhancer: Store<State> = createStore(reducer, {
   todos: []
-}, enhancer);
+}, genericEnhancer);
 
 
 /* dispatch */

--- a/test/typescript/store.ts
+++ b/test/typescript/store.ts
@@ -1,6 +1,6 @@
 import {
   Store, createStore, Reducer, Action, StoreEnhancer, GenericStoreEnhancer,
-  StoreCreator, Unsubscribe
+  StoreCreator, StoreEnhancerStoreCreator, Unsubscribe
 } from "../../index.d.ts";
 
 
@@ -21,7 +21,7 @@ const storeWithInitialState: Store<State> = createStore(reducer, {
   todos: []
 });
 
-const genericEnhancer: GenericStoreEnhancer = next => next;
+const genericEnhancer: GenericStoreEnhancer = <S>(next: StoreEnhancerStoreCreator<S>) => next;
 const specificEnhencer: StoreEnhancer<State> = next => next;
 
 const storeWithGenericEnhancer: Store<State> = createStore(reducer, genericEnhancer);


### PR DESCRIPTION
Following up https://github.com/reactjs/redux/pull/1526#issuecomment-205403474 here is a PR that enhance typyings for `StoreEnhancer`.

- make `StoreEnhancer` to be parameterized by state type, because it's always being called with known type of the state, so that it opens a way to create state-specific enhancers
- when a generic version of `StoreEnhancer` is needed, newly introduced `GenericStoreEnhancer` can be used, which a function with same signature but has a state type parameter; obviously it's assignable to any typed store enhancer
- `StoreEnhancer` exposes a `StoreEnhancerStoreCreator<S>` as a result, that is a stricter version of `StoreCreator` which strictly expects to get a reducer and initial state (not optionals)
- `applyMiddlewares` now returns `GenericStoreEnhancer` as the middlewares are generic
- tests that show/prove usage of the new signature have also been added

/cc @aikoven