### PR TITLE
feat(store): add observable proposal interop to store

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
   "dependencies": {
     "lodash": "^4.2.1",
     "lodash-es": "^4.2.1",
-    "loose-envify": "^1.1.0"
+    "loose-envify": "^1.1.0",
+    "symbol-observable": "^0.2.1"
   },
   "devDependencies": {
     "babel-cli": "^6.3.15",
@@ -101,6 +102,7 @@
     "isparta": "^4.0.0",
     "mocha": "^2.2.5",
     "rimraf": "^2.3.4",
+    "rxjs": "^5.0.0-beta.6",
     "typescript": "^1.8.0",
     "typescript-definition-tester": "0.0.4",
     "webpack": "^1.9.6"

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -1,4 +1,5 @@
 import isPlainObject from 'lodash/isPlainObject'
+import $$observable from 'symbol-observable'
 
 /**
  * These are private action types reserved by Redux.
@@ -198,6 +199,49 @@ export default function createStore(reducer, initialState, enhancer) {
     dispatch({ type: ActionTypes.INIT })
   }
 
+  /**
+   * Interoperability point for observable/reactive libraries.
+   * @returns {observable} A minimal observable of state changes.
+   * For more information, see the observable proposal:
+   * https://github.com/zenparsing/es-observable
+   */
+  function observable() {
+    var outerSubscribe = subscribe
+    return {
+      /**
+       * The minimal observable subscription method.
+       * @param {Object} observer Any object that can be used as an observer.
+       * The observer object should have a `next` method.
+       * @returns {subscription} An object with an `unsubscribe` method that can
+       * be used to unsubscribe the observable from the store, and prevent further
+       * emission of values from the observable.
+       */
+      subscribe(observer) {
+        if (typeof observer !== 'object') {
+          throw new TypeError('Expected observer to be an object')
+        }
+
+        var observeState = () => {
+          if (observer.next) {
+            observer.next(getState())
+          }
+        }
+
+        // send initial state to observer
+        observeState()
+
+        // send subsequent states to observer
+        var unsubscribe = outerSubscribe(observeState)
+
+        // return an unsubscribable
+        return { unsubscribe }
+      },
+      [$$observable]() {
+        return this
+      }
+    }
+  }
+
   // When a store is created, an "INIT" action is dispatched so that every
   // reducer returns their initial state. This effectively populates
   // the initial state tree.
@@ -207,6 +251,7 @@ export default function createStore(reducer, initialState, enhancer) {
     dispatch,
     subscribe,
     getState,
-    replaceReducer
+    replaceReducer,
+    [$$observable]: observable
   }
 }


### PR DESCRIPTION
- Adds `Symbol.observable` method to the store that returns a generic observable
- Adds tests to ensure interoperability. (rxjs 5 was used for a simple integration test, and
  is a dev only dependency)

closes #1631