### PR TITLE
Remove "enhancer" reference from applyMiddleware function

### DIFF
--- a/src/applyMiddleware.js
+++ b/src/applyMiddleware.js
@@ -17,8 +17,8 @@ import compose from './compose'
  * @returns {Function} A store enhancer applying the middleware.
  */
 export default function applyMiddleware(...middlewares) {
-  return (createStore) => (reducer, preloadedState, enhancer) => {
-    var store = createStore(reducer, preloadedState, enhancer)
+  return (createStore) => (reducer, preloadedState) => {
+    var store = createStore(reducer, preloadedState)
     var dispatch = store.dispatch
     var chain = []
 


### PR DESCRIPTION
I could be wrong here, but was reviewing the createStore and applyMiddleware functions, and it seems like there should not be a reference to any "enhancer" within applyMiddleware. 

It is my understanding that the applyMiddleware function typically gets called and then passed into createStore as the "enhancer" argument. Within createStore, we then have:

```
if (typeof enhancer !== 'undefined') {
    if (typeof enhancer !== 'function') {
      throw new Error('Expected the enhancer to be a function.')
    }

    return enhancer(createStore)(reducer, preloadedState)
  }
```

Specifically, now focusing on the last line:
```
return enhancer(createStore)(reducer, preloadedState)
```

Since no enhancer would ever be passed in as a 3rd argument, then it seems unnecessary to include the reference to an enhancer in the applyMiddleware function.

Again, could be missing something here, but it seems including a reference to an "enhancer" within the applyMiddleware function is getting away from the spirit of what the function is trying to accomplish (wrapping the "unenhanced" store with a modified dispatch method).
