### PR TITLE
use reducerKey to run reducer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,7 @@
  */
 export interface Action {
   type: any;
+  reducerKey?: string;
 }
 
 

--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -143,6 +143,12 @@ export default function combineReducers(reducers) {
       }
     }
 
+    if (action.reducerKey && finalReducers[reducerKey]) {
+      var previousStateForKey = state[reducerKey]
+      nextState[reducerKey] = finalReducers[reducerKey](previousStateForKey, action)
+      return nextState !== previousStateForKey ? Object.assign({}, state, nextState) : state
+    }
+
     let hasChanged = false
     const nextState = {}
     for (let i = 0; i < finalReducerKeys.length; i++) {

--- a/test/combineReducers.spec.js
+++ b/test/combineReducers.spec.js
@@ -292,5 +292,19 @@ describe('Utils', () => {
       spy.mockClear()
       console.error = preSpy
     })
+
+    it('returns a composite reducer that maps the state keys to given reducers and use reducerKey to run reducer', () => {
+      const reducer = combineReducers({
+        counter: (state = 0, action) =>
+        action.type === 'increment' ? state + 1 : state,
+        stack: (state = [], action) =>
+        action.type === 'push' ? [ ...state, action.value ] : state
+      })
+
+      const s1 = reducer({}, { type: 'increment' })
+      expect(s1).toEqual({ counter: 1, stack: [] })
+      const s2 = reducer(s1, { reducerKey: 'stack', type: 'push', value: 'a' })
+      expect(s2).toEqual({ counter: 1, stack: [ 'a' ] })
+    })
   })
 })


### PR DESCRIPTION
Why not use "reducerkey" to perform only one reducer, instead of executing the loop？