### PR TITLE
Remove `Symbol()` from real-world example

### DIFF
--- a/examples/real-world/src/middleware/api.js
+++ b/examples/real-world/src/middleware/api.js
@@ -73,7 +73,7 @@ export const Schemas = {
 }
 
 // Action key that carries API call info interpreted by this Redux middleware.
-export const CALL_API = Symbol('Call API')
+export const CALL_API = 'Call API'
 
 // A Redux middleware that interprets actions with CALL_API info specified.
 // Performs the call and promises when such actions are dispatched.


### PR DESCRIPTION
**Problem summary**
Real-world example doesn't work on browsers that are not supporting symbol data types.

**Change summary**
Updated `CALL_API` action key to be string primitive.

**Fix verification summary**
Tested on Windows, Internet Explorer 11

Resolves #2217