### PR TITLE
add examples with Flowtype support + libdefs for redux and react-redux

### DIFF
--- a/examples/todos-flow/.flowconfig
+++ b/examples/todos-flow/.flowconfig
@@ -1,0 +1,9 @@
+[ignore]
+<PROJECT_ROOT>/node_modules/fbjs
+
+[include]
+
+[libs]
+../../flow-typed
+
+[options]

--- a/examples/todos-flow/.gitignore
+++ b/examples/todos-flow/.gitignore
@@ -1,0 +1,11 @@
+# See http://help.github.com/ignore-files/ for more about ignoring files.
+
+# dependencies
+node_modules
+
+# production
+build
+
+# misc
+.DS_Store
+npm-debug.log

--- a/examples/todos-flow/README.md
+++ b/examples/todos-flow/README.md
@@ -1,0 +1,34 @@
+# Redux Todos Example
+
+This project template was built with [Create React App](https://github.com/facebookincubator/create-react-app).
+
+## Available Scripts
+
+In the project directory, you can run:
+
+### `npm start`
+
+Runs the app in the development mode.<br>
+Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+
+The page will reload if you make edits.<br>
+You will also see any lint errors in the console.
+
+### `npm run build`
+
+Builds the app for production to the `build` folder.<br>
+It correctly bundles React in production mode and optimizes the build for the best performance.
+
+The build is minified and the filenames include the hashes.<br>
+Your app is ready to be deployed!
+
+### `npm run eject`
+
+**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
+
+If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
+
+Instead, it will copy all the configuration files and the transitive dependencies (Webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
+
+You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
+

--- a/examples/todos-flow/index.html
+++ b/examples/todos-flow/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Redux Todos Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+
+      To begin the development, run `npm start` in this folder.
+      To create a production bundle, use `npm run build`.
+    -->
+  </body>
+</html>

--- a/examples/todos-flow/package.json
+++ b/examples/todos-flow/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "todos",
+  "version": "0.0.1",
+  "private": true,
+  "devDependencies": {
+    "enzyme": "^2.4.1",
+    "react-addons-test-utils": "^15.3.0",
+    "react-scripts": "^0.4.0"
+  },
+  "dependencies": {
+    "react": "^15.3.0",
+    "react-dom": "^15.3.0",
+    "react-redux": "^4.4.5",
+    "redux": "^3.5.2"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "eject": "react-scripts eject",
+    "test": "react-scripts test"
+  },
+  "eslintConfig": {
+    "extends": "./node_modules/react-scripts/config/eslint.js"
+  }
+}

--- a/examples/todos-flow/src/actions/index.js
+++ b/examples/todos-flow/src/actions/index.js
@@ -1,0 +1,26 @@
+// @flow
+import type { Id, Text, VisibilityFilter, Action } from '../types'
+
+let nextTodoId: Id = 0
+
+export const addTodo = (text: Text): Action => {
+  return {
+    type: 'ADD_TODO',
+    id: nextTodoId++,
+    text
+  }
+}
+
+export const setVisibilityFilter = (filter: VisibilityFilter): Action => {
+  return {
+    type: 'SET_VISIBILITY_FILTER',
+    filter
+  }
+}
+
+export const toggleTodo = (id: Id): Action => {
+  return {
+    type: 'TOGGLE_TODO',
+    id
+  }
+}

--- a/examples/todos-flow/src/actions/index.spec.js
+++ b/examples/todos-flow/src/actions/index.spec.js
@@ -1,0 +1,25 @@
+import * as actions from './index'
+
+describe('todo actions', () => {
+  it('addTodo should create ADD_TODO action', () => {
+    expect(actions.addTodo('Use Redux')).toEqual({
+      type: 'ADD_TODO',
+      id: 0,
+      text: 'Use Redux'
+    })
+  })
+
+  it('setVisibilityFilter should create SET_VISIBILITY_FILTER action', () => {
+    expect(actions.setVisibilityFilter('active')).toEqual({
+      type: 'SET_VISIBILITY_FILTER',
+      filter: 'active'
+    })
+  })
+
+  it('toggleTodo should create TOGGLE_TODO action', () => {
+    expect(actions.toggleTodo(1)).toEqual({
+      type: 'TOGGLE_TODO',
+      id: 1
+    })
+  })
+})

--- a/examples/todos-flow/src/components/App.js
+++ b/examples/todos-flow/src/components/App.js
@@ -1,0 +1,15 @@
+// @flow
+import React from 'react'
+import Footer from './Footer'
+import AddTodo from '../containers/AddTodo'
+import VisibleTodoList from '../containers/VisibleTodoList'
+
+const App = () => (
+  <div>
+    <AddTodo />
+    <VisibleTodoList />
+    <Footer />
+  </div>
+)
+
+export default App

--- a/examples/todos-flow/src/components/Footer.js
+++ b/examples/todos-flow/src/components/Footer.js
@@ -1,0 +1,23 @@
+// @flow
+import React from 'react'
+import FilterLink from '../containers/FilterLink'
+
+const Footer = () => (
+  <p>
+    Show:
+    {" "}
+    <FilterLink filter="SHOW_ALL">
+      All
+    </FilterLink>
+    {", "}
+    <FilterLink filter="SHOW_ACTIVE">
+      Active
+    </FilterLink>
+    {", "}
+    <FilterLink filter="SHOW_COMPLETED">
+      Completed
+    </FilterLink>
+  </p>
+)
+
+export default Footer

--- a/examples/todos-flow/src/components/Link.js
+++ b/examples/todos-flow/src/components/Link.js
@@ -1,0 +1,27 @@
+// @flow
+import React from 'react'
+
+export type Props = {
+  active: boolean,
+  children?: React$Element<any>,
+  onClick: () => void
+};
+
+const Link = ({ active, children, onClick }: Props) => {
+  if (active) {
+    return <span>{children}</span>
+  }
+
+  return (
+    <a href="#"
+       onClick={e => {
+         e.preventDefault()
+         onClick()
+       }}
+    >
+      {children}
+    </a>
+  )
+}
+
+export default Link

--- a/examples/todos-flow/src/components/Todo.js
+++ b/examples/todos-flow/src/components/Todo.js
@@ -1,0 +1,22 @@
+// @flow
+import React from 'react'
+import type { Text } from '../types'
+
+export type Props = {
+  onClick: () => void,
+  completed: boolean,
+  text: Text
+};
+
+const Todo = ({ onClick, completed, text }: Props) => (
+  <li
+    onClick={onClick}
+    style={{
+      textDecoration: completed ? 'line-through' : 'none'
+    }}
+  >
+    {text}
+  </li>
+)
+
+export default Todo

--- a/examples/todos-flow/src/components/TodoList.js
+++ b/examples/todos-flow/src/components/TodoList.js
@@ -1,0 +1,23 @@
+// @flow
+import React from 'react'
+import Todo from './Todo'
+import type { Todos, Id } from '../types'
+
+export type Props = {
+  todos: Todos,
+  onTodoClick: (id: Id) => void
+};
+
+const TodoList = ({ todos, onTodoClick }: Props) => (
+  <ul>
+    {todos.map(todo =>
+      <Todo
+        key={todo.id}
+        {...todo}
+        onClick={() => onTodoClick(todo.id)}
+      />
+    )}
+  </ul>
+)
+
+export default TodoList

--- a/examples/todos-flow/src/containers/AddTodo.js
+++ b/examples/todos-flow/src/containers/AddTodo.js
@@ -1,0 +1,38 @@
+// @flow
+import React from 'react'
+import { connect } from 'react-redux'
+import { addTodo } from '../actions'
+import type { Dispatch } from '../types'
+import type { Connector } from 'react-redux'
+
+type Props = {
+  dispatch: Dispatch
+};
+
+const AddTodo = ({ dispatch }) => {
+  let input
+
+  return (
+    <div>
+      <form onSubmit={e => {
+        e.preventDefault()
+        if (!input.value.trim()) {
+          return
+        }
+        dispatch(addTodo(input.value))
+        input.value = ''
+      }}>
+        <input ref={node => {
+          input = node
+        }} />
+        <button type="submit">
+          Add Todo
+        </button>
+      </form>
+    </div>
+  )
+}
+
+const connector: Connector<{}, Props> = connect()
+
+export default connector(AddTodo)

--- a/examples/todos-flow/src/containers/FilterLink.js
+++ b/examples/todos-flow/src/containers/FilterLink.js
@@ -1,0 +1,32 @@
+// @flow
+import { connect } from 'react-redux'
+import { setVisibilityFilter } from '../actions'
+import Link from '../components/Link'
+import type { Props } from '../components/Link'
+import type { State, Dispatch, VisibilityFilter } from '../types'
+import type { Connector } from 'react-redux'
+
+type OwnProps = {
+  filter: VisibilityFilter
+};
+
+const mapStateToProps = (state: State, ownProps) => {
+  return {
+    active: ownProps.filter === state.visibilityFilter
+  }
+}
+
+const mapDispatchToProps = (dispatch: Dispatch, ownProps) => {
+  return {
+    onClick: () => {
+      dispatch(setVisibilityFilter(ownProps.filter))
+    }
+  }
+}
+
+const connector: Connector<OwnProps, Props> = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)
+
+export default connector(Link)

