### PR TITLE
Issue 1743

### DIFF
--- a/docs/Glossary.md
+++ b/docs/Glossary.md
@@ -114,10 +114,10 @@ See the complete [store API reference](api/Store.md#dispatch) for more details.
 ## Store creator
 
 ```js
-type StoreCreator = (reducer: Reducer, initialState: ?State) => Store
+type StoreCreator = (reducer: Reducer, preloadedState: ?State) => Store
 ```
 
-A store creator is a function that creates a Redux store. Like with dispatching function, we must distinguish the base store creator, [`createStore(reducer, initialState)`](api/createStore.md) exported from the Redux package, from store creators that are returned from the store enhancers.
+A store creator is a function that creates a Redux store. Like with dispatching function, we must distinguish the base store creator, [`createStore(reducer, preloadedState)`](api/createStore.md) exported from the Redux package, from store creators that are returned from the store enhancers.
 
 ## Store enhancer
 

--- a/docs/advanced/ExampleRedditAPI.md
+++ b/docs/advanced/ExampleRedditAPI.md
@@ -170,10 +170,10 @@ import rootReducer from './reducers'
 
 const loggerMiddleware = createLogger()
 
-export default function configureStore(initialState) {
+export default function configureStore(preloadedState) {
   return createStore(
     rootReducer,
-    initialState,
+    preloadedState,
     applyMiddleware(
       thunkMiddleware,
       loggerMiddleware

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -6,7 +6,7 @@ This section documents the complete Redux API. Keep in mind that Redux is only c
 
 ### Top-Level Exports
 
-* [createStore(reducer, [initialState])](createStore.md)
+* [createStore(reducer, [preloadedState])](createStore.md)
 * [combineReducers(reducers)](combineReducers.md)
 * [applyMiddleware(...middlewares)](applyMiddleware.md)
 * [bindActionCreators(actionCreators, dispatch)](bindActionCreators.md)

--- a/docs/api/applyMiddleware.md
+++ b/docs/api/applyMiddleware.md
@@ -232,7 +232,7 @@ export default connect(
 
   const store = createStore(
     reducer,
-    initialState,
+    preloadedState,
     applyMiddleware(...middleware)
   )
   ```

--- a/docs/api/createStore.md
+++ b/docs/api/createStore.md
@@ -1,4 +1,4 @@
-# `createStore(reducer, [initialState], [enhancer])`
+# `createStore(reducer, [preloadedState], [enhancer])`
 
 Creates a Redux [store](Store.md) that holds the complete state tree of your app.  
 There should only be a single store in your app.
@@ -7,7 +7,7 @@ There should only be a single store in your app.
 
 1. `reducer` *(Function)*: A [reducing function](../Glossary.md#reducer) that returns the next [state tree](../Glossary.md#state), given the current state tree and an [action](../Glossary.md#action) to handle.
 
-2. [`initialState`] *(any)*: The initial state. You may optionally specify it to hydrate the state from the server in universal apps, or to restore a previously serialized user session. If you produced `reducer` with [`combineReducers`](combineReducers.md), this must be a plain object with the same shape as the keys passed to it. Otherwise, you are free to pass anything that your `reducer` can understand.
+2. [`preloadedState`] *(any)*: The initial state. You may optionally specify it to hydrate the state from the server in universal apps, or to restore a previously serialized user session. If you produced `reducer` with [`combineReducers`](combineReducers.md), this must be a plain object with the same shape as the keys passed to it. Otherwise, you are free to pass anything that your `reducer` can understand.
 
 3. [`enhancer`] *(Function)*: The store enhancer. You may optionally specify it to enhance the store with third-party capabilities such as middleware, time travel, persistence, etc. The only store enhancer that ships with Redux is [`applyMiddleware()`](./applyMiddleware.md).
 

--- a/docs/recipes/ServerRendering.md
+++ b/docs/recipes/ServerRendering.md
@@ -92,9 +92,9 @@ function handleRender(req, res) {
 
 ### Inject Initial Component HTML and State
 
-The final step on the server side is to inject our initial component HTML and initial state into a template to be rendered on the client side. To pass along the state, we add a `<script>` tag that will attach `preloadedState` to `window.__INITIAL_STATE__`.
+The final step on the server side is to inject our initial component HTML and initial state into a template to be rendered on the client side. To pass along the state, we add a `<script>` tag that will attach `preloadedState` to `window.__PRELOADED_STATE__`.
 
-The `preloadedState` will then be available on the client side by accessing `window.__INITIAL_STATE__`.
+The `preloadedState` will then be available on the client side by accessing `window.__PRELOADED_STATE__`.
 
 We also include our bundle file for the client-side application via a script tag. This is whatever output your bundling tool provides for your client entry point. It may be a static file or a URL to a hot reloading development server.
 
@@ -109,7 +109,7 @@ function renderFullPage(html, preloadedState) {
       <body>
         <div id="root">${html}</div>
         <script>
-          window.__INITIAL_STATE__ = ${JSON.stringify(preloadedState)}
+          window.__PRELOADED_STATE__ = ${JSON.stringify(preloadedState)}
         </script>
         <script src="/static/bundle.js"></script>
       </body>
@@ -124,7 +124,7 @@ function renderFullPage(html, preloadedState) {
 
 ## The Client Side
 
-The client side is very straightforward. All we need to do is grab the initial state from `window.__INITIAL_STATE__`, and pass it to our [`createStore()`](../api/createStore.md) function as the initial state.
+The client side is very straightforward. All we need to do is grab the initial state from `window.__PRELOADED_STATE__`, and pass it to our [`createStore()`](../api/createStore.md) function as the initial state.
 
 Let’s take a look at our new client file:
 
@@ -139,7 +139,7 @@ import App from './containers/App'
 import counterApp from './reducers'
 
 // Grab the state from a global injected into server-generated HTML
-const preloadedState = window.__INITIAL_STATE__
+const preloadedState = window.__PRELOADED_STATE__
 
 // Create Redux store with initial state
 const store = createStore(counterApp, preloadedState)
@@ -202,7 +202,7 @@ function handleRender(req, res) {
 }
 ```
 
-The code reads from the Express `Request` object passed into our server middleware. The parameter is parsed into a number and then set in the initial state. If you visit [http://localhost:3000/?counter=100](http://localhost:3000/?counter=100) in your browser, you’ll see the counter starts at 100. In the rendered HTML, you’ll see the counter output as 100 and the `__INITIAL_STATE__` variable has the counter set in it.
+The code reads from the Express `Request` object passed into our server middleware. The parameter is parsed into a number and then set in the initial state. If you visit [http://localhost:3000/?counter=100](http://localhost:3000/?counter=100) in your browser, you’ll see the counter starts at 100. In the rendered HTML, you’ll see the counter output as 100 and the `__PRELOADED_STATE__` variable has the counter set in it.
 
 ### Async State Fetching
 

--- a/docs/recipes/ServerRendering.md
+++ b/docs/recipes/ServerRendering.md
@@ -53,7 +53,7 @@ app.use(handleRender)
 
 // We are going to fill these out in the sections to follow
 function handleRender(req, res) { /* ... */ }
-function renderFullPage(html, initialState) { /* ... */ }
+function renderFullPage(html, preloadedState) { /* ... */ }
 
 app.listen(port)
 ```
@@ -83,23 +83,23 @@ function handleRender(req, res) {
   )
 
   // Grab the initial state from our Redux store
-  const initialState = store.getState()
+  const preloadedState = store.getState()
 
   // Send the rendered page back to the client
-  res.send(renderFullPage(html, initialState))
+  res.send(renderFullPage(html, preloadedState))
 }
 ```
 
 ### Inject Initial Component HTML and State
 
-The final step on the server side is to inject our initial component HTML and initial state into a template to be rendered on the client side. To pass along the state, we add a `<script>` tag that will attach `initialState` to `window.__INITIAL_STATE__`.
+The final step on the server side is to inject our initial component HTML and initial state into a template to be rendered on the client side. To pass along the state, we add a `<script>` tag that will attach `preloadedState` to `window.__INITIAL_STATE__`.
 
-The `initialState` will then be available on the client side by accessing `window.__INITIAL_STATE__`.
+The `preloadedState` will then be available on the client side by accessing `window.__INITIAL_STATE__`.
 
 We also include our bundle file for the client-side application via a script tag. This is whatever output your bundling tool provides for your client entry point. It may be a static file or a URL to a hot reloading development server.
 
 ```js
-function renderFullPage(html, initialState) {
+function renderFullPage(html, preloadedState) {
   return `
     <!doctype html>
     <html>
@@ -109,7 +109,7 @@ function renderFullPage(html, initialState) {
       <body>
         <div id="root">${html}</div>
         <script>
-          window.__INITIAL_STATE__ = ${JSON.stringify(initialState)}
+          window.__INITIAL_STATE__ = ${JSON.stringify(preloadedState)}
         </script>
         <script src="/static/bundle.js"></script>
       </body>
@@ -139,10 +139,10 @@ import App from './containers/App'
 import counterApp from './reducers'
 
 // Grab the state from a global injected into server-generated HTML
-const initialState = window.__INITIAL_STATE__
+const preloadedState = window.__INITIAL_STATE__
 
 // Create Redux store with initial state
-const store = createStore(counterApp, initialState)
+const store = createStore(counterApp, preloadedState)
 
 render(
   <Provider store={store}>
@@ -182,10 +182,10 @@ function handleRender(req, res) {
   const counter = parseInt(params.counter, 10) || 0
 
   // Compile an initial state
-  let initialState = { counter }
+  let preloadedState = { counter }
 
   // Create a new Redux store instance
-  const store = createStore(counterApp, initialState)
+  const store = createStore(counterApp, preloadedState)
 
   // Render the component to a string
   const html = renderToString(
@@ -245,10 +245,10 @@ function handleRender(req, res) {
     const counter = parseInt(params.counter, 10) || apiResult || 0
 
     // Compile an initial state
-    let initialState = { counter }
+    let preloadedState = { counter }
 
     // Create a new Redux store instance
-    const store = createStore(counterApp, initialState)
+    const store = createStore(counterApp, preloadedState)
 
     // Render the component to a string
     const html = renderToString(

--- a/examples/async/store/configureStore.js
+++ b/examples/async/store/configureStore.js
@@ -3,10 +3,10 @@ import thunkMiddleware from 'redux-thunk'
 import createLogger from 'redux-logger'
 import rootReducer from '../reducers'
 
-export default function configureStore(initialState) {
+export default function configureStore(preloadedState) {
   const store = createStore(
     rootReducer,
-    initialState,
+    preloadedState,
     applyMiddleware(thunkMiddleware, createLogger())
   )
 

--- a/examples/real-world/store/configureStore.dev.js
+++ b/examples/real-world/store/configureStore.dev.js
@@ -5,10 +5,10 @@ import api from '../middleware/api'
 import rootReducer from '../reducers'
 import DevTools from '../containers/DevTools'
 
-export default function configureStore(initialState) {
+export default function configureStore(preloadedState) {
   const store = createStore(
     rootReducer,
-    initialState,
+    preloadedState,
     compose(
       applyMiddleware(thunk, api, createLogger()),
       DevTools.instrument()

--- a/examples/real-world/store/configureStore.prod.js
+++ b/examples/real-world/store/configureStore.prod.js
@@ -3,10 +3,10 @@ import thunk from 'redux-thunk'
 import api from '../middleware/api'
 import rootReducer from '../reducers'
 
-export default function configureStore(initialState) {
+export default function configureStore(preloadedState) {
   return createStore(
     rootReducer,
-    initialState,
+    preloadedState,
     applyMiddleware(thunk, api)
   )
 }

--- a/examples/todomvc/store/configureStore.js
+++ b/examples/todomvc/store/configureStore.js
@@ -1,8 +1,8 @@
 import { createStore } from 'redux'
 import rootReducer from '../reducers'
 
-export default function configureStore(initialState) {
-  const store = createStore(rootReducer, initialState)
+export default function configureStore(preloadedState) {
+  const store = createStore(rootReducer, preloadedState)
 
   if (module.hot) {
     // Enable Webpack hot module replacement for reducers

--- a/examples/tree-view/store/configureStore.js
+++ b/examples/tree-view/store/configureStore.js
@@ -1,8 +1,8 @@
 import { createStore } from 'redux'
 import reducer from '../reducers'
 
-export default function configureStore(initialState) {
-  const store = createStore(reducer, initialState)
+export default function configureStore(preloadedState) {
+  const store = createStore(reducer, preloadedState)
 
   if (module.hot) {
     // Enable Webpack hot module replacement for reducers

--- a/examples/universal/client/index.js
+++ b/examples/universal/client/index.js
@@ -5,8 +5,8 @@ import { Provider } from 'react-redux'
 import configureStore from '../common/store/configureStore'
 import App from '../common/containers/App'
 
-const initialState = window.__INITIAL_STATE__
-const store = configureStore(initialState)
+const preloadedState = window.__INITIAL_STATE__
+const store = configureStore(preloadedState)
 const rootElement = document.getElementById('app')
 
 render(

--- a/examples/universal/client/index.js
+++ b/examples/universal/client/index.js
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux'
 import configureStore from '../common/store/configureStore'
 import App from '../common/containers/App'
 
-const preloadedState = window.__INITIAL_STATE__
+const preloadedState = window.__PRELOADED_STATE__
 const store = configureStore(preloadedState)
 const rootElement = document.getElementById('app')
 

--- a/examples/universal/common/store/configureStore.js
+++ b/examples/universal/common/store/configureStore.js
@@ -2,10 +2,10 @@ import { createStore, applyMiddleware } from 'redux'
 import thunk from 'redux-thunk'
 import rootReducer from '../reducers'
 
-export default function configureStore(initialState) {
+export default function configureStore(preloadedState) {
   const store = createStore(
     rootReducer,
-    initialState,
+    preloadedState,
     applyMiddleware(thunk)
   )
 

--- a/examples/universal/server/server.js
+++ b/examples/universal/server/server.js
@@ -56,7 +56,7 @@ function handleRender(req, res) {
   })
 }
 
-function renderFullPage(html, initialState) {
+function renderFullPage(html, preloadedState) {
   return `
     <!doctype html>
     <html>
@@ -66,7 +66,7 @@ function renderFullPage(html, initialState) {
       <body>
         <div id="app">${html}</div>
         <script>
-          window.__INITIAL_STATE__ = ${JSON.stringify(initialState)}
+          window.__PRELOADED_STATE__ = ${JSON.stringify(preloadedState)}
         </script>
         <script src="/static/bundle.js"></script>
       </body>

--- a/examples/universal/server/server.js
+++ b/examples/universal/server/server.js
@@ -36,10 +36,10 @@ function handleRender(req, res) {
     const counter = parseInt(params.counter, 10) || apiResult || 0
 
     // Compile an initial state
-    const initialState = { counter }
+    const preloadedState = { counter }
 
     // Create a new Redux store instance
-    const store = configureStore(initialState)
+    const store = configureStore(preloadedState)
 
     // Render the component to a string
     const html = renderToString(

--- a/index.d.ts
+++ b/index.d.ts
@@ -188,14 +188,14 @@ export interface Store<S> {
 /**
  * A store creator is a function that creates a Redux store. Like with
  * dispatching function, we must distinguish the base store creator,
- * `createStore(reducer, initialState)` exported from the Redux package, from
+ * `createStore(reducer, preloadedState)` exported from the Redux package, from
  * store creators that are returned from the store enhancers.
  *
  * @template S State object type.
  */
 export interface StoreCreator {
   <S>(reducer: Reducer<S>, enhancer?: StoreEnhancer<S>): Store<S>;
-  <S>(reducer: Reducer<S>, initialState: S, enhancer?: StoreEnhancer<S>): Store<S>;
+  <S>(reducer: Reducer<S>, preloadedState: S, enhancer?: StoreEnhancer<S>): Store<S>;
 }
 
 /**
@@ -218,7 +218,7 @@ export interface StoreCreator {
  */
 export type StoreEnhancer<S> = (next: StoreEnhancerStoreCreator<S>) => StoreEnhancerStoreCreator<S>;
 export type GenericStoreEnhancer = <S>(next: StoreEnhancerStoreCreator<S>) => StoreEnhancerStoreCreator<S>;
-export type StoreEnhancerStoreCreator<S> = (reducer: Reducer<S>, initialState: S) => Store<S>;
+export type StoreEnhancerStoreCreator<S> = (reducer: Reducer<S>, preloadedState: S) => Store<S>;
 
 /**
  * Creates a Redux store that holds the state tree.
@@ -234,7 +234,7 @@ export type StoreEnhancerStoreCreator<S> = (reducer: Reducer<S>, initialState: S
  * @param reducer A function that returns the next state tree, given the
  *   current state tree and the action to handle.
  *
- * @param [initialState] The initial state. You may optionally specify it to
+ * @param [preloadedState] The initial state. You may optionally specify it to
  *   hydrate the state from the server in universal apps, or to restore a
  *   previously serialized user session. If you use `combineReducers` to
  *   produce the root reducer function, this must be an object with the same

--- a/src/applyMiddleware.js
+++ b/src/applyMiddleware.js
@@ -17,8 +17,8 @@ import compose from './compose'
  * @returns {Function} A store enhancer applying the middleware.
  */
 export default function applyMiddleware(...middlewares) {
-  return (createStore) => (reducer, initialState, enhancer) => {
-    var store = createStore(reducer, initialState, enhancer)
+  return (createStore) => (reducer, preloadedState, enhancer) => {
+    var store = createStore(reducer, preloadedState, enhancer)
     var dispatch = store.dispatch
     var chain = []
 

--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -15,7 +15,7 @@ function getUndefinedStateErrorMessage(key, action) {
 function getUnexpectedStateShapeWarningMessage(inputState, reducers, action) {
   var reducerKeys = Object.keys(reducers)
   var argumentName = action && action.type === ActionTypes.INIT ?
-    'initialState argument passed to createStore' :
+    'preloadedState argument passed to createStore' :
     'previous state received by the reducer'
 
   if (reducerKeys.length === 0) {

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -22,7 +22,7 @@ export var ActionTypes = {
  * @param {Function} reducer A function that returns the next state tree, given
  * the current state tree and the action to handle.
  *
- * @param {any} [initialState] The initial state. You may optionally specify it
+ * @param {any} [preloadedState] The initial state. You may optionally specify it
  * to hydrate the state from the server in universal apps, or to restore a
  * previously serialized user session.
  * If you use `combineReducers` to produce the root reducer function, this must be
@@ -36,10 +36,10 @@ export var ActionTypes = {
  * @returns {Store} A Redux store that lets you read the state, dispatch actions
  * and subscribe to changes.
  */
-export default function createStore(reducer, initialState, enhancer) {
-  if (typeof initialState === 'function' && typeof enhancer === 'undefined') {
-    enhancer = initialState
-    initialState = undefined
+export default function createStore(reducer, preloadedState, enhancer) {
+  if (typeof preloadedState === 'function' && typeof enhancer === 'undefined') {
+    enhancer = preloadedState
+    preloadedState = undefined
   }
 
   if (typeof enhancer !== 'undefined') {
@@ -47,7 +47,7 @@ export default function createStore(reducer, initialState, enhancer) {
       throw new Error('Expected the enhancer to be a function.')
     }
 
-    return enhancer(createStore)(reducer, initialState)
+    return enhancer(createStore)(reducer, preloadedState)
   }
 
   if (typeof reducer !== 'function') {
@@ -55,7 +55,7 @@ export default function createStore(reducer, initialState, enhancer) {
   }
 
   var currentReducer = reducer
-  var currentState = initialState
+  var currentState = preloadedState
   var currentListeners = []
   var nextListeners = currentListeners
   var isDispatching = false

--- a/test/typescript/store.ts
+++ b/test/typescript/store.ts
@@ -17,7 +17,7 @@ const reducer: Reducer<State> = (state: State, action: Action): State => {
 
 const store: Store<State> = createStore<State>(reducer);
 
-const storeWithInitialState: Store<State> = createStore(reducer, {
+const storeWithPreloadedState: Store<State> = createStore(reducer, {
   todos: []
 });
 
@@ -27,7 +27,7 @@ const specificEnhencer: StoreEnhancer<State> = next => next;
 const storeWithGenericEnhancer: Store<State> = createStore(reducer, genericEnhancer);
 const storeWithSpecificEnhancer: Store<State> = createStore(reducer, specificEnhencer);
 
-const storeWithInitialStateAndEnhancer: Store<State> = createStore(reducer, {
+const storeWithPreloadedStateAndEnhancer: Store<State> = createStore(reducer, {
   todos: []
 }, genericEnhancer);
 


### PR DESCRIPTION
This renames `initialState` in `createStore` and `configureStore`, as well as `window.__INITIAL_STATE__` to address https://github.com/reactjs/redux/issues/1743. It doesn't touch use of `initialState` in the reducer examples. 

There are a couple of comments that refer to `preloadedState` as 'initial state' that weren't addressed because I thought 'initial state' added to readability, e.g. https://github.com/reactjs/redux/compare/master...dliv:issue-1743?expand=1#diff-2b443c0a3e751858f6315977ee4a769aR85