### PR TITLE
Remove eslintConfig from package.json in examples

### DIFF
--- a/examples/async/package.json
+++ b/examples/async/package.json
@@ -17,8 +17,5 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "eject": "react-scripts eject"
-  },
-  "eslintConfig": {
-    "extends": "./node_modules/react-scripts/config/eslint.js"
   }
 }

--- a/examples/counter/package.json
+++ b/examples/counter/package.json
@@ -18,8 +18,5 @@
     "build": "react-scripts build",
     "eject": "react-scripts eject",
     "test": "react-scripts test"
-  },
-  "eslintConfig": {
-    "extends": "./node_modules/react-scripts/config/eslint.js"
   }
 }

--- a/examples/real-world/package.json
+++ b/examples/real-world/package.json
@@ -25,8 +25,5 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "eject": "react-scripts eject"
-  },
-  "eslintConfig": {
-    "extends": "./node_modules/react-scripts/config/eslint.js"
   }
 }

--- a/examples/shopping-cart/package.json
+++ b/examples/shopping-cart/package.json
@@ -20,8 +20,5 @@
     "build": "react-scripts build",
     "eject": "react-scripts eject",
     "test": "react-scripts test"
-  },
-  "eslintConfig": {
-    "extends": "./node_modules/react-scripts/config/eslint.js"
   }
 }

--- a/examples/todomvc/package.json
+++ b/examples/todomvc/package.json
@@ -20,8 +20,5 @@
     "build": "react-scripts build",
     "eject": "react-scripts eject",
     "test": "react-scripts test"
-  },
-  "eslintConfig": {
-    "extends": "./node_modules/react-scripts/config/eslint.js"
   }
 }

--- a/examples/todos-flow/package.json
+++ b/examples/todos-flow/package.json
@@ -18,8 +18,5 @@
     "build": "react-scripts build",
     "eject": "react-scripts eject",
     "test": "react-scripts test"
-  },
-  "eslintConfig": {
-    "extends": "./node_modules/react-scripts/config/eslint.js"
   }
 }

--- a/examples/todos-with-undo/package.json
+++ b/examples/todos-with-undo/package.json
@@ -16,8 +16,5 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "eject": "react-scripts eject"
-  },
-  "eslintConfig": {
-    "extends": "./node_modules/react-scripts/config/eslint.js"
   }
 }

--- a/examples/todos/package.json
+++ b/examples/todos/package.json
@@ -18,8 +18,5 @@
     "build": "react-scripts build",
     "eject": "react-scripts eject",
     "test": "react-scripts test"
-  },
-  "eslintConfig": {
-    "extends": "./node_modules/react-scripts/config/eslint.js"
   }
 }

--- a/examples/tree-view/package.json
+++ b/examples/tree-view/package.json
@@ -19,8 +19,5 @@
     "build": "react-scripts build",
     "eject": "react-scripts eject",
     "test": "react-scripts test"
-  },
-  "eslintConfig": {
-    "extends": "./node_modules/react-scripts/config/eslint.js"
   }
 }


### PR DESCRIPTION
At react-scripts@^0.6.0 (as dev-dependencies of some examples), `eslintConifg` was removed from package.json default. (facebookincubator/create-react-app/pull/649)

At least, current value `./node_modules/react-scripts/config/eslint.js` is invalid in this version!

