### PR TITLE
Destructure and use shorthand object literal syntax

### DIFF
--- a/examples/todomvc/src/containers/App.js
+++ b/examples/todomvc/src/containers/App.js
@@ -17,8 +17,8 @@ App.propTypes = {
   actions: PropTypes.object.isRequired
 }
 
-const mapStateToProps = state => ({
-  todos: state.todos
+const mapStateToProps = ({todos}) => ({
+  todos
 })
 
 const mapDispatchToProps = dispatch => ({


### PR DESCRIPTION
Seems consistent to destructure and use object literal for this function