### PR TITLE
Add devtools extension support in development

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -258,7 +258,7 @@ export default (() => {
   // property is exposed, let’s enhance our stores to support it.
   // https://github.com/zalmoxisus/redux-devtools-extension
   if (process.env.NODE_ENV === 'development') {
-    if (window.devToolsExtension) {
+    if (typeof window !== 'undefined' && window.devToolsExtension) {
       return window.devToolsExtension()(createStore)
     }
   }

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -36,7 +36,7 @@ export var ActionTypes = {
  * @returns {Store} A Redux store that lets you read the state, dispatch actions
  * and subscribe to changes.
  */
-export default function createStore(reducer, initialState, enhancer) {
+function createStore(reducer, initialState, enhancer) {
   if (typeof initialState === 'function' && typeof enhancer === 'undefined') {
     enhancer = initialState
     initialState = undefined
@@ -251,3 +251,16 @@ export default function createStore(reducer, initialState, enhancer) {
     [$$observable]: observable
   }
 }
+
+export default (() => {
+  // React works out of the box with its developer tools Chrome extension, we
+  // want Redux to as well. If we are in development, and a `devToolsExtension`
+  // property is exposed, let’s enhance our stores to support it.
+  // https://github.com/zalmoxisus/redux-devtools-extension
+  if (process.env.NODE_ENV === 'development') {
+    if (window.devToolsExtension) {
+      return window.devToolsExtension()(createStore)
+    }
+  }
+  return createStore
+})()


### PR DESCRIPTION
React works out of the box with its developer tools extension, Redux probably should to. This PR is in the hopes that there is a solution to get Redux working out of the box with its developer tools chrome extension.

Code was written in this way so that it can be minified away in production builds.

\cc @zalmoxisus