--- a/examples/todos-flow/src/containers/VisibleTodoList.js
+++ b/examples/todos-flow/src/containers/VisibleTodoList.js
@@ -1,0 +1,40 @@
+// @flow
+import { connect } from 'react-redux'
+import { toggleTodo } from '../actions'
+import TodoList from '../components/TodoList'
+import type { State, Dispatch } from '../types'
+import type { Connector } from 'react-redux'
+import type { Props } from '../components/TodoList'
+
+const getVisibleTodos = (todos, filter) => {
+  switch (filter) {
+    case 'SHOW_COMPLETED':
+      return todos.filter(t => t.completed)
+    case 'SHOW_ACTIVE':
+      return todos.filter(t => !t.completed)
+    case 'SHOW_ALL':
+    default :
+      return todos
+  }
+}
+
+const mapStateToProps = (state: State) => {
+  return {
+    todos: getVisibleTodos(state.todos, state.visibilityFilter)
+  }
+}
+
+const mapDispatchToProps = (dispatch: Dispatch) => {
+  return {
+    onTodoClick: (id) => {
+      dispatch(toggleTodo(id))
+    }
+  }
+}
+
+const connector: Connector<{}, Props> = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)
+
+export default connector(TodoList)

--- a/examples/todos-flow/src/index.js
+++ b/examples/todos-flow/src/index.js
@@ -1,0 +1,17 @@
+// @flow
+import React from 'react'
+import { render } from 'react-dom'
+import { createStore } from 'redux'
+import { Provider } from 'react-redux'
+import App from './components/App'
+import reducer from './reducers'
+import type { Store } from './types'
+
+const store: Store = createStore(reducer)
+
+render(
+  <Provider store={store}>
+    <App />
+  </Provider>,
+  document.getElementById('root')
+)

