### PR TITLE
Add extra required babel configuration step

### DIFF
--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -17,6 +17,14 @@ To use it together with [Babel](http://babeljs.io), you will need to install `ba
 npm install --save-dev babel-register
 ```
 
+and configure it to use ES2015 features in `.babelrc`:
+
+```js
+{
+  "presets": ["es2015"]
+}
+```
+
 Then, add this to `scripts` in your `package.json`:
 
 ```js


### PR DESCRIPTION
I had to add a `.babelrc` change to get the default examples to work, as described [here](http://jamesknelson.com/testing-in-es6-with-mocha-and-babel-6/). Without doing this, Mocha complained `import` was an unexpected reserved word.

I am running node 4.4.3.