### PR TITLE
SSR client: Free memory used for initial state

### DIFF
--- a/docs/recipes/ServerRendering.md
+++ b/docs/recipes/ServerRendering.md
@@ -141,6 +141,9 @@ import counterApp from './reducers'
 // Grab the state from a global variable injected into the server-generated HTML
 const preloadedState = window.__PRELOADED_STATE__
 
+// Allow the passed state to be garbage-collected
+delete window.__PRELOADED_STATE__
+ 
 // Create Redux store with initial state
 const store = createStore(counterApp, preloadedState)
 


### PR DESCRIPTION
If the reference is not removed, it cannot be GC'd. Once the store is created, there is no use for the global `window.__PRELOADED_STATE__` variable.