### PR TITLE
Moved data request into componentDidMount

### DIFF
--- a/examples/real-world/src/containers/UserPage.js
+++ b/examples/real-world/src/containers/UserPage.js
@@ -22,7 +22,7 @@ class UserPage extends Component {
     loadStarred: PropTypes.func.isRequired
   }
 
-  componentWillMount() {
+  componentDidMount() {
     loadData(this.props)
   }
 


### PR DESCRIPTION
As far as I know Fiber will introduce changes to the mounting pipeline which can result in componentWillMount being called and the component not mounting (aborted, stalled) I think we should suggest to perform data fetching in componentDidMount.