### PR TITLE
Modification to docs/basics/Reducers to make imports more clear. This…

### DIFF
--- a/docs/basics/Reducers.md
+++ b/docs/basics/Reducers.md
@@ -84,13 +84,6 @@ function todoApp(state = initialState, action) {
 
 Now let's handle `SET_VISIBILITY_FILTER`. All it needs to do is to change `visibilityFilter` on the state. Easy:
 
-First, add `SET_VISIBILITY_FILTER` to our list of imports from `actions.js`.
-```js
-import { SET_VISIBILITY_FILTER, VisibilityFilters } from './actions';
-```
-
-Now we can test our action type for `SET_VISIBILITY_FILTER` and return new, modified state accordingly.
-
 ```js
 function todoApp(state = initialState, action) {
   switch (action.type) {

--- a/docs/basics/Reducers.md
+++ b/docs/basics/Reducers.md
@@ -84,6 +84,13 @@ function todoApp(state = initialState, action) {
 
 Now let's handle `SET_VISIBILITY_FILTER`. All it needs to do is to change `visibilityFilter` on the state. Easy:
 
+First, add `SET_VISIBILITY_FILTER` to our list of imports from `actions.js`.
+```js
+import { SET_VISIBILITY_FILTER, VisibilityFilters } from './actions';
+```
+
+Now we can test our action type for `SET_VISIBILITY_FILTER` and return new, modified state accordingly.
+
 ```js
 function todoApp(state = initialState, action) {
   switch (action.type) {
@@ -115,7 +122,7 @@ Note that:
 
 ## Handling More Actions
 
-We have two more actions to handle! Let's extend our reducer to handle `ADD_TODO`.
+We have two more actions to handle! Just like we did with `SET_VISIBILITY_FILTER`, we'll import the `ADD_TODO` and `TOGGLE_TODO` actions and then extend our reducer to handle `ADD_TODO`.
 
 ```js
 function todoApp(state = initialState, action) {
@@ -244,8 +251,14 @@ function todoApp(state = initialState, action) {
 
 Note that `todos` also accepts `state`—but it's an array! Now `todoApp` just gives it the slice of the state to manage, and `todos` knows how to update just that slice. **This is called *reducer composition*, and it's the fundamental pattern of building Redux apps.**
 
-Let's explore reducer composition more. Can we also extract a reducer managing just `visibilityFilter`? We can:
+Let's explore reducer composition more. Can we also extract a reducer managing just `visibilityFilter`? We can.
 
+Below our imports, let's use [ES6 Object Destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) to declare `SHOW_ALL`:
+```js
+const { SHOW_ALL } = VisibilityFilters;
+```
+
+Then:
 ```js
 function visibilityFilter(state = SHOW_ALL, action) {
   switch (action.type) {


### PR DESCRIPTION
… should help reduce the need to scroll down to the completed code at the bottom of the file, as mentioned in #2107

This is to address the concerns mentioned in #2107. Specifically, I added some of the missing/assumed import statements into the Basics/Reducers section. If you read the rest of the issue, you'll notice that the original poster's problem has been solved.