### PR TITLE
Load data in right lifecycle event

### DIFF
--- a/docs/recipes/ReducingBoilerplate.md
+++ b/docs/recipes/ReducingBoilerplate.md
@@ -213,7 +213,7 @@ class Posts extends Component {
     )
   }
 
-  componentDidMount() {
+  componentWillMount() {
     this.loadData(this.props.userId)
   }
 
@@ -295,7 +295,7 @@ import { connect } from 'react-redux'
 import { loadPosts } from './actionCreators'
 
 class Posts extends Component {
-  componentDidMount() {
+  componentWillMount() {
     this.props.dispatch(loadPosts(this.props.userId))
   }
 


### PR DESCRIPTION
It's better to load the data in `componentWillMount` instead of `componentDidMount`. When we do it in the former we are setting the status of data to be `fetching` so before `renders()` runs, so that it will actually render the loading screen.