### PR TITLE
added an import for TodoList to first VisibleTodoList example

### DIFF
--- a/docs/basics/UsageWithReact.md
+++ b/docs/basics/UsageWithReact.md
@@ -284,6 +284,7 @@ Finally, we create the `VisibleTodoList` by calling `connect()` and passing thes
 
 ```js
 import { connect } from 'react-redux'
+import TodoList from '../components/TodoList'
 
 const VisibleTodoList = connect(
   mapStateToProps,


### PR DESCRIPTION
When the connect function usage is shown with VisibleTodoList, the initial example doesn't import the TodoList component. This is properly shown further down in the containers/VisibleTodoList section, but it should be shown in both places so it's known where the reference to TodoList comes from. 