### PR TITLE
Doc: clarify Navigating with React Router section

### DIFF
--- a/docs/advanced/UsageWithReactRouter.md
+++ b/docs/advanced/UsageWithReactRouter.md
@@ -118,7 +118,7 @@ export default Root;
 
 ## Navigating with React Router
 
-React Router comes with a [`<Link />`](https://github.com/reactjs/react-router/blob/master/docs/API.md#link) component that let you navigate around your application. We can use it in our example and change our container `<FilterLink />` component so we can change the URL using `<FilterLink />`. The `activeStyle={}` property lets you apply a style on the active state.
+React Router comes with a [`<Link />`](https://github.com/reactjs/react-router/blob/master/docs/API.md#link) component that lets you navigate around your application. In our example, we can wrap `<Link />` with a new container component `<FilterLink />` so as to dynamically change the URL. The `activeStyle={}` property lets us apply a style on the active state.
 
 
 #### `containers/FilterLink.js`


### PR DESCRIPTION
Fixed typo and improved clarity surrounding use of `<Link />`.