### PR TITLE
Warn if user uses previous state

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -18,7 +18,7 @@ function printWarningOnEmptyState(action) {
 
   return (
     `Given action ${actionName} returned your previous state` +
-    `Are you sure you want this action to be empty?`
+    `Are you sure you need this action to be empty?`
   )
 }
 
@@ -141,7 +141,7 @@ export default function combineReducers(reducers) {
         var errorMessage = getUndefinedStateErrorMessage(key, action)
         throw new Error(errorMessage)
       }
-      if (nextStateForKey === ' ') {
+      if (typeof nextStateForKey === previousStateForKey) {
         var warningMessageOnState = printWarningOnEmptyState(action)
         if(warningMessageOnState) {
           warning(warningMessageOnState)

--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -141,7 +141,7 @@ export default function combineReducers(reducers) {
         var errorMessage = getUndefinedStateErrorMessage(key, action)
         throw new Error(errorMessage)
       }
-      if (typeof nextStateForKey === ' ') {
+      if (nextStateForKey === ' ') {
         var warningMessageOnState = printWarningOnEmptyState(action)
         if(warningMessageOnState) {
           warning(warningMessageOnState)

--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -18,7 +18,7 @@ function printWarningOnEmptyState(action) {
 
   return (
     `Given action ${actionName} returned your previous state` +
-    `Are you sure you need this action to be empty?`
+    `Are you sure you want this action to be empty?`
   )
 }
 

--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -12,6 +12,16 @@ function getUndefinedStateErrorMessage(key, action) {
   )
 }
 
+function printWarningOnEmptyState(action) {
+  var actionType = action && action.type
+  var actionName = actionType && `"${actionType.toString()}"` || 'an action'
+
+  return (
+    `Given action ${actionName} returned your previous state` +
+    `Are you sure you need this action to be empty?`
+  )
+}
+
 function getUnexpectedStateShapeWarningMessage(inputState, reducers, action) {
   var reducerKeys = Object.keys(reducers)
   var argumentName = action && action.type === ActionTypes.INIT ?
@@ -130,6 +140,12 @@ export default function combineReducers(reducers) {
       if (typeof nextStateForKey === 'undefined') {
         var errorMessage = getUndefinedStateErrorMessage(key, action)
         throw new Error(errorMessage)
+      }
+      if (typeof nextStateForKey === ' ') {
+        var warningMessageOnState = printWarningOnEmptyState(action)
+        if(warningMessageOnState) {
+          warning(warningMessageOnState)
+        }
       }
       nextState[key] = nextStateForKey
       hasChanged = hasChanged || nextStateForKey !== previousStateForKey


### PR DESCRIPTION
## Description 

So.. This PR is 50/50. It needs some work in my eyes. I'm not 100% sure how to check the previous state vs the current one, so please help out on this if I misunderstood this completely in the PR or haven't got the code to do what I wanted it to.

### Why this PR?

We want the user to know that he is setting the previous state. Maybe he/she doesn't even need to do that. This helps users to maybe refactor the code they want in a more effective matter.

### Functionality 

It warns possible "empty" states/previousStates that are the same.

### What has been changed?

The only thing added is a new warning function along with a conditional to check if this is true. Note that I'm not sure if I set it up correctly. It ran through tests fine, but would be convenient to double-check this.

## Note

A lot of small patches, as I had a mixed thought about checking if the string is empty or if we just could do a normal conditional between two variables. Naturally last option was more reasonable.