### PR TITLE
Use compose to bind action creator to keep DRY

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,13 +63,7 @@ The result will be in the `dist` folder.
 
 ### Testing and Linting
 
-To run both linting and testing at once, run the following:
-
-```
-npm run check:src
-```
-
-To only run linting:
+To run linting:
 
 ```
 npm run lint

--- a/src/bindActionCreators.js
+++ b/src/bindActionCreators.js
@@ -1,8 +1,5 @@
 import warning from './utils/warning'
-
-function bindActionCreator(actionCreator, dispatch) {
-  return (...args) => dispatch(actionCreator(...args))
-}
+import compose from './compose'
 
 /**
  * Turns an object whose values are action creators, into an object with the
@@ -27,7 +24,7 @@ function bindActionCreator(actionCreator, dispatch) {
  */
 export default function bindActionCreators(actionCreators, dispatch) {
   if (typeof actionCreators === 'function') {
-    return bindActionCreator(actionCreators, dispatch)
+    return compose(dispatch, actionCreators)
   }
 
   if (typeof actionCreators !== 'object' || actionCreators === null) {
@@ -43,7 +40,7 @@ export default function bindActionCreators(actionCreators, dispatch) {
     const key = keys[i]
     const actionCreator = actionCreators[key]
     if (typeof actionCreator === 'function') {
-      boundActionCreators[key] = bindActionCreator(actionCreator, dispatch)
+      boundActionCreators[key] = compose(dispatch, actionCreator)
     } else {
       warning(`bindActionCreators expected a function actionCreator for key '${key}', instead received type '${typeof actionCreator}'.`)
     }


### PR DESCRIPTION
Wasn't able to find discussion so apologies if this was discussed. Tradeoffs: this will have a small performance hit due to the checks and reduce call in compose but keeps code DRY.