### PR TITLE
Use object literal property value shorthand consistently

### DIFF
--- a/examples/async/actions/index.js
+++ b/examples/async/actions/index.js
@@ -29,7 +29,7 @@ function requestPosts(reddit) {
 function receivePosts(reddit, json) {
   return {
     type: RECEIVE_POSTS,
-    reddit: reddit,
+    reddit,
     posts: json.data.children.map(child => child.data),
     receivedAt: Date.now()
   }


### PR DESCRIPTION
All action functions returned objects using the property value shorthand for the 'reddit' key & value except for 'receivePosts'. I updated it simply for consistency. I think it was just an oversight.