### PR TITLE
change webpack UglifyJsPlugin's config to fix #2054

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,7 +28,14 @@ if (env === 'production') {
         pure_getters: true,
         unsafe: true,
         unsafe_comps: true,
-        warnings: false
+        warnings: false,
+        screw_ie8: false
+      },
+      mangle: {
+        screw_ie8: false
+      },
+      output: {
+        screw_ie8: false
       }
     })
   )


### PR DESCRIPTION
-  Fix https://github.com/reactjs/redux/issues/2054

> change webpack UglifyJsPlugin's config, which newest version do not enable IE8 support by default

see

[https://github.com/mishoo/UglifyJS2/commit/02c638209ee22816b1324ff0c0f47b27db1336af](https://github.com/mishoo/UglifyJS2/commit/02c638209ee22816b1324ff0c0f47b27db1336af)
