### PR TITLE
Update symbol-observable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "lodash": "^4.2.1",
     "lodash-es": "^4.2.1",
     "loose-envify": "^1.1.0",
-    "symbol-observable": "^0.2.4"
+    "symbol-observable": "^1.0.1"
   },
   "devDependencies": {
     "babel-cli": "^6.3.15",


### PR DESCRIPTION
Hey!

Unfortunately some kinds of webpack builds causes an exception with outdated `symbol-observable` polyfill. There was a fix for that situation: https://github.com/blesh/symbol-observable/pull/8

Could you update the version for this case, please?

Alex