### PR TITLE
Use more ES6 syntaxes in the async example

### DIFF
--- a/examples/async/src/actions/index.js
+++ b/examples/async/src/actions/index.js
@@ -3,46 +3,36 @@ export const RECEIVE_POSTS = 'RECEIVE_POSTS'
 export const SELECT_REDDIT = 'SELECT_REDDIT'
 export const INVALIDATE_REDDIT = 'INVALIDATE_REDDIT'
 
-export function selectReddit(reddit) {
-  return {
-    type: SELECT_REDDIT,
-    reddit
-  }
+export const selectReddit = reddit => ({
+  type: SELECT_REDDIT,
+  reddit
+})
+
+export const invalidateReddit = reddit => ({
+  type: INVALIDATE_REDDIT,
+  reddit
+})
+
+export const requestPosts = reddit => ({
+  type: REQUEST_POSTS,
+  reddit
+})
+
+export const receivePosts = (reddit, json) => ({
+  type: RECEIVE_POSTS,
+  reddit,
+  posts: json.data.children.map(child => child.data),
+  receivedAt: Date.now()
+})
+
+const fetchPosts = reddit => dispatch => {
+  dispatch(requestPosts(reddit))
+  return fetch(`https://www.reddit.com/r/${reddit}.json`)
+    .then(response => response.json())
+    .then(json => dispatch(receivePosts(reddit, json)))
 }
 
-export function invalidateReddit(reddit) {
-  return {
-    type: INVALIDATE_REDDIT,
-    reddit
-  }
-}
-
-function requestPosts(reddit) {
-  return {
-    type: REQUEST_POSTS,
-    reddit
-  }
-}
-
-function receivePosts(reddit, json) {
-  return {
-    type: RECEIVE_POSTS,
-    reddit,
-    posts: json.data.children.map(child => child.data),
-    receivedAt: Date.now()
-  }
-}
-
-function fetchPosts(reddit) {
-  return dispatch => {
-    dispatch(requestPosts(reddit))
-    return fetch(`https://www.reddit.com/r/${reddit}.json`)
-      .then(response => response.json())
-      .then(json => dispatch(receivePosts(reddit, json)))
-  }
-}
-
-function shouldFetchPosts(state, reddit) {
+const shouldFetchPosts = (state, reddit) => {
   const posts = state.postsByReddit[reddit]
   if (!posts) {
     return true
@@ -53,10 +43,8 @@ function shouldFetchPosts(state, reddit) {
   return posts.didInvalidate
 }
 
-export function fetchPostsIfNeeded(reddit) {
-  return (dispatch, getState) => {
-    if (shouldFetchPosts(getState(), reddit)) {
-      return dispatch(fetchPosts(reddit))
-    }
+export const fetchPostsIfNeeded = reddit => (dispatch, getState) => {
+  if (shouldFetchPosts(getState(), reddit)) {
+    return dispatch(fetchPosts(reddit))
   }
 }

--- a/examples/async/src/components/Picker.js
+++ b/examples/async/src/components/Picker.js
@@ -1,24 +1,16 @@
-import React, { Component, PropTypes } from 'react'
+import React, { PropTypes } from 'react'
 
-export default class Picker extends Component {
-  render() {
-    const { value, onChange, options } = this.props
-
-    return (
-      <span>
-        <h1>{value}</h1>
-        <select onChange={e => onChange(e.target.value)}
-                value={value}>
-          {options.map(option =>
-            <option value={option} key={option}>
-              {option}
-            </option>)
-          }
-        </select>
-      </span>
-    )
-  }
-}
+const Picker = ({ value, onChange, options }) => <span>
+  <h1>{value}</h1>
+  <select onChange={e => onChange(e.target.value)}
+          value={value}>
+    {options.map(option =>
+      <option value={option} key={option}>
+        {option}
+      </option>)
+    }
+  </select>
+</span>
 
 Picker.propTypes = {
   options: PropTypes.arrayOf(
@@ -27,3 +19,5 @@ Picker.propTypes = {
   value: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired
 }
+
+export default Picker

--- a/examples/async/src/components/Posts.js
+++ b/examples/async/src/components/Posts.js
@@ -1,17 +1,13 @@
-import React, { PropTypes, Component } from 'react'
+import React, { PropTypes } from 'react'
 
-export default class Posts extends Component {
-  render() {
-    return (
-      <ul>
-        {this.props.posts.map((post, i) =>
-          <li key={i}>{post.title}</li>
-        )}
-      </ul>
-    )
-  }
-}
+const Posts = ({posts}) => <ul>
+  {posts.map((post, i) =>
+    <li key={i}>{post.title}</li>
+  )}
+</ul>
 
 Posts.propTypes = {
   posts: PropTypes.array.isRequired
 }
+
+export default Posts

--- a/examples/async/src/containers/App.js
+++ b/examples/async/src/containers/App.js
@@ -5,12 +5,6 @@ import Picker from '../components/Picker'
 import Posts from '../components/Posts'
 
 class App extends Component {
-  constructor(props) {
-    super(props)
-    this.handleChange = this.handleChange.bind(this)
-    this.handleRefreshClick = this.handleRefreshClick.bind(this)
-  }
-
   componentDidMount() {
     const { dispatch, selectedReddit } = this.props
     dispatch(fetchPostsIfNeeded(selectedReddit))
@@ -23,11 +17,9 @@ class App extends Component {
     }
   }
 
-  handleChange(nextReddit) {
-    this.props.dispatch(selectReddit(nextReddit))
-  }
+  handleChange = nextReddit => this.props.dispatch(selectReddit(nextReddit))
 
-  handleRefreshClick(e) {
+  handleRefreshClick = e => {
     e.preventDefault()
 
     const { dispatch, selectedReddit } = this.props
@@ -76,7 +68,7 @@ App.propTypes = {
   dispatch: PropTypes.func.isRequired
 }
 
-function mapStateToProps(state) {
+const mapStateToProps = state => {
   const { selectedReddit, postsByReddit } = state
   const {
     isFetching,

--- a/examples/async/src/reducers/index.js
+++ b/examples/async/src/reducers/index.js
@@ -4,7 +4,7 @@ import {
   REQUEST_POSTS, RECEIVE_POSTS
 } from '../actions'
 
-function selectedReddit(state = 'reactjs', action) {
+const selectedReddit = (state = 'reactjs', action) => {
   switch (action.type) {
     case SELECT_REDDIT:
       return action.reddit
@@ -13,11 +13,11 @@ function selectedReddit(state = 'reactjs', action) {
   }
 }
 
-function posts(state = {
+const posts = (state = {
   isFetching: false,
   didInvalidate: false,
   items: []
-}, action) {
+}, action) => {
   switch (action.type) {
     case INVALIDATE_REDDIT:
       return {
@@ -43,7 +43,7 @@ function posts(state = {
   }
 }
 
-function postsByReddit(state = { }, action) {
+const postsByReddit = (state = { }, action) => {
   switch (action.type) {
     case INVALIDATE_REDDIT:
     case RECEIVE_POSTS:


### PR DESCRIPTION
Convert the async example files to using fat arrows and stateless components.

This is a follow up to what I started in the counter example in #1942. 

I’ll be ok if we decide to stick to the old notation on this example since the fat arrows don’t add any feature in itself, except reduce the number of lines in files.

References #1800