### PR TITLE
Enable support for Mozilla Addons

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "lodash": "^4.2.1",
     "lodash-es": "^4.2.1",
     "loose-envify": "^1.1.0",
-    "symbol-observable": "^1.0.2"
+    "symbol-observable": "^1.0.3"
   },
   "devDependencies": {
     "babel-cli": "^6.3.15",

--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -2,6 +2,8 @@ import { ActionTypes } from './createStore'
 import isPlainObject from 'lodash/isPlainObject'
 import warning from './utils/warning'
 
+var NODE_ENV = typeof process !== 'undefined' ? process.env.NODE_ENV : 'development'
+
 function getUndefinedStateErrorMessage(key, action) {
   var actionType = action && action.type
   var actionName = actionType && `"${actionType.toString()}"` || 'an action'
@@ -103,7 +105,7 @@ export default function combineReducers(reducers) {
   for (var i = 0; i < reducerKeys.length; i++) {
     var key = reducerKeys[i]
 
-    if (process.env.NODE_ENV !== 'production') {
+    if (NODE_ENV !== 'production') {
       if (typeof reducers[key] === 'undefined') {
         warning(`No reducer provided for key "${key}"`)
       }
@@ -115,7 +117,7 @@ export default function combineReducers(reducers) {
   }
   var finalReducerKeys = Object.keys(finalReducers)
 
-  if (process.env.NODE_ENV !== 'production') {
+  if (NODE_ENV !== 'production') {
     var unexpectedKeyCache = {}
   }
 
@@ -131,7 +133,7 @@ export default function combineReducers(reducers) {
       throw sanityError
     }
 
-    if (process.env.NODE_ENV !== 'production') {
+    if (NODE_ENV !== 'production') {
       var warningMessage = getUnexpectedStateShapeWarningMessage(state, finalReducers, action, unexpectedKeyCache)
       if (warningMessage) {
         warning(warningMessage)

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import warning from './utils/warning'
 function isCrushed() {}
 
 if (
+  typeof process !== 'undefined' &&
   process.env.NODE_ENV !== 'production' &&
   typeof isCrushed.name === 'string' &&
   isCrushed.name !== 'isCrushed'


### PR DESCRIPTION
Redux seems to be great solution for managing state of browser extensions. Unfortunately it doesn't work properly with Firefox addons, because it requires global *process* object which is not available inside addon environment. This applies to both web-extensions and jetpack-based addons. In case of web-extensions it is possible make polyfill for *process* object, but it is not possible with jetpack (at least without [using custom modules loader][1]).

I've fixed this issue by checking if *process* object exists before using it. There was also issue with one of dependencies - *symbol-observable* - but it was [fixed yesterday][2].

[1]: https://gist.github.com/empyrical/f1cca44da1f81cb09a26
[2]: https://github.com/blesh/symbol-observable/pull/23