### PR TITLE
Updated `npmcdn.com` links to `unpkg.com`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ npm install --save redux
 ```
 
 This assumes you are using [npm](https://www.npmjs.com/) as your package manager.  
-If you don't, you can [access these files on npmcdn](https://npmcdn.com/redux/), download them, or point your package manager to them.
+If you don't, you can [access these files on unpkg](https://unpkg.com/redux/), download them, or point your package manager to them.
 
 Most commonly people consume Redux as a collection of [CommonJS](http://webpack.github.io/docs/commonjs.html) modules. These modules are what you get when you import `redux` in a [Webpack](http://webpack.github.io), [Browserify](http://browserify.org/), or a Node environment. If you like to live on the edge and use [Rollup](http://rollupjs.org), we support that as well.
 
-If you don't use a module bundler, it's also fine. The `redux` npm package includes precompiled production and development [UMD](https://github.com/umdjs/umd) builds in the [`dist` folder](https://npmcdn.com/redux/dist/). They can be used directly without a bundler and are thus compatible with many popular JavaScript module loaders and environments. For example, you can drop a UMD build as a [`<script>` tag](https://npmcdn.com/redux/dist/redux.js) on the page, or [tell Bower to install it](https://github.com/reactjs/redux/pull/1181#issuecomment-167361975). The UMD builds make Redux available as a `window.Redux` global variable.
+If you don't use a module bundler, it's also fine. The `redux` npm package includes precompiled production and development [UMD](https://github.com/umdjs/umd) builds in the [`dist` folder](https://unpkg.com/redux/dist/). They can be used directly without a bundler and are thus compatible with many popular JavaScript module loaders and environments. For example, you can drop a UMD build as a [`<script>` tag](https://unpkg.com/redux/dist/redux.js) on the page, or [tell Bower to install it](https://github.com/reactjs/redux/pull/1181#issuecomment-167361975). The UMD builds make Redux available as a `window.Redux` global variable.
 
 The Redux source code is written in ES2015 but we precompile both CommonJS and UMD builds to ES5 so they work in [any modern browser](http://caniuse.com/#feat=es5). You don't need to use Babel or a module bundler to [get started with Redux](https://github.com/reactjs/redux/blob/master/examples/counter-vanilla/index.html).
 

--- a/docs/basics/UsageWithReact.md
+++ b/docs/basics/UsageWithReact.md
@@ -14,7 +14,7 @@ We will use React to build our simple todo app.
 npm install --save react-redux
 ```
 
-If you don't use npm, you may grab the latest UMD build from npmcdn (either a [development](https://npmcdn.com/react-redux@latest/dist/react-redux.js) or a [production](https://npmcdn.com/react-redux@latest/dist/react-redux.min.js) build). The UMD build exports a global called `window.ReactRedux` if you add it to your page via a `<script>` tag.
+If you don't use npm, you may grab the latest UMD build from unpkg (either a [development](https://unpkg.com/react-redux@latest/dist/react-redux.js) or a [production](https://unpkg.com/react-redux@latest/dist/react-redux.min.js) build). The UMD build exports a global called `window.ReactRedux` if you add it to your page via a `<script>` tag.
 
 ## Presentational and Container Components
 

--- a/examples/counter-vanilla/index.html
+++ b/examples/counter-vanilla/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>Redux basic example</title>
-    <script src="https://npmcdn.com/redux@latest/dist/redux.min.js"></script>
+    <script src="https://unpkg.com/redux@latest/dist/redux.min.js"></script>
   </head>
   <body>
     <div>


### PR DESCRIPTION
According to the [creator's twitter](https://twitter.com/mjackson/status/770427936449101824) and the [npmcdn's website](https://npmcdn.com/#/) the project was renamed to *unpkg* to avoid trademark issues. 
This PR updates the references to 'npmcdn.com' in Redux's examples and docs to the new link.