### PR TITLE
Flow declarations: Make the State argument of Reducer optional

### DIFF
--- a/flow-typed/redux.js
+++ b/flow-typed/redux.js
@@ -22,7 +22,7 @@ declare module 'redux' {
     replaceReducer(nextReducer: Reducer<S, A>): void
   };
 
-  declare type Reducer<S, A> = (state: S, action: A) => S;
+  declare type Reducer<S, A> = (state?: S, action: A) => S;
 
   declare type CombinedReducer<S, A> = (state: $Shape<S> & {} | void, action: A) => S;
 


### PR DESCRIPTION
The existing flow-typed declaration for Redux does not take into account the fact that Redux will pass `undefined` the first time it calls your reducers.

From [the Redux docs](http://redux.js.org/docs/recipes/reducers/InitializingState.html):
"Reducers can also specify an initial value by looking for an incoming state argument that is `undefined`, and returning the value they'd like to use as a default. This can either be done with an explicit check inside the reducer, or by using the ES6 default argument value syntax"

The existing flow-typed declaration works fine if you always use combineReducers, but Flow will incorrectly report an error if you write a custom root reducer etc., and manually pass `undefined` into child reducers.

With this proposed change, reducers may accept `undefined` as the `state` argument per the Redux API, but Flow still enforces that the reducers' return value cannot be `undefined`.