### PR TITLE
[Proposal] Make `combineReducers` pass extra arguments to child reducers

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -126,7 +126,7 @@ export default function combineReducers(reducers) {
     sanityError = e
   }
 
-  return function combination(state = {}, action) {
+  return function combination(state = {}, action, ...args) {
     if (sanityError) {
       throw sanityError
     }
@@ -144,7 +144,7 @@ export default function combineReducers(reducers) {
       var key = finalReducerKeys[i]
       var reducer = finalReducers[key]
       var previousStateForKey = state[key]
-      var nextStateForKey = reducer(previousStateForKey, action)
+      var nextStateForKey = reducer(previousStateForKey, action, ...args)
       if (typeof nextStateForKey === 'undefined') {
         var errorMessage = getUndefinedStateErrorMessage(key, action)
         throw new Error(errorMessage)


### PR DESCRIPTION
This can be useful a couple cases:

## 1. Reducers with dependencies

In my opinion the most explicit and convenient way to have one branch of reducers dependent on another branch is to make them have common parent that calculates dependency branch first and then passes its to the dependent reducer:

```js
const dependencyReducer = (state = ..., action) => {...};

const dependentReducer = (state = ..., action, dependency) => {...};

const parentReducer = (state = {}, action) => {
  const {dependency, dependent} = state;

  const nextDependency = dependencyReducer(state, action);
  const nextDependent = dependentReducer(state, action, nextDependency);

  if (nextDependency !== dependency || nextDependent !== dependent)
    return {dependency: nextDependency, dependent: nextDependent};

  return state;
};
```

The change in this PR allows `dependentReducer` to be built from smaller parts, each one accepting dependency.

## 2. Multiple branches of same shape

Suppose we are developing an instant messenger. We can switch between chat views for different contacts and we want to store some data for each view, e.g. entered text, scroll position etc.

Let's structure state like this:

```js
{
  alice: {
    enteredText: '...',
    scrollPosition: ...,
  },
  bob: {
    enteredText: '...',
    scrollPosition: ...,
  },
  ...
}
```

Actions:

```js
const chatOpened = (contact) => ({
  type: 'CHAT_OPENED',
  contact,
});

const textEntered = (contact, text) => ({
  type: 'TEXT_ENTERED',
  contact,
  text,
});
```

My first approach to this was to have parent reducer look into action's `contact` prop and pass action to `chatViewReducer` for particular branch. But that couples parent to child, parent has to know of all actions that child accepts etc.

So my current approach is to pass all actions to `chatViewReducer` for all child branches with `contact` passed as third argument:

```js
const chatsReducer = (state = {}, action) => {
  if (action.type === 'CHAT_OPENED') {
    return {
      ...state, 
      [action.contact]: chatViewReducer(undefined, action, action.contact),
    };
  }

  const nextState = {};
  let hasChanged = false;

  for (let contact of Object.keys(state)) {
    nextState[contact] = chatViewReducer(state[contact], action, contact);
    hasChanged = hasChanged || nextState[contact]  !== state[contact];
  }

  return hasChanged ? nextState : state;
};
```

Once again, this change allows `chatViewReducers` to be built from smaller parts each accepting `contact` as third argument, allowing them to filter incoming actions by `contact` to see if they correspond to that particular chat view.

Right now I have a custom `combineReducers` version that is almost the same as original.

Also, the above pattern can be generalised as reducer factory:

```js
/**
 * @param childReducer reducer for state branches
 * @param shouldAddKey function that accepts action and returns undefined or 
 *   string key to be added to state
 * @param shouldRemoveKey function that accepts action and returns undefined or
 *   string key to be removed from state
 */
function createMappingReducer(childReducer, shouldAddKey, shouldRemoveKey) {
  ...
}

const chatsReducer = createMappingReducer(chatViewReducer, (action) => {
  if (action.type === 'CHAT_OPENED')
    return action.contact;
});
```