### PR TITLE
Preserve any extra keys for composability

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -154,6 +154,6 @@ export default function combineReducers(reducers) {
       nextState[key] = nextStateForKey
       hasChanged = hasChanged || nextStateForKey !== previousStateForKey
     }
-    return hasChanged ? nextState : state
+    return hasChanged ? Object.assign({}, state, nextState) : state
   }
 }

--- a/test/combineReducers.spec.js
+++ b/test/combineReducers.spec.js
@@ -292,5 +292,25 @@ describe('Utils', () => {
       spy.mockClear()
       console.error = preSpy
     })
+
+    it('preserves extra keys', () => {
+      const increment = 'INCREMENT'
+
+      const reducer = combineReducers({
+        counter(state = 0, action) {
+          switch (action.type) {
+            case increment:
+              return state + 1
+            default:
+              return state
+          }
+        }
+      })
+
+      const result = reducer({ counter: 0, extra: 42 }, { type: increment })
+
+      expect(result.counter).toEqual(1)
+      expect(result.extra).toEqual(42)
+    })
   })
 })


### PR DESCRIPTION
This is a fix for behavior noticed in #2058 that is considered by @markerikson as "working as intended", but effectively making reducers produced by combineReducers not composable. I strongly disagree with this opinion, so I ask for second opinion of @gaearon before you close this PR.

PR solves an issue where I compose reducer produced by `combineReducers` with other reducer (for example by using `reduceReducers`, but also simple applying):

``` js
const result = combinedReducer(otherReducer(state, action))
```

``` js
const composedReducer = reduceReducers(combinedReducer, otherReducer)
const result = composedReducer(state, action)
```

If otherReducer returns keys not used in `combinedReducer`, then `combinedReducer` not only shows a warning that `Unexpected key "extra" found in previous state received by the reducer` (what I can leave with evenrually), **but also removes extra keys set by `otherReducer`**.

This severly limits composability of reducers, and I think it shoudn't be a default behavior of redux.

You can see simplest example possible in test I attach to this PR, where an extra key is present in state passed to reducer produced with combineReducers, but this keys is missing in result.

This modification is fully backward compatible, I hope you agree to include it.
