### PR TITLE
Minor fix for JSDoc for createStore() arguments

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -28,7 +28,7 @@ export var ActionTypes = {
  * If you use `combineReducers` to produce the root reducer function, this must be
  * an object with the same shape as `combineReducers` keys.
  *
- * @param {Function} enhancer The store enhancer. You may optionally specify it
+ * @param {Function} [enhancer] The store enhancer. You may optionally specify it
  * to enhance the store with third-party capabilities such as middleware,
  * time travel, persistence, etc. The only store enhancer that ships with Redux
  * is `applyMiddleware()`.


### PR DESCRIPTION
Minor fix for JSDoc for createStore() arguments to avoid "missed argument" warning from IDE, e.g. WebStorm. Fixes #1979