### PR TITLE
Keep dispatch available while middleware is initializing

### DIFF
--- a/src/applyMiddleware.js
+++ b/src/applyMiddleware.js
@@ -19,7 +19,7 @@ import compose from './compose'
 export default function applyMiddleware(...middlewares) {
   return (createStore) => (reducer, initialState, enhancer) => {
     var store = createStore(reducer, initialState, enhancer)
-    var dispatch
+    var dispatch = store.dispatch
     var chain = []
 
     var middlewareAPI = {

--- a/test/applyMiddleware.spec.js
+++ b/test/applyMiddleware.spec.js
@@ -94,4 +94,22 @@ describe('applyMiddleware', () => {
       done()
     })
   })
+
+  it('keeps unwrapped dispatch available while middleware is initializing', () => {
+    // This is documenting the existing behavior in Redux 3.x.
+    // We plan to forbid this in Redux 4.x.
+
+    function earlyDispatch({ dispatch }) {
+      dispatch(addTodo('Hello'))
+      return () => action => action
+    }
+
+    const store = createStore(reducers.todos, applyMiddleware(earlyDispatch))
+    expect(store.getState()).toEqual([
+      {
+        id: 1,
+        text: 'Hello'
+      }
+    ])
+  })
 })


### PR DESCRIPTION
Fixes #1644 which is a regression introduced in #1592 that got into 3.5.0.
Some middleware was relying on this pattern, and we broke it.

This PR reverts #1592 and adds a test for this regression.