### PR TITLE
Refactors applyMiddleware to reduce confusion around createStore args.

### DIFF
--- a/src/applyMiddleware.js
+++ b/src/applyMiddleware.js
@@ -17,8 +17,8 @@ import compose from './compose'
  * @returns {Function} A store enhancer applying the middleware.
  */
 export default function applyMiddleware(...middlewares) {
-  return (createStore) => (reducer, preloadedState, enhancer) => {
-    const store = createStore(reducer, preloadedState, enhancer)
+  return (createStore) => (...args) => {
+    const store = createStore(...args)
     let dispatch = store.dispatch
     let chain = []
 


### PR DESCRIPTION
Because #2200 #2131 https://github.com/reactjs/redux/pull/2128 #2028...