### PR TITLE
Replace `sanity` language in combineReducers

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -54,7 +54,7 @@ function getUnexpectedStateShapeWarningMessage(inputState, reducers, action, une
   }
 }
 
-function assertReducerSanity(reducers) {
+function assertReducerShape(reducers) {
   Object.keys(reducers).forEach(key => {
     const reducer = reducers[key]
     const initialState = reducer(undefined, { type: ActionTypes.INIT })
@@ -122,16 +122,16 @@ export default function combineReducers(reducers) {
     unexpectedKeyCache = {}
   }
 
-  let sanityError
+  let shapeAssertionError
   try {
-    assertReducerSanity(finalReducers)
+    assertReducerShape(finalReducers)
   } catch (e) {
-    sanityError = e
+    shapeAssertionError = e
   }
 
   return function combination(state = {}, action) {
-    if (sanityError) {
-      throw sanityError
+    if (shapeAssertionError) {
+      throw shapeAssertionError
     }
 
     if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
This addresses issue https://github.com/reactjs/redux/issues/2334

This replaces `sanityError` and `assertReducerSanity` with more descriptive, less ableist language that describes what the check is actually doing (checking and asserting the shape). I'm proposing to call it `assertReducerShape` and describe the error as a `shapeAssertionError` so that we're more precise and more inclusive at the same time!
