### PR TITLE
Compose Reducers with a common action

### DIFF
--- a/src/composeReducers.js
+++ b/src/composeReducers.js
@@ -1,0 +1,22 @@
+/**
+ * Composes reducer functions passing a new state object to the function on the
+ * right and each receiving the same action object. The composed function will
+ * have a function signature of (state, action) making itself a reducer.
+ *
+ * @param {...Function} funcs The reducer functions to compose.
+ * @returns {Function} A function obtained by composing the argument functions
+ * from left to right. For example, compose(f, g, h) is identical to doing
+ * (state) => h(g(f(state, action), action), action).
+ */
+
+export default function composeReducers(...funcs) {
+  return (state, action) => {
+    let currentState = state
+
+    for (var i = 0; i < funcs.length; i++) {
+      currentState = funcs[i](currentState, action)
+    }
+
+    return currentState
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import combineReducers from './combineReducers'
 import bindActionCreators from './bindActionCreators'
 import applyMiddleware from './applyMiddleware'
 import compose from './compose'
+import composeReducers from './composeReducers'
 import warning from './utils/warning'
 
 /*
@@ -30,5 +31,6 @@ export {
   combineReducers,
   bindActionCreators,
   applyMiddleware,
-  compose
+  compose,
+  composeReducers
 }

--- a/test/composeReducers.spec.js
+++ b/test/composeReducers.spec.js
@@ -1,0 +1,28 @@
+import expect, { createSpy } from 'expect'
+import { composeReducers } from '../src'
+
+describe('Utils', () => {
+  describe('composeReducers', () => {
+    it('should run each reducer passing previous state and a common action', () => {
+      const action = { a: 'action' }
+      const state1 = { b: 'state1' }
+      const state2 = { c: 'state2' }
+      const state3 = { d: 'state3' }
+      const state4 = { e: 'state4' }
+      const func1 = createSpy().andReturn(state2)
+      const func2 = createSpy().andReturn(state3)
+      const func3 = createSpy().andReturn(state4)
+
+      const reducers = composeReducers(func1, func2, func3)
+
+      expect(reducers(state1, action)).toBe(state4)
+
+      expect(func1.calls[0].arguments[0]).toBe(state1)
+      expect(func1.calls[0].arguments[1]).toBe(action)
+      expect(func2.calls[0].arguments[0]).toBe(state2)
+      expect(func2.calls[0].arguments[1]).toBe(action)
+      expect(func3.calls[0].arguments[0]).toBe(state3)
+      expect(func3.calls[0].arguments[1]).toBe(action)
+    })
+  })
+})


### PR DESCRIPTION
```javascript
function firstName(state = '', action = {}) {
  if (action.type === SET_FIRST_NAME) {
    return action.payload
  }

  return state
}

function lastName(state = '', action = {}) {
  if (action.type === SET_LAST_NAME) {
    return action.payload
  }

  return state
}

const reducer = combineReducers({
  firstName,
  lastName
})

function handleSetFullName(state, action) {
  if (action.type === SET_FULL_NAME) {
    const parts = action.payload.split(' ')

    return {
      ...state,
      firstName: parts[0],
      lastName: parts[1]
    }
  }

  return state
}

export default composeReducers(
  reducer,
  handleSetFullName
);
```

reactjs/redux#897