### PR TITLE
Remove filtering inside compose 

### DIFF
--- a/src/compose.js
+++ b/src/compose.js
@@ -10,8 +10,6 @@
  */
 
 export default function compose(...funcs) {
-  funcs = funcs.filter(func => typeof func === 'function')
-
   if (funcs.length === 0) {
     return arg => arg
   }

--- a/test/compose.spec.js
+++ b/test/compose.spec.js
@@ -21,15 +21,15 @@ describe('Utils', () => {
       expect(compose(c, a, b)(final)('')).toBe('cab')
     })
 
-    it('composes only functions', () => {
+    it('throws at runtime if argument is not a function', () => {
       const square = x => x * x
       const add = (x, y) => x + y
-      
-      expect(compose(square, add, false)(1, 2)).toBe(9)
-      expect(compose(square, add, undefined)(1, 2)).toBe(9)
-      expect(compose(square, add, true)(1, 2)).toBe(9)
-      expect(compose(square, add, NaN)(1, 2)).toBe(9)
-      expect(compose(square, add, '42')(1, 2)).toBe(9)
+
+      expect(() => compose(square, add, false)(1, 2)).toThrow()
+      expect(() => compose(square, add, undefined)(1, 2)).toThrow()
+      expect(() => compose(square, add, true)(1, 2)).toThrow()
+      expect(() => compose(square, add, NaN)(1, 2)).toThrow()
+      expect(() => compose(square, add, '42')(1, 2)).toThrow()
     })
 
     it('can be seeded with multiple arguments', () => {
@@ -41,7 +41,6 @@ describe('Utils', () => {
     it('returns the first given argument if given no functions', () => {
       expect(compose()(1, 2)).toBe(1)
       expect(compose()(3)).toBe(3)
-      expect(compose(false,4,'test')(3)).toBe(3)
       expect(compose()()).toBe(undefined)
     })
 


### PR DESCRIPTION
1) With filtering `compose` does not have the well know definition of this function as like as in your comments https://github.com/reactjs/redux/blob/master/src/compose.js#L7-L9
2) Then I accidentally pass something what is not a function into compose, the only thing I could expect is an error not silent code execution. (there is no need at all to pass anything which is not a function)
3) Typed definition of compose (even you does not use it) will be really hard to create with filtering.

So I suggest you to remove this line.
