### PR TITLE
Update api.js normalizr URL

### DIFF
--- a/examples/real-world/middleware/api.js
+++ b/examples/real-world/middleware/api.js
@@ -48,7 +48,7 @@ function callApi(endpoint, schema) {
 // consumption by reducers, because we can easily build a normalized tree
 // and keep it updated as we fetch more data.
 
-// Read more about Normalizr: https://github.com/gaearon/normalizr
+// Read more about Normalizr: https://github.com/paularmstrong/normalizr
 
 // GitHub's API may return results with uppercase letters while the query
 // doesn't contain any. For example, "someuser" could result in "SomeUser"


### PR DESCRIPTION
The normalizr lib has moved to a different location. Update the URL in comments to point to the new repo.