### PR TITLE
Add support to compose only functions in utils/compose

### DIFF
--- a/src/compose.js
+++ b/src/compose.js
@@ -14,7 +14,7 @@ export default function compose(...funcs) {
     return arg => arg
   }
 
-  funcs = funcs.filter(func => (typeof func === 'function'))
+  funcs = funcs.filter(func => typeof func === 'function')
 
   if (funcs.length === 1) {
     return funcs[0]

--- a/src/compose.js
+++ b/src/compose.js
@@ -14,6 +14,8 @@ export default function compose(...funcs) {
     return arg => arg
   }
 
+  funcs = funcs.filter(func => (typeof func === 'function'))
+
   if (funcs.length === 1) {
     return funcs[0]
   }

--- a/test/compose.spec.js
+++ b/test/compose.spec.js
@@ -21,6 +21,17 @@ describe('Utils', () => {
       expect(compose(c, a, b)(final)('')).toBe('cab')
     })
 
+    it('composes only functions', () => {
+      const square = x => x * x
+      const add = (x, y) => x + y
+      
+      expect(compose(square, add, false)(1, 2)).toBe(9)
+      expect(compose(square, add, undefined)(1, 2)).toBe(9)
+      expect(compose(square, add, true)(1, 2)).toBe(9)
+      expect(compose(square, add, NaN)(1, 2)).toBe(9)
+      expect(compose(square, add, '42')(1, 2)).toBe(9)
+    })
+
     it('can be seeded with multiple arguments', () => {
       const square = x => x * x
       const add = (x, y) => x + y


### PR DESCRIPTION
In our project we found some case that can brake your application. 
It can be broken when you've tried to pass not a function in enhance array to compose function.

```
const toEnhance = [
    router.enhancer,
    applyMiddleware(...middleware),
    window && window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__() // false in this case will cause a bug
];
const enhancer = compose(...toEnhance);
```

Of course I can filter array before passing it to enhancer, but I think it will be useful to manage it in compose function.