### PR TITLE
updated 1st index.js example

### DIFF
--- a/docs/advanced/AsyncActions.md
+++ b/docs/advanced/AsyncActions.md
@@ -390,12 +390,10 @@ How do we include the Redux Thunk middleware in the dispatch mechanism? We use t
 
 ```js
 import thunkMiddleware from 'redux-thunk'
-import createLogger from 'redux-logger'
+import loggerMiddleware from 'redux-logger'
 import { createStore, applyMiddleware } from 'redux'
 import { selectSubreddit, fetchPosts } from './actions'
 import rootReducer from './reducers'
-
-const loggerMiddleware = createLogger()
 
 const store = createStore(
   rootReducer,


### PR DESCRIPTION
`redux-logger` now exports the middleware directly, fixes #2327