### PR TITLE
enable the keyword "this" in actioncreators when it is an object

### DIFF
--- a/src/bindActionCreators.js
+++ b/src/bindActionCreators.js
@@ -1,5 +1,5 @@
-function bindActionCreator(actionCreator, dispatch) {
-  return (...args) => dispatch(actionCreator(...args))
+function bindActionCreator(actionCreator, dispatch, context) {
+  return (...args) => dispatch(actionCreator.apply(context, args))
 }
 
 /**
@@ -41,7 +41,7 @@ export default function bindActionCreators(actionCreators, dispatch) {
     var key = keys[i]
     var actionCreator = actionCreators[key]
     if (typeof actionCreator === 'function') {
-      boundActionCreators[key] = bindActionCreator(actionCreator, dispatch)
+      boundActionCreators[key] = bindActionCreator(actionCreator, dispatch, actionCreators)
     }
   }
   return boundActionCreators


### PR DESCRIPTION
when actioncreators is an object , i always need to use 'this' in an actioncreator function, but after using bindActionCreator , the keyword 'this' doesn't work