### PR TITLE
fix(index.js): Add check for process object which might not be defined

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -113,7 +113,7 @@ export default function combineReducers(reducers) {
       throw sanityError
     }
 
-    if (process.env.NODE_ENV !== 'production') {
+    if (typeof process !== 'undefined' && process.env && process.env.NODE_ENV !== 'production') {
       var warningMessage = getUnexpectedStateShapeWarningMessage(state, finalReducers, action)
       if (warningMessage) {
         warning(warningMessage)

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,8 @@ import warning from './utils/warning'
 function isCrushed() {}
 
 if (
+  typeof process !== 'undefined' &&
+  process.env &&
   process.env.NODE_ENV !== 'production' &&
   typeof isCrushed.name === 'string' &&
   isCrushed.name !== 'isCrushed'


### PR DESCRIPTION
If the redux module has been bundled outside of webpack and is running on a client browser the process object may not be defined.  This pull request adds a check to make sure the process object is ok to use.