### PR TITLE
Suggestion: Warn when bindActionCreators encounters non-function property

### DIFF
--- a/src/bindActionCreators.js
+++ b/src/bindActionCreators.js
@@ -1,3 +1,5 @@
+import warning from './utils/warning'
+
 function bindActionCreator(actionCreator, dispatch) {
   return (...args) => dispatch(actionCreator(...args))
 }
@@ -42,6 +44,8 @@ export default function bindActionCreators(actionCreators, dispatch) {
     const actionCreator = actionCreators[key]
     if (typeof actionCreator === 'function') {
       boundActionCreators[key] = bindActionCreator(actionCreator, dispatch)
+    } else {
+      warning(`bindActionCreators expected a function actionCreator for key '${key}', instead received type '${typeof actionCreator}'.`)
     }
   }
   return boundActionCreators

--- a/test/bindActionCreators.spec.js
+++ b/test/bindActionCreators.spec.js
@@ -17,6 +17,8 @@ describe('bindActionCreators', () => {
   })
 
   it('wraps the action creators with the dispatch function', () => {
+    const _console = console
+    global.console = { error: jest.fn() }
     const boundActionCreators = bindActionCreators(actionCreators, store.dispatch)
     expect(
       Object.keys(boundActionCreators)
@@ -31,9 +33,13 @@ describe('bindActionCreators', () => {
     expect(store.getState()).toEqual([
       { id: 1, text: 'Hello' }
     ])
+    expect(console.error).toHaveBeenCalled()
+    global.console = _console
   })
 
   it('skips non-function values in the passed object', () => {
+    const _console = console
+    global.console = { error: jest.fn() }
     const boundActionCreators = bindActionCreators({
       ...actionCreators,
       foo: 42,
@@ -47,6 +53,9 @@ describe('bindActionCreators', () => {
     ).toEqual(
       Object.keys(actionCreatorFunctions)
     )
+    // 6 instead of 5 because of `__esModule: true` property from importing `actionCreators`
+    expect(console.error.mock.calls.length).toBe(6)
+    global.console = _console
   })
 
   it('supports wrapping a single function only', () => {


### PR DESCRIPTION
I've found myself debugging 'Dude, where's my prop?' situations when I've done something like

```javascript
import { doSomething } from './actions' // for whatever reason, `doSomething` is `undefined`

...

const MyComponent = props => {
   ...
   const onClick = () => {
     props.doSomething() // error at runtime --> doSomething is undefined
   }
}

const mapDispatchToProps = {
  ...
  doSomething
  ...
}
```

It would speed up debugging in these situations if `bindActionCreators` logged a warning when it's passed an object with non-function properties.