### PR TITLE
pass current state to subscribers

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -175,7 +175,7 @@ export default function createStore(reducer, preloadedState, enhancer) {
     const listeners = currentListeners = nextListeners
     for (let i = 0; i < listeners.length; i++) {
       const listener = listeners[i]
-      listener()
+      listener(currentState)
     }
 
     return action


### PR DESCRIPTION
at least in it's vanilla form - it will be usefull if store.subscribe() will have the current state as an argument, instead of needlessly calling store.getState() inside.