### PR TITLE
Use lodash-webpack-plugin.

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
   },
   "homepage": "http://redux.js.org",
   "dependencies": {
-    "lodash": "^4.2.1",
-    "lodash-es": "^4.2.1",
+    "lodash": "^4.13.1",
+    "lodash-es": "^4.13.1",
     "loose-envify": "^1.1.0",
     "symbol-observable": "^0.2.4"
   },
@@ -102,6 +102,7 @@
     "gitbook-cli": "^0.3.4",
     "glob": "^6.0.4",
     "isparta": "^4.0.0",
+    "lodash-webpack-plugin": "^0.9.3",
     "mocha": "^2.2.5",
     "rimraf": "^2.3.4",
     "rxjs": "^5.0.0-beta.6",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var LodashModuleReplacementPlugin = require('lodash-webpack-plugin')
 var webpack = require('webpack')
 
 var env = process.env.NODE_ENV
@@ -14,6 +15,7 @@ var config = {
     libraryTarget: 'umd'
   },
   plugins: [
+    new LodashModuleReplacementPlugin(),
     new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify(env)
@@ -27,7 +29,6 @@ if (env === 'production') {
       compressor: {
         pure_getters: true,
         unsafe: true,
-        unsafe_comps: true,
         warnings: false
       }
     })


### PR DESCRIPTION
I just released [lodash-webpack-plugin](https://github.com/lodash/lodash-webpack-plugin).

![demo](https://cloud.githubusercontent.com/assets/4303/15064867/2c5420b0-130e-11e6-8293-5037d359851f.gif)

This would ensure you continue to get smaller modular builds and would allow you to expand your Lodash module use without worrying about the overhead of things like [iteratee shorthands](https://github.com/lodash/lodash-webpack-plugin#feature-sets).