### PR TITLE
Typo fix

### DIFF
--- a/docs/recipes/reducers/08-ReusingReducerLogic.md
+++ b/docs/recipes/reducers/08-ReusingReducerLogic.md
@@ -1,6 +1,6 @@
 # Reusing Reducer Logic
 
-As an application grows, common patterns in reducer logic will start to emerge.  You may find several parts of your reducer logic doing the same kinds of work for different types of data, and want to reduce duplication by reusing the same common logic for each data type.  Or, you may want to have multiple "instances" of a certain type of data being handled in the store.  However, the global structure of a Redux store comes with some tradeoffs: it makes it easy to track the overall state of an application, but can also make it harder to "target" actions that need to update a specific piece of state, particularly if you are using `combineReducers`.
+As an application grows, common patterns in reducer logic will start to emerge.  You may find several parts of your reducer logic doing the same kinds of work for different types of data, and want to reduce duplication by reusing the same common logic for each data type.  Or, you may want to have multiple "instances" of a certain type of data being handled in the store.  However, the global structure of a Redux store comes with some trade-offs: it makes it easy to track the overall state of an application, but can also make it harder to "target" actions that need to update a specific piece of state, particularly if you are using `combineReducers`.
 
 As an example, let's say that we want to track multiple counters in our application, named A, B, and C.  We define our initial `counter` reducer, and we use `combineReducers` to set up our state:
 


### PR DESCRIPTION
NIT: Fixed to use proper spelling for "trade-offs".
I was too anxious to read through this one as it was just merged. Great work!
Just noticed this super minor typo. Feel free to disregard if it's too much of a NIT :)
