### PR TITLE
Add hint key in package.json to detemine what file to load in browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "redux",
   "version": "3.6.0",
   "description": "Predictable state container for JavaScript apps",
+  "browser": "dist/redux.js",
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",


### PR DESCRIPTION
In my framework I have a convenient feature that allows to automatically call AMD modules with RequireJS by their name. For instance, after `redux` installation I'm supposed to be able to do `require(['redux'], ...)` anywhere in my app and it should just work.

In order for above feature to work I'm using different keys from both `bower.json` and `package.json` in order to determine which file should be used by RequireJS to map package name alias there.

With Redux correct path is `dist/redux.js` (minified version can be inferred from here), but there is no single key with this value in current `package.json`. Existing keys are pointing to files that either doesn't work in any browser except recent Safari (ES2015 modules) or CommonJS-compatible file.

There was a key `browser` in jQuery's `package.json` in past, so I decided that this is a good candidate to use.

I'm currently checking following keys (based on `package.json` files of other popular projects) with priority from higher to lower:
* browser
* jspm.main
* main