### PR TITLE
Fix issue : 2264

### DIFF
--- a/docs/recipes/ServerRendering.md
+++ b/docs/recipes/ServerRendering.md
@@ -50,6 +50,8 @@ import App from './containers/App'
 const app = Express()
 const port = 3000
 
+app.use('/static', Express.static('static'));
+
 // This is fired every time the server side receives a request
 app.use(handleRender)
 

--- a/docs/recipes/ServerRendering.md
+++ b/docs/recipes/ServerRendering.md
@@ -50,6 +50,7 @@ import App from './containers/App'
 const app = Express()
 const port = 3000
 
+//Serve static files
 app.use('/static', Express.static('static'));
 
 // This is fired every time the server side receives a request


### PR DESCRIPTION
If no static directory is defined, the handleRender middleware function will be called when the browser fetches for `/static/bundle.js` and will give back the index.html