### PR TITLE
Add optional 'immediate' argument to unsubscribe.

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -108,7 +108,7 @@ export default function createStore(reducer, preloadedState, enhancer) {
     ensureCanMutateNextListeners()
     nextListeners.push(listener)
 
-    return function unsubscribe() {
+    return function unsubscribe(immediate) {
       if (!isSubscribed) {
         return
       }
@@ -118,6 +118,11 @@ export default function createStore(reducer, preloadedState, enhancer) {
       ensureCanMutateNextListeners()
       var index = nextListeners.indexOf(listener)
       nextListeners.splice(index, 1)
+
+      if (immediate) {
+        index = currentListeners.indexOf(listener)
+        currentListeners[index] = function () {}
+      }
     }
   }
 

--- a/test/createStore.spec.js
+++ b/test/createStore.spec.js
@@ -317,6 +317,19 @@ describe('createStore', () => {
     expect(listener3.mock.calls.length).toBe(1)
   })
 
+  it('supports immediate unsubscriptions', () => {
+    const store = createStore(reducers.todos)
+
+    const listener1 = jest.fn(() => unsubscribe(true))
+    const listener2 = jest.fn()
+    store.subscribe(listener1)
+    var unsubscribe = store.subscribe(listener2)
+
+    store.dispatch(unknownAction())
+    expect(listener1.mock.calls.length).toBe(1)
+    expect(listener2.mock.calls.length).toBe(0)
+  })
+
   it('delays subscribe until the end of current dispatch', () => {
     const store = createStore(reducers.todos)
 

--- a/test/createStore.spec.js
+++ b/test/createStore.spec.js
@@ -322,12 +322,15 @@ describe('createStore', () => {
 
     const listener1 = jest.fn(() => unsubscribe(true))
     const listener2 = jest.fn()
+    const listener3 = jest.fn()
     store.subscribe(listener1)
     var unsubscribe = store.subscribe(listener2)
+    store.subscribe(listener3)
 
     store.dispatch(unknownAction())
     expect(listener1.mock.calls.length).toBe(1)
     expect(listener2.mock.calls.length).toBe(0)
+    expect(listener3.mock.calls.length).toBe(1)
   })
 
   it('delays subscribe until the end of current dispatch', () => {


### PR DESCRIPTION
Setting `immediate` to true ensures that the given listener will not be called during the current dispatch (unless it was called before unsubscribing). Useful in scenarios where you'd like to safely clean up resources along with unsubscribing listeners that depend on those resources simultaneously.

Given the proposition is accepted, I'll update the relevant docs asap.