--- a/examples/todos-flow/src/reducers/index.js
+++ b/examples/todos-flow/src/reducers/index.js
@@ -1,0 +1,12 @@
+// @flow
+import todos from './todos'
+import visibilityFilter from './visibilityFilter'
+import type { State, Action } from '../types'
+
+export default function todoApp(state: ?State, action: Action): State {
+  const s = state || {}
+  return {
+    todos: todos(s.todos, action),
+    visibilityFilter: visibilityFilter(s.visibilityFilter, action)
+  }
+}

--- a/examples/todos-flow/src/reducers/todos.js
+++ b/examples/todos-flow/src/reducers/todos.js
@@ -1,0 +1,37 @@
+// @flow
+import type { Todos, Todo, Id, Text, Action } from '../types'
+
+function createTodo(id: Id, text: Text): Todo {
+  return {
+    id,
+    text,
+    completed: false
+  }
+}
+
+function toggleTodo(todos: Todos, id: Id): Todos {
+  return todos.map(t => {
+    if (t.id !== id) {
+      return t
+    }
+    return Object.assign({}, t, {
+      completed: !t.completed
+    })
+  })
+}
+
+const todos = (state: Todos = [], action: Action): Todos => {
+  switch (action.type) {
+    case 'ADD_TODO':
+      return [
+        ...state,
+        createTodo(action.id, action.text)
+      ]
+    case 'TOGGLE_TODO':
+      return toggleTodo(state, action.id)
+    default:
+      return state
+  }
+}
+
+export default todos

