### PR TITLE
Docs: update "import createLogger" to modern "import {createLogger}"

### DIFF
--- a/docs/advanced/AsyncActions.md
+++ b/docs/advanced/AsyncActions.md
@@ -390,7 +390,7 @@ How do we include the Redux Thunk middleware in the dispatch mechanism? We use t
 
 ```js
 import thunkMiddleware from 'redux-thunk'
-import createLogger from 'redux-logger'
+import { createLogger } from 'redux-logger'
 import { createStore, applyMiddleware } from 'redux'
 import { selectSubreddit, fetchPosts } from './actions'
 import rootReducer from './reducers'

--- a/docs/advanced/ExampleRedditAPI.md
+++ b/docs/advanced/ExampleRedditAPI.md
@@ -165,7 +165,7 @@ export default rootReducer
 ```js
 import { createStore, applyMiddleware } from 'redux'
 import thunkMiddleware from 'redux-thunk'
-import createLogger from 'redux-logger'
+import { createLogger } from 'redux-logger'
 import rootReducer from './reducers'
 
 const loggerMiddleware = createLogger()


### PR DESCRIPTION
redux-logger [introduced a breaking change in import syntax](https://github.com/evgenyrodionov/redux-logger/commit/1d12b4125ad2069f1778f3541a94e90ace5e894b) some days ago. Old syntax doesn't work now:
![image](https://cloud.githubusercontent.com/assets/439939/24473676/2070d7fa-14db-11e7-96a5-8dfa35a9421d.png)

Old syntax:
```javascript
import createLogger from 'redux-logger';
```

New syntax:
```javascript
import {createLogger} from 'redux-logger';
```