### PR TITLE
Provide example of initial state SSR scrub

### DIFF
--- a/docs/recipes/ServerRendering.md
+++ b/docs/recipes/ServerRendering.md
@@ -274,7 +274,7 @@ In our example, we take a rudimentary approach to security. When we obtain the p
 
 For our simplistic example, coercing our input into a number is sufficiently secure. If you're handling more complex input, such as freeform text, then you should run that input through an appropriate sanitization function, such as [validator.js](https://www.npmjs.com/package/validator).
 
-Furthermore, you can add additional layers of security by sanitizing your state output. `JSON.stringify` can be subject to script injections. To counter this, you can scrub the JSON string of HTML tags and other dangerous characters. This can be done with either a simple text replacement on the string or via more sophisticated libraries such as [serialize-javascript](https://github.com/yahoo/serialize-javascript).
+Furthermore, you can add additional layers of security by sanitizing your state output. `JSON.stringify` can be subject to script injections. To counter this, you can scrub the JSON string of HTML tags and other dangerous characters. This can be done with either a simple text replacement on the string, e.g. `JSON.stringify(state).replace(/</g, '\\u003c')`, or via more sophisticated libraries such as [serialize-javascript](https://github.com/yahoo/serialize-javascript).
 
 ## Next Steps
 


### PR DESCRIPTION
This short piece of code renders all html tags in JSON harmless, by replacing the `<` character with its unicode escape `\u003c`. Since the only place where JSON can have `<` is in strings, this is sufficient for protecting JSON from XSS injection.

Providing an easy cut'n'paste solution in the documentation ensures that more people will be protected from this problem.