### PR TITLE
Fix Generating Reducers example in Reducing Boilerplate doc

### DIFF
--- a/docs/recipes/ReducingBoilerplate.md
+++ b/docs/recipes/ReducingBoilerplate.md
@@ -483,7 +483,7 @@ Let's write a function that lets us express reducers as an object mapping from a
 
 ```js
 export const todos = createReducer([], {
-  [ActionTypes.ADD_TODO](state, action) {
+  [ActionTypes.ADD_TODO]: (state, action) {
     let text = action.text.trim()
     return [ ...state, text ]
   }


### PR DESCRIPTION
I'm quite new with Redux and ES6, but I think that the current example for the "Generating Reducers" helper usage is not correct.
Here's my suggested change.