### PR TITLE
Improve typings for `compose` function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -357,6 +357,11 @@ export function bindActionCreators<
 
 /* compose */
 
+type Func0<R> = () => R;
+type Func1<T1, R> = (a1: T1) => R;
+type Func2<T1, T2, R> = (a1: T1, a2: T2) => R;
+type Func3<T1, T2, T3, R> = (a1: T1, a2: T2, a3: T3, ...args: any[]) => R;
+
 /**
  * Composes single-argument functions from right to left. The rightmost
  * function can take multiple arguments as it provides the signature for the
@@ -367,27 +372,54 @@ export function bindActionCreators<
  *   to left. For example, `compose(f, g, h)` is identical to doing
  *   `(...args) => f(g(h(...args)))`.
  */
-export function compose(): <R>(a: R, ...args: any[]) => R;
+export function compose(): <R>(a: R) => R;
 
+export function compose<F extends Function>(f: F): F;
+
+/* two functions */
 export function compose<A, R>(
-  f1: (b: A) => R,
-  f2: (...args: any[]) => A
-): (...args: any[]) => R;
+  f1: (b: A) => R, f2: Func0<A>
+): Func0<R>;
+export function compose<A, T1, R>(
+  f1: (b: A) => R, f2: Func1<T1, A>
+): Func1<T1, R>;
+export function compose<A, T1, T2, R>(
+  f1: (b: A) => R, f2: Func2<T1, T2, A>
+): Func2<T1, T2, R>;
+export function compose<A, T1, T2, T3, R>(
+  f1: (b: A) => R, f2: Func3<T1, T2, T3, A>
+): Func3<T1, T2, T3, R>;
 
+/* three functions */
 export function compose<A, B, R>(
-  f1: (b: B) => R,
-  f2: (a: A) => B,
-  f3: (...args: any[]) => A
-): (...args: any[]) => R;
+  f1: (b: B) => R, f2: (a: A) => B, f3: Func0<A>
+): Func0<R>;
+export function compose<A, B, T1, R>(
+  f1: (b: B) => R, f2: (a: A) => B, f3: Func1<T1, A>
+): Func1<T1, R>;
+export function compose<A, B, T1, T2, R>(
+  f1: (b: B) => R, f2: (a: A) => B, f3: Func2<T1, T2, A>
+): Func2<T1, T2, R>;
+export function compose<A, B, T1, T2, T3, R>(
+  f1: (b: B) => R, f2: (a: A) => B, f3: Func3<T1, T2, T3, A>
+): Func3<T1, T2, T3, R>;
 
+/* four functions */
 export function compose<A, B, C, R>(
-  f1: (b: C) => R,
-  f2: (a: B) => C,
-  f3: (a: A) => B,
-  f4: (...args: any[]) => A
-): (...args: any[]) => R;
+  f1: (b: C) => R, f2: (a: B) => C, f3: (a: A) => B, f4: Func0<A>
+): Func0<R>;
+export function compose<A, B, C, T1, R>(
+  f1: (b: C) => R, f2: (a: B) => C, f3: (a: A) => B, f4: Func1<T1, A>
+): Func1<T1, R>;
+export function compose<A, B, C, T1, T2, R>(
+  f1: (b: C) => R, f2: (a: B) => C, f3: (a: A) => B, f4: Func2<T1, T2, A>
+): Func2<T1, T2, R>;
+export function compose<A, B, C, T1, T2, T3, R>(
+  f1: (b: C) => R, f2: (a: B) => C, f3: (a: A) => B, f4: Func3<T1, T2, T3, A>
+): Func3<T1, T2, T3, R>;
 
-export function compose<R>(
-  f1: (a: any) => R,
+/* rest */
+export function compose<A, B, C, R>(
+  f1: (b: C) => R, f2: (a: B) => C, f3: (a: A) => B,
   ...funcs: Function[]
 ): (...args: any[]) => R;

--- a/test/typescript/compose.ts
+++ b/test/typescript/compose.ts
@@ -16,7 +16,20 @@ const t4: (a: string) => number = compose(
 
 
 const t5: number = compose(stringToNumber, numberToString, numberToNumber)(5);
-const t6: string = compose(numberToString, stringToNumber, numberToString, numberToNumber)(5);
+const t6: string = compose(numberToString, stringToNumber, numberToString,
+  numberToNumber)(5);
 
-const t7: string = compose<string>(
-  numberToString, numberToNumber, stringToNumber, numberToString, stringToNumber)("fo");
+const t7: string = compose(
+  numberToString, numberToNumber, stringToNumber, numberToString,
+  stringToNumber)("fo");
+
+
+const multiArgFn = (a: string, b: number, c: boolean): string => 'foo'
+
+const t8: string = compose(multiArgFn)('bar', 42, true);
+const t9: number = compose(stringToNumber, multiArgFn)('bar', 42, true);
+const t10: string = compose(numberToString, stringToNumber,
+  multiArgFn)('bar', 42, true);
+
+const t11: number = compose(stringToNumber, numberToString, stringToNumber,
+  multiArgFn)('bar', 42, true);


### PR DESCRIPTION
Introduce more strict typings for `compose` function to allow smarter inference, e.g.:

```ts
import {compose} from "redux";
import {connect} from "react-redux";
import {withRouter} from "react-router";

compose(
  withRouter,
  connect(
    (state, ownProps) => {
      return {
        foo: 'bar',
      };
    }
  )
)(props => {
  // `props` type is inferred to `{foo: string, router: Router}`
});
```

cc @ulfryk, @Igorbek 