### PR TITLE
Update gitbook to use version 3.2.1

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,5 +1,5 @@
 {
-  "gitbook": "3.x.x",
+  "gitbook": ">=3.2.1",
   "title": "Redux",
   "plugins": ["edit-link", "prism", "-highlight", "github", "anchorjs"],
   "pluginsConfig": {


### PR DESCRIPTION
Following [my answer to #1982](https://github.com/reactjs/redux/issues/1982#issuecomment-250003780), this PR updates GitBook with a fix for anchor links on Firefox.

the URL is retained correctly (Chrome and Firefox), but there still some weird positioning on Firefox, I'll make another PR once we fix this issue as well.