### PR TITLE
Remove isomoprhic-fetch

### DIFF
--- a/examples/real-world/package.json
+++ b/examples/real-world/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "humps": "^1.1.0",
-    "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.16.1",
     "normalizr": "^2.2.1",
     "react": "^15.3.0",

--- a/examples/real-world/src/middleware/api.js
+++ b/examples/real-world/src/middleware/api.js
@@ -1,6 +1,5 @@
 import { Schema, arrayOf, normalize } from 'normalizr'
 import { camelizeKeys } from 'humps'
-import 'isomorphic-fetch'
 
 // Extracts the next page URL from Github API response.
 const getNextPageUrl = response => {


### PR DESCRIPTION
It’s not needed because Create React App includes a `fetch` polyfill and we’re not using server rendering here.