### PR TITLE
Remove .d.ts suffix for imports

### DIFF
--- a/test/typescript/actionCreators.ts
+++ b/test/typescript/actionCreators.ts
@@ -1,7 +1,7 @@
 import {
   ActionCreator, Action, Dispatch,
   bindActionCreators, ActionCreatorsMapObject
-} from "../../index.d.ts";
+} from "../../index";
 
 
 interface AddTodoAction extends Action {

--- a/test/typescript/actions.ts
+++ b/test/typescript/actions.ts
@@ -1,4 +1,4 @@
-import {Action as ReduxAction} from "../../index.d.ts";
+import {Action as ReduxAction} from "../../index";
 
 
 namespace FSA {

--- a/test/typescript/compose.ts
+++ b/test/typescript/compose.ts
@@ -1,4 +1,4 @@
-import {compose} from "../../index.d.ts";
+import {compose} from "../../index";
 
 // copied from DefinitelyTyped/compose-function
 

--- a/test/typescript/dispatch.ts
+++ b/test/typescript/dispatch.ts
@@ -1,4 +1,4 @@
-import {Dispatch, Action} from "../../index.d.ts";
+import {Dispatch, Action} from "../../index";
 
 
 declare const dispatch: Dispatch<any>;
@@ -6,7 +6,7 @@ declare const dispatch: Dispatch<any>;
 const dispatchResult: Action = dispatch({type: 'TYPE'});
 
 // thunk
-declare module "../../index.d.ts" {
+declare module "../../index" {
     export interface Dispatch<S> {
         <R>(asyncAction: (dispatch: Dispatch<S>, getState: () => S) => R): R;
     }

--- a/test/typescript/middleware.ts
+++ b/test/typescript/middleware.ts
@@ -1,9 +1,9 @@
 import {
   Middleware, MiddlewareAPI,
   applyMiddleware, createStore, Dispatch, Reducer, Action
-} from "../../index.d.ts";
+} from "../../index";
 
-declare module "../../index.d.ts" {
+declare module "../../index" {
     export interface Dispatch<S> {
         <R>(asyncAction: (dispatch: Dispatch<S>, getState: () => S) => R): R;
     }
@@ -35,7 +35,6 @@ const loggerMiddleware: Middleware =
         // a middleware further in chain changed it.
         return returnValue
       }
-
 
 
 type State = {

--- a/test/typescript/reducers.ts
+++ b/test/typescript/reducers.ts
@@ -1,7 +1,7 @@
 import {
   Reducer, Action, combineReducers,
   ReducersMapObject
-} from "../../index.d.ts";
+} from "../../index";
 
 
 type TodosState = string[];

--- a/test/typescript/store.ts
+++ b/test/typescript/store.ts
@@ -1,7 +1,7 @@
 import {
   Store, createStore, Reducer, Action, StoreEnhancer, GenericStoreEnhancer,
   StoreCreator, StoreEnhancerStoreCreator, Unsubscribe
-} from "../../index.d.ts";
+} from "../../index";
 
 
 type State = {


### PR DESCRIPTION
A little detail but the suffix '.d.ts' is not required for typescript imports (https://www.typescriptlang.org/docs/handbook/module-resolution.html).

The ts linter tell me `[ts] An import path cannot end with a '.d.ts' extension. Consider importing '../../index' instead.`.