### PR TITLE
#1792 candidate: Make combineReducers shape-agnostic

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "expect": "^1.8.0",
     "gitbook-cli": "^0.3.4",
     "glob": "^6.0.4",
+    "immutable": "3.8.1",
     "isparta": "^4.0.0",
     "mocha": "^2.2.5",
     "rimraf": "^2.3.4",


### PR DESCRIPTION
Candidate for #1792. Adds options parameter to `combineReducers` which can include `get`, `create`, and `keys` methods. There is no `set` method because we can just use `create` instead.

Adds a few new warnings and errors relevant to these methods without altering the old warnings and errors. The `isPlainObject` warning now just checks for `typeof state === 'object'`, so it still warns when something like a `Number` is passed in.

The keys methods is for iterating over the state keys, which is needed to check for unexpected keys. It can be excluded and will simply warn if the result of the default `Object.keys(...)` doesn't match the reducer shape.

Also added a param to `getUnexpectedStateShapeWarningMessage` to pass in the already computed `reducerKeys` instead of recalculating them from the reducer.