### PR TITLE
Update to TypeScript 2.1

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -47,6 +47,8 @@ export type Reducer<S> = <A extends Action>(state: S, action: A) => S;
 
 /**
  * Object whose values correspond to different reducer functions.
+ *
+ * @template S State object type.
  */
 export type ReducersMapObject<S> = {
   [P in keyof S]: Reducer<S[P]>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -48,8 +48,8 @@ export type Reducer<S> = <A extends Action>(state: S, action: A) => S;
 /**
  * Object whose values correspond to different reducer functions.
  */
-export interface ReducersMapObject {
-  [key: string]: Reducer<any>;
+export type ReducersMapObject<S> = {
+  [P in keyof S]: Reducer<S[P]>;
 }
 
 /**
@@ -70,7 +70,7 @@ export interface ReducersMapObject {
  * @returns A reducer function that invokes every reducer inside the passed
  *   object, and builds a state object with the same shape.
  */
-export function combineReducers<S>(reducers: ReducersMapObject): Reducer<S>;
+export function combineReducers<S>(reducers: ReducersMapObject<S>): Reducer<S>;
 
 
 /* store */

--- a/package.json
+++ b/package.json
@@ -112,8 +112,8 @@
     "rollup-plugin-replace": "^1.1.1",
     "rollup-plugin-uglify": "^1.0.1",
     "rxjs": "^5.0.0-beta.6",
-    "typescript": "^1.8.0",
-    "typescript-definition-tester": "0.0.4"
+    "typescript": "^2.1.0",
+    "typescript-definition-tester": "^0.0.5"
   },
   "npmName": "redux",
   "npmFileMap": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4143,17 +4143,17 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript-definition-tester@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/typescript-definition-tester/-/typescript-definition-tester-0.0.4.tgz#94b9edc4fe803b47f5f64ff5ddaf8eed1196156c"
+typescript-definition-tester@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/typescript-definition-tester/-/typescript-definition-tester-0.0.5.tgz#91c574d78ea05b81ed81244d50ec30d8240c356f"
   dependencies:
     assertion-error "^1.0.1"
     dts-bundle "^0.2.0"
     lodash "^3.6.0"
 
-typescript@^1.8.0:
-  version "1.8.10"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-1.8.10.tgz#b475d6e0dff0bf50f296e5ca6ef9fbb5c7320f1e"
+typescript@^2.1.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.2.1.tgz#4862b662b988a4c8ff691cc7969622d24db76ae9"
 
 uglify-js@^2.6, uglify-js@^2.6.1:
   version "2.7.5"


### PR DESCRIPTION
This allows us to define the reducers map object genetically, so it can be type checked against a state object.  This is a breaking change for projects still using TypeScript versions less than 2.1.

Resolves #2298.

Let me know if there are any issues with this PR that I should take care of.