### PR TITLE
Enable yarn caching in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ branches:
   only:
     - master
 cache:
+  yarn: true
   directories:
   - $HOME/.npm
   - examples/async/node_modules


### PR DESCRIPTION
This enables yarn caching during Travis CI builds
https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Caching-with-yarn