### PR TITLE
Removed extra comma in package.json example

### DIFF
--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -33,7 +33,7 @@ Then, add this to `scripts` in your `package.json`:
   "scripts": {
     ...
     "test": "mocha --compilers js:babel-register --recursive",
-    "test:watch": "npm test -- --watch",
+    "test:watch": "npm test -- --watch"
   },
   ...
 }


### PR DESCRIPTION
There's an extra comma in package.json on WritingTests example recipe page that would cause some of the npm commands to fail