### PR TITLE
Simplify Promise nesting

### DIFF
--- a/examples/real-world/src/middleware/api.js
+++ b/examples/real-world/src/middleware/api.js
@@ -25,20 +25,20 @@ const callApi = (endpoint, schema) => {
 
   return fetch(fullUrl)
     .then(response =>
-      response.json().then(json => ({ json, response }))
-    ).then(({ json, response }) => {
-      if (!response.ok) {
-        return Promise.reject(json)
-      }
+      response.json().then(json => {
+        if (!response.ok) {
+          return Promise.reject(json)
+        }
 
-      const camelizedJson = camelizeKeys(json)
-      const nextPageUrl = getNextPageUrl(response)
+        const camelizedJson = camelizeKeys(json)
+        const nextPageUrl = getNextPageUrl(response)
 
-      return Object.assign({},
-        normalize(camelizedJson, schema),
-        { nextPageUrl }
-      )
-    })
+        return Object.assign({},
+          normalize(camelizedJson, schema),
+          { nextPageUrl }
+        )
+      })
+    )
 }
 
 // We use this Normalizr schemas to transform API responses from a nested form


### PR DESCRIPTION
If you need to keep past promise results in scope, you can just nest.   There's no need for creating and de-structuring objects.  This makes the code look more complex than it would be in callbacks, when in reality the pyramid approach of callbacks works just as well if you accept small amounts of promise nesting.

Promises are about fixing error propagation and zalgo, not fixing the pyramid of doom.  The pyramid of doom is almost never a real/significant problem, so we should just accept it existing here.