### PR TITLE
Add ReduxInitAction interface to type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,13 @@ export interface Action {
   type: any;
 }
 
+/**
+ * This is the action type that combineReducers() sends to initialize
+ * reducers.
+ */
+export interface ReduxInitAction extends Action {
+  type: "@@redux/INIT";
+}
 
 /* reducers */
 


### PR DESCRIPTION
In attempting to model of all of the action types in our TypeScript app, the `@@redux/INIT` action is the odd one out, as it originates from the redux code itself. It'd be great if that were part of the redux type definitions themselves instead.