### PR TITLE
Expose action to listener

### DIFF
--- a/docs/Glossary.md
+++ b/docs/Glossary.md
@@ -96,7 +96,7 @@ See [`applyMiddleware(...middlewares)`](./api/applyMiddleware.md) for a detailed
 type Store = {
   dispatch: Dispatch
   getState: () => State
-  subscribe: (listener: () => void) => () => void
+  subscribe: (listener: (action: Action) => void) => () => void
   replaceReducer: (reducer: Reducer) => void
 }
 ```

--- a/docs/api/Store.md
+++ b/docs/api/Store.md
@@ -110,10 +110,12 @@ function select(state) {
 }
 
 let currentValue
-function handleChange() {
+function handleChange(action) {
+  console.log('Action executed:', action);
+
   let previousValue = currentValue
   currentValue = select(store.getState())
-  
+
   if (previousValue !== currentValue) {
     console.log('Some deep nested property changed from', previousValue, 'to', currentValue)
   }

--- a/docs/basics/Store.md
+++ b/docs/basics/Store.md
@@ -38,8 +38,9 @@ console.log(store.getState())
 
 // Every time the state changes, log it
 // Note that subscribe() returns a function for unregistering the listener
-let unsubscribe = store.subscribe(() =>
-  console.log(store.getState())
+let unsubscribe = store.subscribe((action) =>
+  console.log('Action:', action)
+  console.log('New state:', store.getState())
 )
 
 // Dispatch some actions

--- a/index.d.ts
+++ b/index.d.ts
@@ -171,7 +171,7 @@ export interface Store<S> {
    * @param listener A callback to be invoked on every dispatch.
    * @returns A function to remove this change listener.
    */
-  subscribe(listener: () => void): Unsubscribe;
+  subscribe(listener: (action: Action) => void): Unsubscribe;
 
   /**
    * Replaces the reducer currently used by the store to calculate the state.

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -174,7 +174,7 @@ export default function createStore(reducer, preloadedState, enhancer) {
 
     var listeners = currentListeners = nextListeners
     for (var i = 0; i < listeners.length; i++) {
-      listeners[i]()
+      listeners[i](action)
     }
 
     return action

--- a/test/createStore.spec.js
+++ b/test/createStore.spec.js
@@ -406,6 +406,18 @@ describe('createStore', () => {
     store.dispatch(addTodo('Hello'))
   })
 
+  it('provides access to the action when a subscriber is notified', done => {
+    const store = createStore(reducers.todos)
+    store.subscribe((action) => {
+      expect(action).toEqual({
+        type: 'ADD_TODO',
+        text: 'Hello'
+      })
+      done()
+    })
+    store.dispatch(addTodo('Hello'))
+  })
+
   it('only accepts plain object actions', () => {
     const store = createStore(reducers.todos)
     expect(() =>


### PR DESCRIPTION
Today if you want to know if something changed you have to compare your previous state to the new state and in that case you might need to compare different values with one another.

With this PR we now also expose the action to the listener, making it easier to do something when an action was executed.

```js
store.subscribe((action) => {
  if (action.type === 'SOMETHING') {
     // do something else
  }
});