### PR TITLE
Fix FAQs Table of Contents links to Immutable.JS questions

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -27,11 +27,12 @@
   - [Why is immutability required in Redux?](/docs/faq/ImmutableData.md#why-is-immutability-required)
   - [Do I have to use Immutable.JS?](/docs/faq/ImmutableData.md#do-i-have-to-use-immutable-js)
   - [What are the issues with using ES6 for immutable operations?](/docs/faq/ImmutableData.md#issues-with-es6-for-immutable-ops)
-  - [Why should I use an immutable-focused library such as Immutable.JS?](/docs/faq/ImmutableData.md#why-use-immutable-library)
-  - [Why should I choose Immutable.JS as an immutable library?](/docs/faq/ImmutableData.md#why-choose-immutable-js)
-  - [What are the issues with using Immutable.JS?](/docs/faq/ImmutableData.md#issues-with-immutable-js)
-  - [Is Immutable.JS worth the effort?](/docs/faq/ImmutableData.md#is-immutable-js-worth-effort)
-  - [What are the Recommended Best Practices for using Immutable.JS with Redux?](/docs/faq/ImmutableData.md#immutable-js-best-practices)
+- **Using Immutable.JS with Redux**
+  - [Why should I use an immutable-focused library such as Immutable.JS?](/docs/recipes/UsingImmutableJS.md#why-use-immutable-library)
+  - [Why should I choose Immutable.JS as an immutable library?](/docs/recipes/UsingImmutableJS.md#why-choose-immutable-js)
+  - [What are the issues with using Immutable.JS?](/docs/recipes/UsingImmutableJS.md#issues-with-immutable-js)
+  - [Is Immutable.JS worth the effort?](/docs/recipes/UsingImmutableJS.md#is-immutable-js-worth-effort)
+  - [What are some opinionated Best Practices for using Immutable.JS with Redux?](/docs/recipes/UsingImmutableJS.md#immutable-js-best-practices)
 
 - **Code Structure**  
   - [What should my file structure look like? How should I group my action creators and reducers in my project? Where should my selectors go?](/docs/faq/CodeStructure.md#structure-file-structure)


### PR DESCRIPTION
There are 5 incorrect links in the Immutable section of the FAQs relating to `Immutable.JS` that have since been broken out into their own article in `/docs/recipes/UsingImmutableJS.md`. 

The links in `FAQ.md` still refer to the original location of these questions in `/docs/faq/ImmutableData.md`.

This PR simply breaks out the `Immutable.JS` questions into their own Table of Contents section, separate from the `Immutable Data` section, in `FAQ.md` to reflect their new home at `/docs/recipes/UsingImmutableJS.md`.