### PR TITLE
Simplify composer

### DIFF
--- a/src/compose.js
+++ b/src/compose.js
@@ -20,7 +20,5 @@ export default function compose(...funcs) {
     return funcs[0]
   }
 
-  const last = funcs[funcs.length - 1]
-  const rest = funcs.slice(0, -1)
-  return (...args) => rest.reduceRight((composed, f) => f(composed), last(...args))
+  return funcs.reduce((a, b) => (...args) => a(b(...args)))
 }


### PR DESCRIPTION
cleaned up the composer so that it doesn't rely on slicing and reversing the array of functions