--- a/examples/todos-flow/src/reducers/todos.spec.js
+++ b/examples/todos-flow/src/reducers/todos.spec.js
@@ -1,0 +1,111 @@
+import todos from './todos'
+
+describe('todos reducer', () => {
+  it('should handle initial state', () => {
+    expect(
+      todos(undefined, {})
+    ).toEqual([])
+  })
+
+  it('should handle ADD_TODO', () => {
+    expect(
+      todos([], {
+        type: 'ADD_TODO',
+        text: 'Run the tests',
+        id: 0
+      })
+    ).toEqual([
+      {
+        text: 'Run the tests',
+        completed: false,
+        id: 0
+      }
+    ])
+
+    expect(
+      todos([
+        {
+          text: 'Run the tests',
+          completed: false,
+          id: 0
+        }
+      ], {
+        type: 'ADD_TODO',
+        text: 'Use Redux',
+        id: 1
+      })
+    ).toEqual([
+      {
+        text: 'Run the tests',
+        completed: false,
+        id: 0
+      }, {
+        text: 'Use Redux',
+        completed: false,
+        id: 1
+      }
+    ])
+
+    expect(
+      todos([
+        {
+          text: 'Run the tests',
+          completed: false,
+          id: 0
+        }, {
+          text: 'Use Redux',
+          completed: false,
+          id: 1
+        }
+      ], {
+        type: 'ADD_TODO',
+        text: 'Fix the tests',
+        id: 2
+      })
+    ).toEqual([
+      {
+        text: 'Run the tests',
+        completed: false,
+        id: 0
+      }, {
+        text: 'Use Redux',
+        completed: false,
+        id: 1
+      }, {
+        text: 'Fix the tests',
+        completed: false,
+        id: 2
+      }
+    ])
+  })
+
+  it('should handle TOGGLE_TODO', () => {
+    expect(
+      todos([
+        {
+          text: 'Run the tests',
+          completed: false,
+          id: 1
+        }, {
+          text: 'Use Redux',
+          completed: false,
+          id: 0
+        }
+      ], {
+        type: 'TOGGLE_TODO',
+        id: 1
+      })
+    ).toEqual([
+      {
+        text: 'Run the tests',
+        completed: true,
+        id: 1
+      }, {
+        text: 'Use Redux',
+        completed: false,
+        id: 0
+      }
+    ])
+  })
+
+})

--- a/examples/todos-flow/src/reducers/visibilityFilter.js
+++ b/examples/todos-flow/src/reducers/visibilityFilter.js
@@ -1,0 +1,13 @@
+// @flow
+import type { VisibilityFilter, Action } from '../types'
+
+const visibilityFilter = (state: VisibilityFilter = 'SHOW_ALL', action: Action): VisibilityFilter => {
+  switch (action.type) {
+    case 'SET_VISIBILITY_FILTER':
+      return action.filter
+    default:
+      return state
+  }
+}
+
+export default visibilityFilter

--- a/examples/todos-flow/src/types/index.js
+++ b/examples/todos-flow/src/types/index.js
@@ -1,0 +1,35 @@
+// @flow
+import type { Store as ReduxStore, Dispatch as ReduxDispatch } from 'redux'
+
+export type Id = number;
+
+export type Text = string;
+
+export type Todo = {
+  id: Id,
+  text: Text,
+  completed: boolean
+};
+
+export type VisibilityFilter =
+    'SHOW_ALL'
+  | 'SHOW_ACTIVE'
+  | 'SHOW_COMPLETED'
+  ;
+
+export type Todos = Array<Todo>;
+
+export type State = {
+  todos: Todos,
+  visibilityFilter: VisibilityFilter
+};
+
+export type Action =
+    { type: 'ADD_TODO', id: Id, text: Text }
+  | { type: 'TOGGLE_TODO', id: Id }
+  | { type: 'SET_VISIBILITY_FILTER', filter: VisibilityFilter }
+  ;
+
+export type Store = ReduxStore<State, Action>;
+
+export type Dispatch = ReduxDispatch<Action>;

