### PR TITLE
Update Gitbook version

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,0 +1,1 @@
+docs/README.md

--- a/book.json
+++ b/book.json
@@ -1,9 +1,6 @@
 {
-  "gitbook": "2.4.3",
+  "gitbook": "3.x.x",
   "title": "Redux",
-  "structure": {
-    "summary": "docs/README.md"
-  },
   "plugins": ["edit-link", "prism", "-highlight", "github", "anker-enable"],
   "pluginsConfig": {
     "edit-link": {
@@ -12,6 +9,12 @@
     },
     "github": {
       "url": "https://github.com/reactjs/redux/"
+    },
+    "theme-default": {
+      "showLevel": true,
+      "styles": {
+        "website": "build/gitbook.css"
+      }
     }
   }
 }

--- a/book.json
+++ b/book.json
@@ -1,7 +1,7 @@
 {
   "gitbook": "3.x.x",
   "title": "Redux",
-  "plugins": ["edit-link", "prism", "-highlight", "github", "anker-enable"],
+  "plugins": ["edit-link", "prism", "-highlight", "github", "anchorjs"],
   "pluginsConfig": {
     "edit-link": {
       "base": "https://github.com/reactjs/redux/tree/master",

--- a/build/gitbook.css
+++ b/build/gitbook.css
@@ -1,0 +1,9 @@
+.book-summary ul.summary li span {
+  cursor: not-allowed;
+  opacity: 0.3;
+}
+
+.book-summary ul.summary li a:hover {
+  color: #008cff;
+  text-decoration: none;
+}

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "eslint-config-rackt": "^1.1.1",
     "eslint-plugin-react": "^3.16.1",
     "expect": "^1.8.0",
-    "gitbook-cli": "^0.3.4",
+    "gitbook-cli": "^2.3.0",
     "glob": "^6.0.4",
     "isparta": "^4.0.0",
     "mocha": "^2.2.5",


### PR DESCRIPTION
Went down this rabbit hole because I was sick of the `graceful-fs` warnings on Node 6. So, this fixes that.

Retained everything from the original Gitbook theme, as far as I can tell. The only thing missing is the read-tracking checkmarks, but honestly I didn't find much value in them. Maybe others do, though? I can look into a replacement if it's a big deal. 

Also, I'm going to go check into #1865 so the next build works for hash links.