### PR TITLE
Added support to combineReducers to make the coding of loading state easier.

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -126,9 +126,13 @@ export default function combineReducers(reducers) {
       var key = finalReducerKeys[i]
       var reducer = finalReducers[key]
       var previousStateForKey = state[key]
-      var nextStateForKey = reducer(previousStateForKey, action)
+      var appliedAction = !action || action.type !== ActionTypes.HYDRATE ? action : {
+          type: ActionTypes.HYDRATE,
+          state: action.state[key]
+      }
+      var nextStateForKey = reducer(previousStateForKey, appliedAction)
       if (typeof nextStateForKey === 'undefined') {
-        var errorMessage = getUndefinedStateErrorMessage(key, action)
+        var errorMessage = getUndefinedStateErrorMessage(key, appliedAction)
         throw new Error(errorMessage)
       }
       nextState[key] = nextStateForKey

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -8,7 +8,8 @@ import $$observable from 'symbol-observable'
  * Do not reference these action types directly in your code.
  */
 export var ActionTypes = {
-  INIT: '@@redux/INIT'
+  INIT: '@@redux/INIT',
+  HYDRATE: '@@redux/HYDRATE'
 }
 
 /**

--- a/test/combineReducers.spec.js
+++ b/test/combineReducers.spec.js
@@ -237,5 +237,36 @@ describe('Utils', () => {
 
       spy.restore()
     })
+
+    it('returns a composite reducer that can handle HYDRATE actions', () => {
+      const reducer = combineReducers({
+        counter: (state = 0, action) => {
+          switch (action.type) {
+            case 'increment':
+              return state + 1
+            case ActionTypes.HYDRATE:
+              return action.state;
+            default:
+              return state
+          }
+        },
+        stack: (state = [], action) => {
+          switch (action.type) {
+            case 'push':
+              return [ ...state, action.value ]
+            case ActionTypes.HYDRATE:
+              return action.state;
+            default:
+              return state
+          }
+        }
+      })
+
+      const s1 = reducer({}, {type:'increment'})
+      expect(s1).toEqual({counter:1, stack:[]})
+      const savedState = {counter:7, stack:['a', 'b']}
+      const s3 = reducer(s1, { type: ActionTypes.HYDRATE, state: savedState })
+      expect(s3).toEqual(savedState)
+    })
   })
 })


### PR DESCRIPTION
With the existing implementation of `combineReducers` if you try to add an action to load
the state every reducer will get the entire state passed to them and would need to have
knowledge of where they are in the state tree to lookup their new state.

I've added a special HYDRATE action type (`@@redux/HYDRATE`) which combineReducers looks for and handles as a special case passing down only the state for each reducer.

This means that each reducer can opt in to the load and choose how it wants to handle it.
Usually this will just be returning `action.state`.