### PR TITLE
Add expect to devDependencies to run tests

### DIFF
--- a/examples/shopping-cart/package.json
+++ b/examples/shopping-cart/package.json
@@ -32,6 +32,7 @@
     "babel-preset-react-hmre": "^1.1.1",
     "cross-env": "^1.0.7",
     "enzyme": "^2.0.0",
+    "expect": "^1.20.1",
     "express": "^4.13.3",
     "json-loader": "^0.5.3",
     "react-addons-test-utils": "^0.14.7",


### PR DESCRIPTION
`expect` package is missing from devDependencies and it's required to run tests in this example.