### PR TITLE
Fix listeners array leak

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -174,7 +174,8 @@ export default function createStore(reducer, preloadedState, enhancer) {
 
     var listeners = currentListeners = nextListeners
     for (var i = 0; i < listeners.length; i++) {
-      listeners[i]()
+      var listener = listeners[i]
+      listener()
     }
 
     return action

--- a/test/createStore.spec.js
+++ b/test/createStore.spec.js
@@ -406,6 +406,15 @@ describe('createStore', () => {
     store.dispatch(addTodo('Hello'))
   })
 
+  it('does not leak private listeners array', done => {
+    const store = createStore(reducers.todos)
+    store.subscribe(function () {
+      expect(this).toNotBeA(Array)
+      done()
+    })
+    store.dispatch(addTodo('Hello'))
+  })
+
   it('only accepts plain object actions', () => {
     const store = createStore(reducers.todos)
     expect(() =>


### PR DESCRIPTION
A minor issue, `listeners` is leaked as the `this` context when invoking each `listener`.