### PR TITLE
fix(Symbol.observable): update symbol-observable to fix IE8 issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "lodash": "^4.2.1",
     "lodash-es": "^4.2.1",
     "loose-envify": "^1.1.0",
-    "symbol-observable": "^0.2.1"
+    "symbol-observable": "^0.2.3"
   },
   "devDependencies": {
     "babel-cli": "^6.3.15",


### PR DESCRIPTION
This updates symbol-observable dependency to be 0.2.3 or higher in order to fix an issue where legacy browsers did not like `Symbol.for` statement inside of the ponyfill

related #1632
related #774