### PR TITLE
Change doc examples to use TOGGLE_TODO action consistently

### DIFF
--- a/docs/basics/Actions.md
+++ b/docs/basics/Actions.md
@@ -33,7 +33,7 @@ We’ll add one more action type to describe a user ticking off a todo as comple
 
 ```js
 {
-  type: COMPLETE_TODO,
+  type: TOGGLE_TODO,
   index: 5
 }
 ```
@@ -114,7 +114,7 @@ Action creators can also be asynchronous and have side-effects. You can read abo
  */
 
 export const ADD_TODO = 'ADD_TODO'
-export const COMPLETE_TODO = 'COMPLETE_TODO'
+export const TOGGLE_TODO = 'TOGGLE_TODO'
 export const SET_VISIBILITY_FILTER = 'SET_VISIBILITY_FILTER'
 
 /*
@@ -135,8 +135,8 @@ export function addTodo(text) {
   return { type: ADD_TODO, text }
 }
 
-export function completeTodo(index) {
-  return { type: COMPLETE_TODO, index }
+export function toggleTodo(index) {
+  return { type: TOGGLE_TODO, index }
 }
 
 export function setVisibilityFilter(filter) {

--- a/docs/basics/Reducers.md
+++ b/docs/basics/Reducers.md
@@ -142,15 +142,15 @@ function todoApp(state = initialState, action) {
 
 Just like before, we never write directly to `state` or its fields, and instead we return new objects. The new `todos` is equal to the old `todos` concatenated with a single new item at the end. The fresh todo was constructed using the data from the action.
 
-Finally, the implementation of the `COMPLETE_TODO` handler shouldn’t come as a complete surprise:
+Finally, the implementation of the `TOGGLE_TODO` handler shouldn’t come as a complete surprise:
 
 ```js
-case COMPLETE_TODO:
+case TOGGLE_TODO:
   return Object.assign({}, state, {
     todos: state.todos.map((todo, index) => {
       if (index === action.index) {
         return Object.assign({}, todo, {
-          completed: true
+          completed: !todo.completed
         })
       }
       return todo
@@ -181,12 +181,12 @@ function todoApp(state = initialState, action) {
           }
         ]
       })
-    case COMPLETE_TODO:
+    case TOGGLE_TODO:
       return Object.assign({}, state, {
         todos: state.todos.map((todo, index) => {
           if(index === action.index) {
             return Object.assign({}, todo, {
-              completed: true
+              completed: !todo.completed
             })
           }
           return todo
@@ -211,11 +211,11 @@ function todos(state = [], action) {
           completed: false
         }
       ]
-    case COMPLETE_TODO:
+    case TOGGLE_TODO:
       return state.map((todo, index) => {
         if (index === action.index) {
           return Object.assign({}, todo, {
-            completed: true
+            completed: !todo.completed
           })
         }
         return todo
@@ -232,7 +232,7 @@ function todoApp(state = initialState, action) {
         visibilityFilter: action.filter
       })
     case ADD_TODO:
-    case COMPLETE_TODO:
+    case TOGGLE_TODO:
       return Object.assign({}, state, {
         todos: todos(state.todos, action)
       })
@@ -270,11 +270,11 @@ function todos(state = [], action) {
           completed: false
         }
       ]
-    case COMPLETE_TODO:
+    case TOGGLE_TODO:
       return state.map((todo, index) => {
         if (index === action.index) {
           return Object.assign({}, todo, {
-            completed: true
+            completed: !todo.completed
           })
         }
         return todo
@@ -370,7 +370,7 @@ All [`combineReducers()`](../api/combineReducers.md) does is generate a function
 
 ```js
 import { combineReducers } from 'redux'
-import { ADD_TODO, COMPLETE_TODO, SET_VISIBILITY_FILTER, VisibilityFilters } from './actions'
+import { ADD_TODO, TOGGLE_TODO, SET_VISIBILITY_FILTER, VisibilityFilters } from './actions'
 const { SHOW_ALL } = VisibilityFilters
 
 function visibilityFilter(state = SHOW_ALL, action) {
@@ -392,11 +392,11 @@ function todos(state = [], action) {
           completed: false
         }
       ]
-    case COMPLETE_TODO:
+    case TOGGLE_TODO:
       return state.map((todo, index) => {
         if (index === action.index) {
           return Object.assign({}, todo, {
-            completed: true
+            completed: !todo.completed
           })
         }
         return todo

--- a/docs/basics/Store.md
+++ b/docs/basics/Store.md
@@ -31,7 +31,7 @@ let store = createStore(todoApp, window.STATE_FROM_SERVER)
 Now that we have created a store, let’s verify our program works! Even without any UI, we can already test the update logic.
 
 ```js
-import { addTodo, completeTodo, setVisibilityFilter, VisibilityFilters } from './actions'
+import { addTodo, toggleTodo, setVisibilityFilter, VisibilityFilters } from './actions'
 
 // Log the initial state
 console.log(store.getState())
@@ -46,8 +46,8 @@ let unsubscribe = store.subscribe(() =>
 store.dispatch(addTodo('Learn about actions'))
 store.dispatch(addTodo('Learn about reducers'))
 store.dispatch(addTodo('Learn about store'))
-store.dispatch(completeTodo(0))
-store.dispatch(completeTodo(1))
+store.dispatch(toggleTodo(0))
+store.dispatch(toggleTodo(1))
 store.dispatch(setVisibilityFilter(VisibilityFilters.SHOW_COMPLETED))
 
 // Stop listening to state updates


### PR DESCRIPTION
The examples in the Basics documentation use COMPLETE_TODO actions all the way up until 2.6 with the complete todo list source code, where it uses a TOGGLE_TODO action. 