### PR TITLE
applyMiddleware tests are using object property enumeration order

### DIFF
--- a/test/applyMiddleware.spec.js
+++ b/test/applyMiddleware.spec.js
@@ -20,8 +20,8 @@ describe('applyMiddleware', () => {
 
     expect(spy.mock.calls.length).toEqual(1)
 
-    expect(spy.mock.calls[0][0]).toHaveProperty('getState');
-    expect(spy.mock.calls[0][0]).toHaveProperty('dispatch');
+    expect(spy.mock.calls[0][0]).toHaveProperty('getState')
+    expect(spy.mock.calls[0][0]).toHaveProperty('dispatch')
 
     expect(store.getState()).toEqual([ { id: 1, text: 'Use Redux' }, { id: 2, text: 'Flux FTW!' } ])
   })

--- a/test/applyMiddleware.spec.js
+++ b/test/applyMiddleware.spec.js
@@ -20,10 +20,8 @@ describe('applyMiddleware', () => {
 
     expect(spy.mock.calls.length).toEqual(1)
 
-    expect(Object.keys(spy.mock.calls[0][0])).toEqual([
-      'getState',
-      'dispatch'
-    ])
+    expect(spy.mock.calls[0][0]).toHaveProperty('getState');
+    expect(spy.mock.calls[0][0]).toHaveProperty('dispatch');
 
     expect(store.getState()).toEqual([ { id: 1, text: 'Use Redux' }, { id: 2, text: 'Flux FTW!' } ])
   })


### PR DESCRIPTION
This is really, really minor, but object property enumeration order is not guaranteed despite being fairly consistent in browsers and node, but it doesn't hurt to take that into account and write the tests accordingly.