### PR TITLE
document assertReducerSanity behavior

### DIFF
--- a/docs/api/combineReducers.md
+++ b/docs/api/combineReducers.md
@@ -45,7 +45,7 @@ Any reducer passed to `combineReducers` must satisfy these rules:
 
 * If the `state` given to it is `undefined`, it must return the initial state for this specific reducer. According to the previous rule, the initial state must not be `undefined` either. It is handy to specify it with ES6 optional arguments syntax, but you can also explicitly check the first argument for being `undefined`.
 
-While `combineReducers` attempts to check that your reducers conform to some of these rules, you should remember them, and do your best to follow them.
+While `combineReducers` attempts to check that your reducers conform to some of these rules, you should remember them, and do your best to follow them. `combineReducers` will check your reducers by passing `undefined` to them; this is done even if you specify initial state to `Redux.createStore(combinedReducers(...), initialState)`. Therefore, you **must** ensure your reducers work properly when receiving `undefined` as state, even if you never intend for them to actually receive `undefined` in your own code.
 
 #### Example
 


### PR DESCRIPTION
It is not clear from the documentation that it is insufficient to merely avoid ever passing in `undefined` as state by using initial state. `assertReducerSanity` will test that your reducer does the right thing when passed `undefined`, even if you never intend for it to be called this way.

This documentation change makes that behavior clearer, in the hopes of saving new users from needless frustration. It was very confusing to see my reducer passed undefined even though I never intended it to be used that way. I did not suspect `combineReducers` would do this.

Hope this helps!
