### PR TITLE
Use change-emitter module to handle subscriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   },
   "homepage": "http://redux.js.org",
   "dependencies": {
+    "change-emitter": "^0.1.2",
     "lodash": "^4.2.1",
     "lodash-es": "^4.2.1",
     "loose-envify": "^1.1.0",


### PR DESCRIPTION
`createStore` includes a really handy, bare-bones event subscription implementation that I found myself wanting in a few other projects. (E.g. here: https://github.com/acdlite/recompose/pull/160). So I extracted it out into a separate module: https://github.com/acdlite/change-emitter

When I tweeted about it, @tappleby pointed me to this issue (which, by coincidence, was closed just three hours ago :D) https://github.com/tappleby/redux-batched-subscribe/issues/8.

This PR rewrites `createStore` to use change-emitter. Not sure if it's something we want to do but I figured we should discuss it.

At the very least, I think it would be valuable to extract the subscription stuff into a separate file, even if it stays within the Redux project.