--- a/flow-typed/react-redux.js
+++ b/flow-typed/react-redux.js
@@ -1,0 +1,73 @@
+import type { Dispatch, Store } from 'redux'
+
+declare module 'react-redux' {
+
+  /*
+
+    S = State
+    A = Action
+    OP = OwnProps
+    SP = StateProps
+    DP = DispatchProps
+
+  */
+
+  declare type MapStateToProps<S, OP: Object, SP: Object> = (state: S, ownProps: OP) => SP | MapStateToProps<S, OP, SP>;
+
+  declare type MapDispatchToProps<A, OP: Object, DP: Object> = ((dispatch: Dispatch<A>, ownProps: OP) => DP) | DP;
+
+  declare type MergeProps<SP, DP: Object, OP: Object, P: Object> = (stateProps: SP, dispatchProps: DP, ownProps: OP) => P;
+
+  declare type StatelessComponent<P> = (props: P) => ?React$Element<any>;
+
+  declare class ConnectedComponent<OP, P, Def, St> extends React$Component<void, OP, void> {
+    static WrappedComponent: Class<React$Component<Def, P, St>>;
+    getWrappedInstance(): React$Component<Def, P, St>;
+    static defaultProps: void;
+    props: OP;
+    state: void;
+  }
+
+  declare type ConnectedComponentClass<OP, P, Def, St> = Class<ConnectedComponent<OP, P, Def, St>>;
+
+  declare type Connector<OP, P> = {
+    (component: StatelessComponent<P>): ConnectedComponentClass<OP, P, void, void>;
+    <Def, St>(component: Class<React$Component<Def, P, St>>): ConnectedComponentClass<OP, P, Def, St>;
+  };
+
+  declare class Provider<S, A> extends React$Component<void, { store: Store<S, A>, children?: any }, void> { }
+
+  declare type ConnectOptions = {
+    pure?: boolean,
+    withRef?: boolean
+  };
+
+  declare function connect<A, OP>(
+    options?: ConnectOptions
+  ): Connector<OP, { dispatch: Dispatch<A> } & OP>;
+
+  declare function connect<S, A, OP, SP>(
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    options?: ConnectOptions
+  ): Connector<OP, SP & { dispatch: Dispatch<A> }>;
+
+  declare function connect<A, OP, DP>(
+    mapStateToProps: null,
+    mapDispatchToProps: MapDispatchToProps<A, OP, DP>,
+    options?: ConnectOptions
+  ): Connector<OP, DP & OP>;
+
+  declare function connect<S, A, OP, SP, DP>(
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: MapDispatchToProps<A, OP, DP>,
+    options?: ConnectOptions
+  ): Connector<OP, SP & DP>;
+
+  declare function connect<S, A, OP, SP, DP, P>(
+    mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: MapDispatchToProps<A, OP, DP>,
+    mergeProps: MergeProps<SP, DP, OP, P>,
+    options?: ConnectOptions
+  ): Connector<OP, P>;
+
+}

