### PR TITLE
Docs: remove semicolons according to code style

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -521,7 +521,7 @@ const mapStateToProps = (state) => {
   return {
     objects: state.objectIds.map(id => state.objects[id])
   }
-};
+}
 ```
 
 Even though the array might contain the exact same object references each time, the array itself is a different reference, so the shallow equality check fails and React Redux would re-render the wrapped component.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -27,17 +27,17 @@ Every function described above is a top-level export. You can import any of them
 #### ES6
 
 ```js
-import { createStore } from 'redux';
+import { createStore } from 'redux'
 ```
 
 #### ES5 (CommonJS)
 
 ```js
-var createStore = require('redux').createStore;
+var createStore = require('redux').createStore
 ```
 
 #### ES5 (UMD build)
 
 ```js
-var createStore = Redux.createStore;
+var createStore = Redux.createStore
 ```

--- a/docs/api/applyMiddleware.md
+++ b/docs/api/applyMiddleware.md
@@ -225,9 +225,9 @@ export default connect(
   ```js
   let middleware = [ a, b ]
   if (process.env.NODE_ENV !== 'production') {
-    let c = require('some-debug-middleware');
-    let d = require('another-debug-middleware');
-    middleware = [ ...middleware, c, d ];
+    let c = require('some-debug-middleware')
+    let d = require('another-debug-middleware')
+    middleware = [ ...middleware, c, d ]
   }
 
   const store = createStore(

--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -120,7 +120,7 @@ import thunk from 'redux-thunk'
 import * as actions from '../../actions/counter'
 import * as types from '../../constants/ActionTypes'
 import nock from 'nock'
-import expect from 'expect'; // You can use any testing library
+import expect from 'expect' // You can use any testing library
 
 const middlewares = [ thunk ]
 const mockStore = configureMockStore(middlewares)
@@ -462,7 +462,7 @@ const dispatchWithStoreOf = (storeData, action) => {
   const dispatch = singleDispatch(createFakeStore(storeData))(actionAttempt => dispatched = actionAttempt)
   dispatch(action)
   return dispatched
-};
+}
 
 describe('middleware', () => {
   it('should dispatch if store is empty', () => {


### PR DESCRIPTION
Hi!

Just removed semicolons from docs code, according to code style.