### PR TITLE
Fixed quote types inconsistency in a warning message

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -4,10 +4,10 @@ import warning from './utils/warning'
 
 function getUndefinedStateErrorMessage(key, action) {
   const actionType = action && action.type
-  const actionName = (actionType && `"${actionType.toString()}"`) || 'an action'
+  const actionDescription = (actionType && `action "${String(actionType)}"`) || 'an action'
 
   return (
-    `Given action ${actionName}, reducer "${key}" returned undefined. ` +
+    `Given ${actionDescription}, reducer "${key}" returned undefined. ` +
     `To ignore an action, you must explicitly return the previous state. ` +
     `If you want this reducer to hold no value, you can return null instead of undefined.`
   )


### PR DESCRIPTION
While reading the source code I've noticed that this could produce such text:
`Given action an action`
which is really unnatural to say. So I've refactored it a little to be more human-friendly and produce either:
- `Given action "SOME_TYPE"`
- or `Given an action`

Also - if you dont like this `String(variable)` casting approach I may revert this change and amend my PR. But personally I think its more obvious in what it does (casting) + its shorter by 3 chars :P