--- a/flow-typed/react-redux.js
+++ b/flow-typed/react-redux.js
@@ -45,7 +45,7 @@ declare module 'react-redux' {
   declare type Null = null | void;
 
   declare function connect<A, OP>(
-    ...rest: Array<void>
+    ...rest: Array<void> // <= workaround for https://github.com/facebook/flow/issues/2360
   ): Connector<OP, $Supertype<{ dispatch: Dispatch<A> } & OP>>;
 
   declare function connect<A, OP>(

--- a/flow-typed/react-redux.js
+++ b/flow-typed/react-redux.js
@@ -42,26 +42,39 @@ declare module 'react-redux' {
     withRef?: boolean
   };
 
+  declare type Null = null | void;
+
   declare function connect<A, OP>(
-    options?: ConnectOptions
-  ): Connector<OP, { dispatch: Dispatch<A> } & OP>;
+    ...rest: Array<void>
+  ): Connector<OP, $Supertype<{ dispatch: Dispatch<A> } & OP>>;
+
+  declare function connect<A, OP>(
+    mapStateToProps: Null,
+    mapDispatchToProps: Null,
+    mergeProps: Null,
+    options: ConnectOptions
+  ): Connector<OP, $Supertype<{ dispatch: Dispatch<A> } & OP>>;
 
   declare function connect<S, A, OP, SP>(
     mapStateToProps: MapStateToProps<S, OP, SP>,
+    mapDispatchToProps: Null,
+    mergeProps: Null,
     options?: ConnectOptions
-  ): Connector<OP, SP & { dispatch: Dispatch<A> }>;
+  ): Connector<OP, $Supertype<SP & { dispatch: Dispatch<A> } & OP>>;
 
   declare function connect<A, OP, DP>(
-    mapStateToProps: null,
+    mapStateToProps: Null,
     mapDispatchToProps: MapDispatchToProps<A, OP, DP>,
+    mergeProps: Null,
     options?: ConnectOptions
-  ): Connector<OP, DP & OP>;
+  ): Connector<OP, $Supertype<DP & OP>>;
 
   declare function connect<S, A, OP, SP, DP>(
     mapStateToProps: MapStateToProps<S, OP, SP>,
     mapDispatchToProps: MapDispatchToProps<A, OP, DP>,
+    mergeProps: Null,
     options?: ConnectOptions
-  ): Connector<OP, SP & DP>;
+  ): Connector<OP, $Supertype<SP & DP & OP>>;
 
   declare function connect<S, A, OP, SP, DP, P>(
     mapStateToProps: MapStateToProps<S, OP, SP>,

--- a/flow-typed/redux.js
+++ b/flow-typed/redux.js
@@ -1,0 +1,54 @@
+declare module 'redux' {
+
+  /*
+
+    S = State
+    A = Action
+
+  */
+
+  declare type Dispatch<A: { type: $Subtype<string> }> = (action: A) => A;
+
+  declare type MiddlewareAPI<S, A> = {
+    dispatch: Dispatch<A>;
+    getState(): S;
+  };
+
+  declare type Store<S, A> = {
+    // rewrite MiddlewareAPI members in order to get nicer error messages (intersections produce long messages)
+    dispatch: Dispatch<A>;
+    getState(): S;
+    subscribe(listener: () => void): () => void;
+    replaceReducer(nextReducer: Reducer<S, A>): void
+  };
+
+  declare type Reducer<S, A> = (state: S, action: A) => S;
+
+  declare type Middleware<S, A> =
+    (api: MiddlewareAPI<S, A>) =>
+      (next: Dispatch<A>) => Dispatch<A>;
+
+  declare type StoreCreator<S, A> = {
+    <S, A>(reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A>): Store<S, A>;
+    <S, A>(reducer: Reducer<S, A>, preloadedState: S, enhancer?: StoreEnhancer<S, A>): Store<S, A>;
+  };
+
+  declare type StoreEnhancer<S, A> = (next: StoreCreator<S, A>) => StoreCreator<S, A>;
+
+  declare function createStore<S, A>(reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A>): Store<S, A>;
+  declare function createStore<S, A>(reducer: Reducer<S, A>, preloadedState: S, enhancer?: StoreEnhancer<S, A>): Store<S, A>;
+
+  declare function applyMiddleware<S, A>(...middlewares: Array<Middleware<S, A>>): StoreEnhancer<S, A>;
+
+  declare type ActionCreator<A> = (...args: Array<any>) => A;
+  declare type ActionCreators<K, A> = { [key: K]: ActionCreator<A> };
+
+  declare function bindActionCreators<A, C: ActionCreator<A>>(actionCreator: C, dispatch: Dispatch<A>): C;
+  declare function bindActionCreators<A, K, C: ActionCreators<K, A>>(actionCreators: C, dispatch: Dispatch<A>): C;
+
+  // unsafe (you can miss a field and / or assign a wrong reducer to a field)
+  declare function combineReducers<S: Object, A>(reducers: {[key: $Keys<S>]: Reducer<any, A>}): Reducer<S, A>;
+
+  declare function compose<S, A>(...fns: Array<StoreEnhancer<S, A>>): Function;
+
+}


### PR DESCRIPTION
**Using Flow for statically analyzing state and actions**

This PR is a proof of concept and is not meant to be merged

Added examples (ordered by difficulty)

- `counter-flow`
- `todos-flow`
- `todomvc-flow`

Added libdefs (in the `ROOT/flow-typed` directory)

- `redux`
- `react-redux`

**Observations**

1) the best type safety is achieved by avoiding the following helpers

- `combineReducers` (you can miss a field and / or assign a wrong reducer to a field)
- `bindActionCreators` (<del>all action creator signatures are erased</del>) <= this is now type safe

`combineReducers` may be replaced by combining the reducers by hand (see the todos-flow example). `bindActionCreators` is unsafe when an object is passed in. <del>However `bindActionCreators` also accepts a single function which is safer (see the todomvc-flow example)</del>

2) `react-redux`'s libdef was pretty hard to write. Should cover the most common cases (at least)

3) In order to please Flow I've done some refactorings but I tried to keep them as small as possible

4) libdefs need community feedback, then we might consider to push them to flow-typed