### PR TITLE
remove initial assignment of `dispatch` in applyMiddleware to make it more expressive

### DIFF
--- a/src/applyMiddleware.js
+++ b/src/applyMiddleware.js
@@ -19,7 +19,8 @@ import compose from './compose'
 export default function applyMiddleware(...middlewares) {
   return (createStore) => (reducer, initialState, enhancer) => {
     var store = createStore(reducer, initialState, enhancer)
-    var dispatch = store.dispatch
+    var storeDispatch = store.dispatch
+    var dispatch
     var chain = []
 
     var middlewareAPI = {
@@ -27,7 +28,7 @@ export default function applyMiddleware(...middlewares) {
       dispatch: (action) => dispatch(action)
     }
     chain = middlewares.map(middleware => middleware(middlewareAPI))
-    dispatch = compose(...chain)(store.dispatch)
+    dispatch = compose(...chain)(storeDispatch)
 
     return {
       ...store,

--- a/src/applyMiddleware.js
+++ b/src/applyMiddleware.js
@@ -19,7 +19,6 @@ import compose from './compose'
 export default function applyMiddleware(...middlewares) {
   return (createStore) => (reducer, initialState, enhancer) => {
     var store = createStore(reducer, initialState, enhancer)
-    var storeDispatch = store.dispatch
     var dispatch
     var chain = []
 
@@ -28,7 +27,7 @@ export default function applyMiddleware(...middlewares) {
       dispatch: (action) => dispatch(action)
     }
     chain = middlewares.map(middleware => middleware(middlewareAPI))
-    dispatch = compose(...chain)(storeDispatch)
+    dispatch = compose(...chain)(store.dispatch)
 
     return {
       ...store,


### PR DESCRIPTION
In the original version, the `dispatch` local variable in `applyMiddleware` stands for
different things before and after the `compose` call.
It'd be more expressive to separate "the original one on store" and "the one with middlewares applied"