### PR TITLE
Deletes no-longer-valid applyMiddleware test.

### DIFF
--- a/test/applyMiddleware.spec.js
+++ b/test/applyMiddleware.spec.js
@@ -105,21 +105,4 @@ describe('applyMiddleware', () => {
     })
   })
 
-  it('keeps unwrapped dispatch available while middleware is initializing', () => {
-    // This is documenting the existing behavior in Redux 3.x.
-    // We plan to forbid this in Redux 4.x.
-
-    function earlyDispatch({ dispatch }) {
-      dispatch(addTodo('Hello'))
-      return () => action => action
-    }
-
-    const store = createStore(reducers.todos, applyMiddleware(earlyDispatch))
-    expect(store.getState()).toEqual([
-      {
-        id: 1,
-        text: 'Hello'
-      }
-    ])
-  })
 })


### PR DESCRIPTION
Behavior has been replaced with the "it warns when dispatching during middleware setup" test in the 'next' branch.