### PR TITLE
Avoiding confusion with "mutating state"

### DIFF
--- a/docs/introduction/ThreePrinciples.md
+++ b/docs/introduction/ThreePrinciples.md
@@ -30,9 +30,9 @@ console.log(store.getState())
 
 ### State is read-only
 
-**The only way to mutate the state is to emit an [action](../Glossary.md#action), an object describing what happened.**
+**The only way to change the state is to emit an [action](../Glossary.md#action), an object describing what happened.**
 
-This ensures that neither the views nor the network callbacks will ever write directly to the state. Instead, they express an intent to mutate. Because all mutations are centralized and happen one by one in a strict order, there are no subtle race conditions to watch out for. As actions are just plain objects, they can be logged, serialized, stored, and later replayed for debugging or testing purposes.
+This ensures that neither the views nor the network callbacks will ever write directly to the state. Instead, they express an intent to transform the state. Because all changes are centralized and happen one by one in a strict order, there are no subtle race conditions to watch out for. As actions are just plain objects, they can be logged, serialized, stored, and later replayed for debugging or testing purposes.
 
 ```js
 store.dispatch({


### PR DESCRIPTION
Hi Dan and the whole redux Dev Team,

I'd kindly ask you to review this little documentation change affecting the introduction/Three Principles chapter.

As proposed in the commit message I'd suggest to use the word 'change' instead of 'mutate' to avoid confusion with the concept of 'immutable state'. As we all know: While not enforced, making state objects immutable is a strongly recommended way of using redux (and only then redux plays well together with pure reducers, time traveling and so on).

I found myself felt a bit confused when reading the introduction for the first time. Furthermore I remember to have seen similar comments elsewhere here.

Maybe this little change helps people not getting on the wrong path in the very beginning.

Cheers and thanks for checking this,
Matthias
  