### PR TITLE
In Flow types, make Reducer's state parameter optional

### DIFF
--- a/flow-typed/redux.js
+++ b/flow-typed/redux.js
@@ -22,7 +22,7 @@ declare module 'redux' {
     replaceReducer(nextReducer: Reducer<S, A>): void
   };
 
-  declare type Reducer<S, A> = (state: S, action: A) => S;
+  declare type Reducer<S, A> = (state?: S, action: A) => S;
 
   declare type Middleware<S, A> =
     (api: MiddlewareAPI<S, A>) =>


### PR DESCRIPTION
According to the [docs](http://redux.js.org/docs/basics/Reducers.html#handling-actions), the reducer initially gets called with the state parameter as undefined. This means this type signature is incorrect, since the state parameter is optional.
