### PR TITLE
Add default value option to combineReducers

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -97,7 +97,7 @@ function assertReducerSanity(reducers) {
  * @returns {Function} A reducer function that invokes every reducer inside the
  * passed object, and builds a state object with the same shape.
  */
-export default function combineReducers(reducers) {
+export default function combineReducers(reducers, defaultValue = {}) {
   var reducerKeys = Object.keys(reducers)
   var finalReducers = {}
   for (var i = 0; i < reducerKeys.length; i++) {
@@ -126,7 +126,7 @@ export default function combineReducers(reducers) {
     sanityError = e
   }
 
-  return function combination(state = {}, action) {
+  return function combination(state = defaultValue, action) {
     if (sanityError) {
       throw sanityError
     }

--- a/test/combineReducers.spec.js
+++ b/test/combineReducers.spec.js
@@ -49,6 +49,13 @@ describe('Utils', () => {
       spy.restore()
     })
 
+    it('accepts default value as secound params', () => {
+      const reducer = combineReducers({
+        fake: (i='') => i
+      }, { fake: 'hello' })
+      expect(reducer(undefined, {}).fake).toEqual('hello')
+    })
+
     it('throws an error if a reducer returns undefined handling an action', () => {
       const reducer = combineReducers({
         counter(state = 0, action) {


### PR DESCRIPTION
Adding a defaultValue option to `combineReducer`.
It's pretty useful when you want to provide a initial state for it. :)