### PR TITLE
Improve combineReducers type safety (TypeScript)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -47,9 +47,11 @@ export type Reducer<S> = <A extends Action>(state: S, action: A) => S;
 
 /**
  * Object whose values correspond to different reducer functions.
+ *
+ * @template S Combines state object type.
  */
-export interface ReducersMapObject {
-  [key: string]: Reducer<any>;
+export interface ReducersMapObject<S> {
+  [P in keyof S]: Reducer<S[P]>;
 }
 
 /**
@@ -70,7 +72,7 @@ export interface ReducersMapObject {
  * @returns A reducer function that invokes every reducer inside the passed
  *   object, and builds a state object with the same shape.
  */
-export function combineReducers<S>(reducers: ReducersMapObject): Reducer<S>;
+export function combineReducers<S>(reducers: ReducersMapObject<S>): Reducer<S>;
 
 
 /* store */


### PR DESCRIPTION
This PR flows names and types of state/reducers through the `combineReducers` function.

Using TypeScript's Mapped Types, validate the reducer map object contains all required properties, and that the child reducers return the correct types.

For example:

    interface RootType {
      users: IUser[],
      sessions: ISession[];
    }

    const users = (state: IUser[]) => state; // NOOP
    const sessions = (state: ISession[]) => state; // NOOP

    const reducer = combineReducers<RootType>({ users, sessions });

That worked before, as it does with this PR.

With this change, various errors are caught at compile time:

- Mismatched child reducer name vs. `RootType` property name
- Missing child reducers
- Child reducers that return different types

Current user code that doesn't specify the type on the call to `combineReducers` has the type inferred from the reducer map, so this change doesn't limit them, although the returned reducer's type reflects the reality of the data it will produce.