### PR TITLE
Add `umdNamedDefine` to add named amd export

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,8 @@ var config = {
   },
   output: {
     library: 'Redux',
-    libraryTarget: 'umd'
+    libraryTarget: 'umd',
+    umdNamedDefine: true
   },
   plugins: [
     new webpack.optimize.OccurrenceOrderPlugin(),


### PR DESCRIPTION
Fixes #1905

```diff
diff --git i/redux.js w/redux.js
index 809cc7f..1ada35d 100644
--- i/redux.js
+++ w/redux.js
@@ -2,7 +2,7 @@
 	if(typeof exports === 'object' && typeof module === 'object')
 		module.exports = factory();
 	else if(typeof define === 'function' && define.amd)
-		define([], factory);
+		define("Redux", [], factory);
 	else if(typeof exports === 'object')
 		exports["Redux"] = factory();
 	else

```