### PR TITLE
Fix typings for `compose` function to accept single rest argument

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -419,7 +419,8 @@ export function compose<A, B, C, T1, T2, T3, R>(
 ): Func3<T1, T2, T3, R>;
 
 /* rest */
-export function compose<A, B, C, R>(
-  f1: (b: C) => R, f2: (a: B) => C, f3: (a: A) => B,
-  ...funcs: Function[]
+export function compose<R>(
+  f1: (b: any) => R, ...funcs: Function[]
 ): (...args: any[]) => R;
+
+export function compose<R>(...funcs: Function[]): (...args: any[]) => R;

--- a/test/typescript/compose.ts
+++ b/test/typescript/compose.ts
@@ -33,3 +33,7 @@ const t10: string = compose(numberToString, stringToNumber,
 
 const t11: number = compose(stringToNumber, numberToString, stringToNumber,
   multiArgFn)('bar', 42, true);
+
+
+const funcs = [stringToNumber, numberToString, stringToNumber];
+const t12 = compose(...funcs)('bar', 42, true);


### PR DESCRIPTION
Fixes #1935.

Cc. @ulfryk @Igorbek 