### PR TITLE
Fix filename typo in UsageWithReactRouter docs

### DIFF
--- a/docs/advanced/UsageWithReactRouter.md
+++ b/docs/advanced/UsageWithReactRouter.md
@@ -141,7 +141,7 @@ const FilterLink = ({ filter, children }) => (
 export default FilterLink;
 ```
 
-#### `containers/Footer.js`
+#### `components/Footer.js`
 ```js
 import React from 'react'
 import FilterLink from '../containers/FilterLink'


### PR DESCRIPTION
* Footer component filename is listed as `containers/Footer.js` in docs
* Directory in the example app is `components/Footer.js`
* Update docs to match example app