### PR TITLE
Avoid unnecessary calls to listeners

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -58,6 +58,8 @@ export default function createStore(reducer, preloadedState, enhancer) {
   var currentState = preloadedState
   var currentListeners = []
   var nextListeners = currentListeners
+  var listeners = []
+  var listenerId = 0
   var isDispatching = false
 
   function ensureCanMutateNextListeners() {
@@ -140,8 +142,14 @@ export default function createStore(reducer, preloadedState, enhancer) {
       isSubscribed = false
 
       ensureCanMutateNextListeners()
-      var index = nextListeners.indexOf(listener)
+      let index = nextListeners.indexOf(listener)
       nextListeners.splice(index, 1)
+
+      index = listeners.indexOf(listener)
+      if (index !== -1 && index > listenerId) {
+        listener()
+        listeners.splice(index, 1)
+      }
     }
   }
 
@@ -196,10 +204,13 @@ export default function createStore(reducer, preloadedState, enhancer) {
       isDispatching = false
     }
 
-    var listeners = currentListeners = nextListeners
-    for (var i = 0; i < listeners.length; i++) {
-      listeners[i]()
+    listeners = currentListeners = nextListeners
+    for (listenerId = 0; listenerId < listeners.length; listenerId++) {
+      listeners[listenerId]()
     }
+    currentListeners = nextListeners
+    listeners = []
+    listenerId = 0
 
     return action
   }

--- a/test/createStore.spec.js
+++ b/test/createStore.spec.js
@@ -1,13 +1,13 @@
 import expect from 'expect'
 import { createStore, combineReducers } from '../src/index'
-import { 
-  addTodo, 
-  dispatchInMiddle, 
+import {
+  addTodo,
+  dispatchInMiddle,
   getStateInMiddle,
   subscribeInMiddle,
   unsubscribeInMiddle,
-  throwError, 
-  unknownAction 
+  throwError,
+  unknownAction
 } from './helpers/actionCreators'
 import * as reducers from './helpers/reducers'
 import * as Rx from 'rxjs'
@@ -388,17 +388,39 @@ describe('createStore', () => {
 
     store.dispatch(unknownAction())
     expect(listener1.calls.length).toBe(1)
-    expect(listener2.calls.length).toBe(2)
-    expect(listener3.calls.length).toBe(2)
+    expect(listener2.calls.length).toBe(1)
+    expect(listener3.calls.length).toBe(1)
     expect(listener4.calls.length).toBe(1)
 
     unsubscribe4()
     store.dispatch(unknownAction())
     expect(listener1.calls.length).toBe(1)
-    expect(listener2.calls.length).toBe(3)
-    expect(listener3.calls.length).toBe(3)
+    expect(listener2.calls.length).toBe(2)
+    expect(listener3.calls.length).toBe(2)
     expect(listener4.calls.length).toBe(1)
   })
+
+  it('notifies a listener unsubscribed with nested dispatch with the new state', () => {
+    const store = createStore(reducers.todos)
+
+    var firstCall = true
+    const listener1 = expect.createSpy().andCall(() => {
+      unsubscribe2()
+      if (firstCall) {
+        firstCall = false
+        store.dispatch(unknownAction())
+      }
+    })
+    const listener2 = expect.createSpy()
+
+    store.subscribe(listener1)
+    let unsubscribe2 = store.subscribe(listener2)
+
+    store.dispatch(unknownAction())
+    expect(listener1.calls.length).toBe(2)
+    expect(listener2.calls.length).toBe(1)
+  })
+
 
   it('provides an up-to-date state when a subscriber is notified', done => {
     const store = createStore(reducers.todos)


### PR DESCRIPTION
This PR is a better version of #1626.
Please see the [original comment](https://github.com/reactjs/redux/pull/1626#issue-148879370) for explanation of aims and proposed solution (mainly related to efficiency and effectiveness of code).

In my opinion the present proposal lowers the computational complexity of the recursive dispatch mechanism and **prevents listeners to be notified more than once with the very same state value during the same call to dispatch**.
The cost to be paid is the use of *slice* and *shift* operations on listener arrays which is anyway O(N) (with N the number of registered listeners) and usually in the order of microseconds.

There is another interesting issue which is solved by the present proposal. Consider the following example:

```javascript
var unsubscribe2
const store = createStore(myReducer)

store.subscribe(() => {
  const state = store.getState()

  if (condition1) {
    unsubscribe2()
  }

  if (condition2) {
    store.dispatch(actionYYY())
  }
})

function listener2() {
  // ...
}
unsubscribe2 = store.subscribe(listener2)

store.dispatch(actionXXX())  // --> making true both condition1 and condition2 
```

With the current code, in case both *condition1* and *condition2* result true at the same time for a particular state, *listener2* will be notified with the new state value as set because of *actionYYY* and not as it was set because of *actionXXX* (when the first listener decided it was the right time to unsubscribe listener2...).
With the new code, *listener2* will be notified its last time right before its actual unsubscription, hence with the state as set by *actionXXX*.

But that's not all.
As a general note I think we should provide a more detailed contract for the *subscribe* and *unsubscribe* API calls and listeners notifications.
With the present proposal we could be able to state:

1. listeners will not be notified with state changes in response to calls to *dispatch* occurred before their subscription (trivial...).
2. listeners will not be notified with state changes in response to calls to *dispatch* occurred after unsubscription requests.
3. listeners will be notified at least once with the most recent state after a call to *dispatch*.
4. in case of nested calls to *dispatch*, listeners could be notified more than once with updating state values but this is not guaranteed and can easily vary depending on the order of subscriptions.
5. listeners will be notified at most once with the very same state in response to the very same call to *dispatch*.


By further modifying dispatch to look like this:
```javascript
function dispatch(action) {

  let nextState
  try {
    isDispatching = true
    nextState = currentReducer(currentState, action)
  } finally {
    isDispatching = false
  }

  if (nextState !== currentState) {
    currentState = nextState
    listeners = currentListeners.slice()
    while (listeners.length) {
      listeners.shift()()
    }
  }

  return action
}
```

at no additional cost, we could change 5. to:
5. listeners will never be notified twice with the same state value

Obvioulsy, secific tests should be added to support these statements.
...and I'll be happy to add them in case you're interested to proceed further with this.