### PR TITLE
Update HOC example in UsingImmutableJS docs

### DIFF
--- a/docs/recipes/UsingImmutableJS.md
+++ b/docs/recipes/UsingImmutableJS.md
@@ -270,7 +270,7 @@ Something needs to map the Immutable.JS props in your Smart Component to the pur
 Here is an example of such a HOC:
 
 ```
-import { React } from 'react';
+import React from 'react';
 import { Iterable } from 'immutable';
 
 export const toJS = (WrappedComponent) =>


### PR DESCRIPTION
The HOC example in the UsingImmutableJS docs used a named export to import React, but it needs to be a default import.