### PR TITLE
Add composeReducers util

### DIFF
--- a/docs/api/composeReducers.md
+++ b/docs/api/composeReducers.md
@@ -1,0 +1,116 @@
+# `composeReducers(initialState, ...reducers)`
+
+Creates a new reducer composing passed in reducers from right to left.
+
+You might want to use this utility to split a complex reducer in small chunks handling the same state.
+Is always better to divide in more chunks reducers that are performing too much calculation
+for a better testing and readability.
+
+Sometimes you can simply flat your state dividing it into more parent keys and use `combineReducers`, which is fine and neat. But sometimes you might need to handle the same state across multiple reducers as they were a big one, which is where a solution like this helps you.
+
+#### Arguments
+
+1. `initialState` (*any*): the initial state to be used by default if no state is passed by redux to the created reducer.
+2. `reducers` (*Array*): The reducers to compose. Each reducer is expected to accept the state and the dispatched action. Its return value will be the new state, if the action matches, to the reducer standing to the left, and so on.
+
+#### Returns
+
+(*Function*): The final reducer obtained by composing the given ones from right to left.
+
+#### Example
+
+This example demonstrates how to use `composeReducers` to split a complex reducer in small easy to test and read ones.
+
+
+#### `reducers/loggedInUser/index.js`
+
+```js
+import { composeReducers } from 'redux'
+import editInfo from './editInfo';
+import uploadPhoto from './uploadPhoto';
+
+
+const loggedInUser = composeReducers(
+  {
+    // shared loader for any save or download
+    loading: false,
+
+    username: '',
+    email: '',
+    photos: [],
+  },
+  editInfo,
+  uploadPhoto
+)
+
+export default loggedInUser;
+```
+
+#### `reducers/loggedInUser/editInfo.js`
+
+```js
+export default function editInfo(state, action) {
+  switch (action.type) {
+    // might be an async operation
+    case 'EDITING_LOGGED_IN_USER_INFO':
+    return {
+      ...state,
+      loading: true
+    }
+
+    case 'SET_LOGGED_IN_USER_USERNAME':
+    return {
+      ...state,
+      loading: false,
+      username: action.payload
+    }
+
+    case 'SET_LOGGED_IN_USER_EMAIL':
+    return {
+      ...state,
+      loading: false,
+      email: action.payload
+    }
+
+    default:
+    return state
+  }
+}
+```
+
+#### `reducers/loggedInUser/uploadPhoto.js`
+
+```js
+export default function editInfo(state, action) {
+  switch (action.type) {
+    case 'UPLOADING_LOGGED_IN_USER_PHOTO':
+    case 'DOWNLOADING_LOGGED_IN_USER_PHOTOS':
+    return {
+      ...state,
+      loading: true
+    }
+
+    case 'ADD_LOGGED_IN_USER_PHOTO':
+    return {
+      ...state,
+      loading: false,
+      photos: [...state.photos, action.payload]
+    }
+
+    case 'SET_LOGGED_IN_USER_PHOTOS':
+    return {
+      ...state,
+      loading: false,
+      photos: action.payload
+    }
+
+    default:
+    return state
+  }
+}
+```
+
+
+#### Tips
+
+* `initialState` lets you define the default state for your reducer, the internal reducers shouldn't care about any initial state in this case.

--- a/flow-typed/redux.js
+++ b/flow-typed/redux.js
@@ -52,4 +52,6 @@ declare module 'redux' {
 
   declare function compose<S, A>(...fns: Array<StoreEnhancer<S, A>>): Function;
 
+  declare function composeReducers<S, A>(initialState: $Shape<S> & {}, ...fns: Array<Reducer<S, A>>): Function;
+
 }

