### PR TITLE
Add a warning for undefined properties passed to combineReducers

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -95,6 +95,11 @@ export default function combineReducers(reducers) {
   var finalReducers = {}
   for (var i = 0; i < reducerKeys.length; i++) {
     var key = reducerKeys[i]
+    if (process.env.NODE_ENV !== 'production') {
+      if (typeof reducers[key] === 'undefined') {
+        warning(`No reducer provided for key "${key}"`)
+      }
+    }
     if (typeof reducers[key] === 'function') {
       finalReducers[key] = reducers[key]
     }

--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -95,11 +95,13 @@ export default function combineReducers(reducers) {
   var finalReducers = {}
   for (var i = 0; i < reducerKeys.length; i++) {
     var key = reducerKeys[i]
+
     if (process.env.NODE_ENV !== 'production') {
       if (typeof reducers[key] === 'undefined') {
         warning(`No reducer provided for key "${key}"`)
       }
     }
+
     if (typeof reducers[key] === 'function') {
       finalReducers[key] = reducers[key]
     }

--- a/test/combineReducers.spec.js
+++ b/test/combineReducers.spec.js
@@ -31,6 +31,24 @@ describe('Utils', () => {
       ).toEqual([ 'stack' ])
     })
 
+    it.only('warns if a reducer prop is undefined', () => {
+      const spy = expect.spyOn(console, 'error')
+
+      let isNotDefined
+      combineReducers({ isNotDefined })
+      expect(spy.calls[0].arguments[0]).toMatch(
+        /No reducer provided for key "isNotDefined"/
+      )
+
+      spy.reset()
+      combineReducers({ thing: undefined })
+      expect(spy.calls[0].arguments[0]).toMatch(
+        /No reducer provided for key "thing"/
+      )
+
+      spy.restore()
+    })
+
     it('throws an error if a reducer returns undefined handling an action', () => {
       const reducer = combineReducers({
         counter(state = 0, action) {

--- a/test/combineReducers.spec.js
+++ b/test/combineReducers.spec.js
@@ -31,7 +31,7 @@ describe('Utils', () => {
       ).toEqual([ 'stack' ])
     })
 
-    it.only('warns if a reducer prop is undefined', () => {
+    it('warns if a reducer prop is undefined', () => {
       const spy = expect.spyOn(console, 'error')
 
       let isNotDefined


### PR DESCRIPTION
This is easy to accidentally do with import statements and `combineReducers` doesn't currently give any indication of anything going wrong, it just ignores properties that aren't functions.

```js
// forgot to export
const thing = (state, action) => ...
```

```js
import {thing} from "../actions/thing"

combineReducers({
  thing
})
```