### PR TITLE
Update AsyncActions doc

### DIFF
--- a/docs/advanced/AsyncActions.md
+++ b/docs/advanced/AsyncActions.md
@@ -331,7 +331,7 @@ function receivePosts(subreddit, json) {
 // Though its insides are different, you would use it just like any other action creator:
 // store.dispatch(fetchPosts('reactjs'))
 
-function fetchPosts(subreddit) {
+export function fetchPosts(subreddit) {
 
   // Thunk middleware knows how to handle functions.
   // It passes the dispatch method as an argument to the function,


### PR DESCRIPTION
As the example shows in `index.js` right below, it runs: 

`import { selectSubreddit, fetchPosts } from './actions'`

...but up until that point, `fetchPosts` is not exported from the `actions.js` file and would be unavailable to the `index.js` module. Changing such that `fetchPosts` is exported.