### PR TITLE
chore(dependencies): update symbol-observable to 0.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "lodash": "^4.2.1",
     "lodash-es": "^4.2.1",
     "loose-envify": "^1.1.0",
-    "symbol-observable": "^0.2.3"
+    "symbol-observable": "^0.2.4"
   },
   "devDependencies": {
     "babel-cli": "^6.3.15",


### PR DESCRIPTION
This updates symbol-observable to 0.2.4 which resolves edge cases where a user may have another polyfill for Symbol.observable in place that results in redux store as not being identifiable as 'observable'. See http://github.com/blesh/symbol-observable/issues#7 and https://github.com/sindresorhus/is-observable/issues/1#issuecomment-214479549