### PR TITLE
2nd argument for sliced states added to combineReducers

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -128,7 +128,7 @@ export default function combineReducers(reducers) {
     sanityError = e
   }
 
-  return function combination(state = {}, action) {
+  return function combination(state = {}, action, ...slicedStates) {
     if (sanityError) {
       throw sanityError
     }
@@ -146,7 +146,7 @@ export default function combineReducers(reducers) {
       var key = finalReducerKeys[i]
       var reducer = finalReducers[key]
       var previousStateForKey = state[key]
-      var nextStateForKey = reducer(previousStateForKey, action)
+      var nextStateForKey = reducer(previousStateForKey, action, ...slicedStates)
       if (typeof nextStateForKey === 'undefined') {
         var errorMessage = getUndefinedStateErrorMessage(key, action)
         throw new Error(errorMessage)


### PR DESCRIPTION
Hey Dan I know you run a tight shift, but I also noticed you recently added an `extraArgument` parameter to `redux-thunk`.  My thinking here is that this makes for a great introduction to "slicing" state as described here: http://redux.js.org/docs/recipes/reducers/BeyondCombineReducers.html 

I think a lot of developers end up using `combineReducers` for a bit too long and end up engaging in various anti-patterns to get access to other states in their reducers, or achieve access in components via other less-than-optimum ways. Slicing state at first can be intimidating and you're almost scared to customize your root reducer. I think a lot of developers--myself included--go through that stage. This is a great bridge for developers toward understanding that their reducer function is really "just a function," while also helping them avoid those anti-patterns. 

It's really quite limiting at first to think of your reducers as these independent atoms that have no knowledge of  state elsewhere. I know I worked around it way longer than I should. That said, that limitation is one thing that makes Redux really easy to understand at first. It just becomes complicated when you want to do more. This could serve as a taste to inspire them to go further down the path of making custom reducers, while also solving one of the biggest problems developers new to redux will have. For many apps, the missing piece is just one reducer's state that they wish other reducers had access to. Shifting to a very custom reducer from `combineReducers` just to achieve that can be a big "ask" for developers new to redux. With this, they just need to treat a single reducer separately in a simple `rootReducer` function, and then pass it to combineReducers and then return both in the final returned state. Basically here's the intended use case:

```
const appReducer = combineReducers(reducers);

return function rootReducer(state={}, action) {
   let location = locationReducer(state.location, action);
   delete state.location; //silence combineReducers warning for passing keys it's unaware of

   return {
     ...appReducer(state, action, location),
     location,
   };
}
```

Currently in one of my apps, I'm unnecessarily shipping a second `combineReducers` function that does just this. To feed my obsession with keeping bundle size as small as possible, I personally would love to just import the one from redux. Either way, great job with Redux! It really has taken *Reactlandia* to the place it was supposed to go.