### PR TITLE
Make ReducersMapObject generic mapped type + upgrade to TS@2.2.1

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -48,8 +48,8 @@ export type Reducer<S> = <A extends Action>(state: S, action: A) => S;
 /**
  * Object whose values correspond to different reducer functions.
  */
-export interface ReducersMapObject {
-  [key: string]: Reducer<any>;
+export type ReducersMapObject<S> = {
+  [K in keyof S]: Reducer<S[K]>
 }
 
 /**
@@ -70,7 +70,7 @@ export interface ReducersMapObject {
  * @returns A reducer function that invokes every reducer inside the passed
  *   object, and builds a state object with the same shape.
  */
-export function combineReducers<S>(reducers: ReducersMapObject): Reducer<S>;
+export function combineReducers<S>(reducers: ReducersMapObject<S>): Reducer<S>;
 
 
 /* store */

--- a/package.json
+++ b/package.json
@@ -112,8 +112,8 @@
     "rollup-plugin-replace": "^1.1.1",
     "rollup-plugin-uglify": "^1.0.1",
     "rxjs": "^5.0.0-beta.6",
-    "typescript": "^1.8.0",
-    "typescript-definition-tester": "0.0.4"
+    "typescript": "^2.2.1",
+    "typescript-definition-tester": "0.0.5"
   },
   "npmName": "redux",
   "npmFileMap": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4143,17 +4143,17 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript-definition-tester@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/typescript-definition-tester/-/typescript-definition-tester-0.0.4.tgz#94b9edc4fe803b47f5f64ff5ddaf8eed1196156c"
+typescript-definition-tester@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/typescript-definition-tester/-/typescript-definition-tester-0.0.5.tgz#91c574d78ea05b81ed81244d50ec30d8240c356f"
   dependencies:
     assertion-error "^1.0.1"
     dts-bundle "^0.2.0"
     lodash "^3.6.0"
 
-typescript@^1.8.0:
-  version "1.8.10"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-1.8.10.tgz#b475d6e0dff0bf50f296e5ca6ef9fbb5c7320f1e"
+typescript@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.2.1.tgz#4862b662b988a4c8ff691cc7969622d24db76ae9"
 
 uglify-js@^2.6, uglify-js@^2.6.1:
   version "2.7.5"


### PR DESCRIPTION
Recent TypeScript 2.1 introduced mapped types so I suggest making `ReducersMapObject` generic and mapped. It allows `combineReducers` to correctly infer whole state type and to check passed reducers map more strictly if used with generic type parameter.
Example:
```typescript
import {combineReducers, Action, Reducer} from 'redux';

type TFooState = {
	bar: string
};

const foo: Reducer<TFooState> = (state: TFooState, action: Action) => {
	return state;
};

// Before fix inferred type is Reducer<{}>
// After fix inferred type is Reducer<{
//   foo: {
//     bar: string
//   }
// }>
const inferred = combineReducers({
	foo
});

type TBarState = {
	test: number
};

const bar: Reducer<TBarState> = (state: TBarState, action: Action) => {
	return state;
}

type TStrictState = {
	foo: TFooState,
	bar: TBarState
};

const extra1 = combineReducers<TStrictState>({
	foo,
	bar,
	//Error: Object literal may only specify known properties
	extra: {}
});

//Implicit cast to an alias with 'Reducer<{}>' type
//Error: Type '{}' is not assignable to type 'TStrictState'
const extra2: Reducer<TStrictState> = combineReducers({
	foo,
	bar,
	extra: {}
});

const missing1 = combineReducers<TStrictState>({
	//Error: Property 'bar' is missing
	foo
});

//Error: Property 'bar' is missing
const missing2: Reducer<TStrictState> = combineReducers({
	foo
});

type TIncorrectFooState = {
	test: number
};

const incorrectFoo: Reducer<TIncorrectFooState> = (state: TIncorrectFooState, action: Action) => {
	return state;
};

//Error: Property 'test' is missing in type 'TFooState'
const incorrect1: Reducer<TStrictState> = combineReducers({
	foo: incorrectFoo,
	bar
});

const incorrect2 = combineReducers<TStrictState>({
	//Error: type 'TFooState' is not assignable to type 'TIncorrectFooState'
	foo: incorrectFoo,
	bar
});
```