### PR TITLE
Remove not necessary argument

### DIFF
--- a/src/applyMiddleware.js
+++ b/src/applyMiddleware.js
@@ -17,8 +17,8 @@ import compose from './compose'
  * @returns {Function} A store enhancer applying the middleware.
  */
 export default function applyMiddleware(...middlewares) {
-  return (createStore) => (reducer, preloadedState, enhancer) => {
-    var store = createStore(reducer, preloadedState, enhancer)
+  return (createStore) => (reducer, preloadedState) => {
+    var store = createStore(reducer, preloadedState)
     var dispatch = store.dispatch
     var chain = []
 


### PR DESCRIPTION
The 'enhancer' argument is not necessary,beacuse there is:
`return enhancer(createStore)(reducer, preloadedState)` at ' createStore.js'

We can see that the function call doesn't pass enhancer as the arguments.

So this is my thought.