### PR TITLE
Add DefinePlugin for NODE_ENV on Real World Example

### DIFF
--- a/examples/real-world/webpack.config.js
+++ b/examples/real-world/webpack.config.js
@@ -14,7 +14,10 @@ module.exports = {
   },
   plugins: [
     new webpack.optimize.OccurrenceOrderPlugin(),
-    new webpack.HotModuleReplacementPlugin()
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.DefinePlugin({
+      "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
+    })
   ],
   module: {
     loaders: [


### PR DESCRIPTION
`NODE_ENV=production npm start` in the Real World Example always loads `Root.dev` component (which includes dev tools), because `NODE_ENV` is never set on the client:
- add webpack DefinePlugin for `process.env.NODE_ENV`