### PR TITLE
Update UsageWithReactRouter.md

### DIFF
--- a/docs/advanced/UsageWithReactRouter.md
+++ b/docs/advanced/UsageWithReactRouter.md
@@ -118,7 +118,7 @@ export default Root;
 
 ## Navigating with React Router
 
-React Router comes with a [<Link />](https://github.com/reactjs/react-router/blob/master/docs/API.md#link) component that let you navigate around your application. We can use it in our example and change our container `<FilterLink />` component so we can change the URL using `<FilterLink />`. The `activeStyle={}` property lets you apply a style on the active state.
+React Router comes with a [`<Link />`](https://github.com/reactjs/react-router/blob/master/docs/API.md#link) component that let you navigate around your application. We can use it in our example and change our container `<FilterLink />` component so we can change the URL using `<FilterLink />`. The `activeStyle={}` property lets you apply a style on the active state.
 
 
 #### `containers/FilterLink.js`


### PR DESCRIPTION
Fix some markdown issue. I added '\`\`' into `[<Link />]` to make it be rendered by github-page.

From 
> React Router comes with a component 

to

> React Router comes with a **`<Link />`** component 

(Sorry, I should have pushed this commit with the one yesterday. However, I just found the 'feature' today. I was translating this article to Chinese this days. [Link](https://github.com/camsong/redux-in-chinese/pull/145).)

:D