### PR TITLE
Don't lint examples

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 **/dist/**
+**/examples/**
 **/node_modules/**
 **/server.js
 **/webpack.config*.js


### PR DESCRIPTION
I broke linting of examples in #1883 because they are now linted via CRA, and it has incompatible configuration with the ancient version of ESLint we’re using. Our lint setup is a mess right now, with `rackt` config being used which is not maintained anymore. For now, I’ll just disable linting of examples altogether to try to get Travis to pass. In the future we should pick a lint config and update ESLint to a modern version.