### PR TITLE
Correct reference for recipe documentation.

### DIFF
--- a/docs/recipes/ServerRendering.md
+++ b/docs/recipes/ServerRendering.md
@@ -20,7 +20,7 @@ Redux's **_only_** job on the server side is to provide the **initial state** of
 
 ## Setting Up
 
-In the following recipe, we are going to look at how to set up server-side rendering. We'll use the simplistic [Counter app](https://github.com/reactjs/redux/tree/master/examples/counter) as a guide and show how the server can render state ahead of time based on the request.
+In the following recipe, we are going to look at how to set up server-side rendering. We'll use the simplistic [Counter app v3.0.6](https://github.com/reactjs/redux/tree/v3.0.6/examples/counter) as a guide and show how the server can render state ahead of time based on the request.
 
 ### Install Packages
 


### PR DESCRIPTION
This is more a suggestion for more general fixes to recipe docs links.  I'm relatively new to redux and was trying to follow this server rendering recipe but saw incorrect files (according to current master branch) referenced when trying to complete recipe steps.  Looking back in the project history, it looks like v3.0.6 may be the last tag that is compatible with the suggested changes. 

Maybe someone who knows the project better can confirm that this is the correct tag to reference for these examples?

I assume this is preferred over rewriting all of the recipes right now.  I just want accurate docs. What do others think?