### PR TITLE
Add action as parameter to store.subscribe funcListeners 

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -176,6 +176,7 @@ export default function createStore(reducer, initialState, enhancer) {
     for (var i = 0; i < listeners.length; i++) {
       /**
        *  add action parameter to listeners,so that subscribers can dictate action
+       *  and use action to customize developer's code stuff
        */
 
       //listeners[i]()

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -174,7 +174,12 @@ export default function createStore(reducer, initialState, enhancer) {
 
     var listeners = currentListeners = nextListeners
     for (var i = 0; i < listeners.length; i++) {
-      listeners[i]()
+      /**
+       *  add action parameter to listeners,so that subscribers can dictate action
+       */
+
+      //listeners[i]()
+      listeners[i](action)
     }
 
     return action


### PR DESCRIPTION
redux is awesome
when in use, I need to **add subscribe listeners with action as the parameter.** that doesn't really affect redux to be put in use and is only a patchy stuff.

the change is like the following:
`   listeners[i]()        == change to =>       listeners[i](action)`
**hope the minor change pull request can be merged**