### PR TITLE
Remove unneeded code

### DIFF
--- a/src/utils/warning.js
+++ b/src/utils/warning.js
@@ -10,11 +10,4 @@ export default function warning(message) {
     console.error(message)
   }
   /* eslint-enable no-console */
-  try {
-    // This error was thrown as a convenience so that you can use this stack
-    // to find the callsite that caused this warning to fire.
-    throw new Error(message)
-  /* eslint-disable no-empty */
-  } catch (e) { }
-  /* eslint-enable no-empty */
 }


### PR DESCRIPTION
`console.error` can print the call site. Even if `console.error` didn't or doesn't exist, the `try...catch` block cannot print the call site. It does nothing here.