### PR TITLE
Add module entry point for webpack 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.5.2",
   "description": "Predictable state container for JavaScript apps",
   "main": "lib/index.js",
+  "module": "es/index.js",
   "jsnext:main": "es/index.js",
   "typings": "./index.d.ts",
   "files": [


### PR DESCRIPTION
This is what webpack 2 prefers. Ideally Rollup will follow along as well, at which point we can drop `jsnext:main`.