### PR TITLE
Push reducer key to finalReducerKeys

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -93,13 +93,14 @@ function assertReducerSanity(reducers) {
 export default function combineReducers(reducers) {
   var reducerKeys = Object.keys(reducers)
   var finalReducers = {}
+  var finalReducerKeys = []
   for (var i = 0; i < reducerKeys.length; i++) {
     var key = reducerKeys[i]
     if (typeof reducers[key] === 'function') {
       finalReducers[key] = reducers[key]
+      finalReducerKeys.push(key)
     }
   }
-  var finalReducerKeys = Object.keys(finalReducers)
 
   var sanityError
   try {


### PR DESCRIPTION
This saves a call to ```Object.keys``` by explicitly pushing the reducer key to ```finalReducerKeys``` when ```typeof reducers[key] === 'function'```.

I guess this might only matter if there were a lot of reducers. Even then, I'm not sure how much of a performance boost this would provide. Either way, just wanted to note something I observed!