--- a/src/composeReducers.js
+++ b/src/composeReducers.js
@@ -1,0 +1,22 @@
+/**
+ * Creates new reducer composing passed in reducers from right to left, handling intialState.
+ *
+ * @param {any} initialState The initial state to be used as default state.
+ * @param {...Function} funcs The functions to compose.
+ * @returns {Function} A composed reducer obtained by composing the argument functions
+ * from right to left. Each reducer receives the state returned by the previous one.
+ */
+
+export default function composeReducers(initialState = {}, ...funcs) {
+  if (funcs.length === 0) {
+    return arg => arg
+  }
+
+  if (funcs.length === 1) {
+    return funcs[0]
+  }
+
+  return function composedReducer(state = initialState, action) {
+    return funcs.reduce((outcomeState, reducer) => reducer(outcomeState, action), state)
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import combineReducers from './combineReducers'
 import bindActionCreators from './bindActionCreators'
 import applyMiddleware from './applyMiddleware'
 import compose from './compose'
+import composeReducers from './composeReducers'
 import warning from './utils/warning'
 
 /*
@@ -30,5 +31,6 @@ export {
   combineReducers,
   bindActionCreators,
   applyMiddleware,
-  compose
+  compose,
+  composeReducers
 }

--- a/test/composeReducers.spec.js
+++ b/test/composeReducers.spec.js
@@ -1,0 +1,63 @@
+import { composeReducers } from '../src'
+
+describe('Utils', () => {
+  describe('composeReducers', () => {
+    const calculator = (state, action) => {
+      switch (action.type) {
+        case 'ADD':
+        return state + action.payload;
+
+        case 'MULTIPLY':
+        return state * action.payload;
+
+        default:
+        return state;
+      }
+    }
+
+    const percentage = (state, action) => {
+      switch (action.type) {
+        case 'ADD_PERCENTAGE':
+        return state + ((state / 100) * action.payload);
+
+        case 'SUBTRACT_PERCENTAGE':
+        return state - ((state / 100) * action.payload);
+
+        default:
+        return state;
+      }
+    }
+
+    it('composes reducers from right to left', () => {
+      const composedReducer = composeReducers(5, calculator, percentage);
+      expect(composedReducer(undefined, {
+        type: 'ADD',
+        payload: 5
+      })).toBe(10);
+      expect(composedReducer(undefined, {
+        type: 'MULTIPLY',
+        payload: 5
+      })).toBe(25);
+      expect(composedReducer(100, {
+        type: 'ADD_PERCENTAGE',
+        payload: 10
+      })).toBe(110);
+      expect(composedReducer(100, {
+        type: 'SUBTRACT_PERCENTAGE',
+        payload: 10
+      })).toBe(90);
+    })
+
+    it('returns the first given argument if given no functions', () => {
+      expect(composeReducers()(1, 2)).toBe(1)
+      expect(composeReducers()(3)).toBe(3)
+      expect(composeReducers()()).toBe(undefined)
+    })
+
+    it('returns the first function if given only one', () => {
+      const fn = () => {}
+
+      expect(composeReducers({}, fn)).toBe(fn)
+    })
+  })
+})


### PR DESCRIPTION
Add `composeReducers` utility to split complex reducers into multiple chunks handling the same state.

I know this kind of thinks could be a library, but I guess redux should provide a bit more utilities on how to solve some common issues.

This could also help people to avoid write complex reducers and find internal custom solutions to split the code, in favour of an already provided way.

## Example of use case (this is not complex but I guess it makes it easier to understand):

### `reducers/loggedInUser/index.js`

```js
import { composeReducers } from 'redux'
import editInfo from './editInfo';
import uploadPhoto from './uploadPhoto';


const loggedInUser = composeReducers(
  {
    // shared loader for any save or download
    loading: false,

    username: '',
    email: '',
    photos: [],
  },
  editInfo,
  uploadPhoto
)

export default loggedInUser;
```

### `reducers/loggedInUser/editInfo.js`

```js
export default function editInfo(state, action) {
  switch (action.type) {
    // might be an async operation
    case 'EDITING_LOGGED_IN_USER_INFO':
    return {
      ...state,
      loading: true
    }

    case 'SET_LOGGED_IN_USER_USERNAME':
    return {
      ...state,
      loading: false,
      username: action.payload
    }

    case 'SET_LOGGED_IN_USER_EMAIL':
    return {
      ...state,
      loading: false,
      email: action.payload
    }

    default:
    return state
  }
}
```

### `reducers/loggedInUser/uploadPhoto.js`

```js
export default function editInfo(state, action) {
  switch (action.type) {
    case 'UPLOADING_LOGGED_IN_USER_PHOTO':
    case 'DOWNLOADING_LOGGED_IN_USER_PHOTOS':
    return {
      ...state,
      loading: true
    }

    case 'ADD_LOGGED_IN_USER_PHOTO':
    return {
      ...state,
      loading: false,
      photos: [...state.photos, action.payload]
    }

    case 'SET_LOGGED_IN_USER_PHOTOS':
    return {
      ...state,
      loading: false,
      photos: action.payload
    }

    default:
    return state
  }
}
```
