### PR TITLE
simplify compose to include only one special case

### DIFF
--- a/src/compose.js
+++ b/src/compose.js
@@ -9,7 +9,5 @@
  * (...args) => f(g(h(...args))).
  */
 export default function compose(...funcs) {
-  return funcs.length === 1
-    ? funcs[0]
-    : funcs.reduce((a, b) => (...args) => a(b(...args)), arg => arg)
+  return funcs.reduce((a, b) => (...args) => a(b(...args)), arg => arg)
 }

--- a/src/compose.js
+++ b/src/compose.js
@@ -8,15 +8,8 @@
  * from right to left. For example, compose(f, g, h) is identical to doing
  * (...args) => f(g(h(...args))).
  */
-
 export default function compose(...funcs) {
-  if (funcs.length === 0) {
-    return arg => arg
-  }
-
-  if (funcs.length === 1) {
-    return funcs[0]
-  }
-
-  return funcs.reduce((a, b) => (...args) => a(b(...args)))
+  return funcs.length === 1
+    ? funcs[0]
+    : funcs.reduce((a, b) => (...args) => a(b(...args)), arg => arg)
 }

--- a/test/compose.spec.js
+++ b/test/compose.spec.js
@@ -44,10 +44,10 @@ describe('Utils', () => {
       expect(compose()()).toBe(undefined)
     })
 
-    it('returns the first function if given only one', () => {
-      const fn = () => {}
+    it('returns the first function (wrapped) if given only one', () => {
+      const fn = () => ':)'
 
-      expect(compose(fn)).toBe(fn)
+      expect(compose(fn)()).toBe(':)')
     })
   })
 })


### PR DESCRIPTION
Saw an opportunity to remove a special case from the compose method by passing an initial value to `reduce` 