### PR TITLE
Define NODE_ENV on client-side in real world example

### DIFF
--- a/examples/real-world/webpack.config.js
+++ b/examples/real-world/webpack.config.js
@@ -14,7 +14,12 @@ module.exports = {
   },
   plugins: [
     new webpack.optimize.OccurenceOrderPlugin(),
-    new webpack.HotModuleReplacementPlugin()
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: JSON.stringify(process.env.NODE_ENV)
+      }
+    })
   ],
   module: {
     loaders: [


### PR DESCRIPTION
Right now NODE_ENV is always undefined on the client-side. This fix allows NODE_ENV to be defined, thus giving us the option to run the app in production mode (currently it'll only run in dev mode - see configureStore.js).