### PR TITLE
combineReducers warns about unexpected state shape once

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -134,6 +134,7 @@ export default function combineReducers(reducers) {
       nextState[key] = nextStateForKey
       hasChanged = hasChanged || nextStateForKey !== previousStateForKey
     }
+    hasChanged = hasChanged || Object.keys(state).length !== finalReducerKeys.length
     return hasChanged ? nextState : state
   }
 }

--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -113,14 +113,15 @@ export default function combineReducers(reducers) {
       throw sanityError
     }
 
+    var hasChanged = false
     if (process.env.NODE_ENV !== 'production') {
       var warningMessage = getUnexpectedStateShapeWarningMessage(state, finalReducers, action)
       if (warningMessage) {
         warning(warningMessage)
+        hasChanged = true
       }
     }
 
-    var hasChanged = false
     var nextState = {}
     for (var i = 0; i < finalReducerKeys.length; i++) {
       var key = finalReducerKeys[i]
@@ -134,7 +135,6 @@ export default function combineReducers(reducers) {
       nextState[key] = nextStateForKey
       hasChanged = hasChanged || nextStateForKey !== previousStateForKey
     }
-    hasChanged = hasChanged || Object.keys(state).length !== finalReducerKeys.length
     return hasChanged ? nextState : state
   }
 }

--- a/test/combineReducers.spec.js
+++ b/test/combineReducers.spec.js
@@ -237,5 +237,24 @@ describe('Utils', () => {
 
       spy.restore()
     })
+
+    it('removes unexpected keys when previous state does not match reducer shape', () => {
+      const spy = expect.spyOn(console, 'error')
+      const reducer = combineReducers({
+        foo(state = { bar: 1 }) {
+          return state
+        },
+        baz(state = { qux: 3 }) {
+          return state
+        }
+      })
+
+      const newState = reducer({ foo: { bar: 1 }, baz: { qux: 3 }, unknown: 1 })
+      expect(newState).toEqual({ foo: { bar: 1 }, baz: { qux: 3 } })
+      expect(spy.calls[0].arguments[0]).toMatch(
+          /Unexpected key "unknown".*previous state.*instead: "foo", "baz"/
+      )
+      spy.restore()
+    })
   })
 })


### PR DESCRIPTION
This updates behavior to only warn once when we have an unexpected state shape that is passed to the reducer. Note that we will still see incorrect behavior as described in #1748 in production environments.