### PR TITLE
return a curried bindActionCreators function if only actionCreators are present

### DIFF
--- a/src/bindActionCreators.js
+++ b/src/bindActionCreators.js
@@ -26,6 +26,11 @@ function bindActionCreator(actionCreator, dispatch) {
  * function.
  */
 export default function bindActionCreators(actionCreators, dispatch) {
+  // return a curried function if only actionCreators are present
+  if(arguments.length === 1) {
+    return (dispatch) => bindActionCreators(actionCreators, dispatch);
+  }
+
   if (typeof actionCreators === 'function') {
     return bindActionCreator(actionCreators, dispatch)
   }

--- a/src/bindActionCreators.js
+++ b/src/bindActionCreators.js
@@ -27,8 +27,8 @@ function bindActionCreator(actionCreator, dispatch) {
  */
 export default function bindActionCreators(actionCreators, dispatch) {
   // return a curried function if only actionCreators are present
-  if(arguments.length === 1) {
-    return (dispatch) => bindActionCreators(actionCreators, dispatch);
+  if (arguments.length === 1) {
+    return dispatch => bindActionCreators(actionCreators, dispatch)
   }
 
   if (typeof actionCreators === 'function') {

--- a/test/bindActionCreators.spec.js
+++ b/test/bindActionCreators.spec.js
@@ -118,6 +118,6 @@ describe('bindActionCreators', () => {
     ])
     expect(console.error).toHaveBeenCalled()
     global.console = _console
-  });
+  })
 
 })

--- a/test/bindActionCreators.spec.js
+++ b/test/bindActionCreators.spec.js
@@ -95,4 +95,29 @@ describe('bindActionCreators', () => {
       'Did you write "import ActionCreators from" instead of "import * as ActionCreators from"?'
     )
   })
+
+  it('returns a curried bindActionCreators function', () => {
+    const _console = console
+    global.console = { error: jest.fn() }
+
+    const curriedBindActionCreators = bindActionCreators(actionCreators)
+    const boundActionCreators = curriedBindActionCreators(store.dispatch)
+
+    expect(
+      Object.keys(boundActionCreators)
+    ).toEqual(
+      Object.keys(actionCreatorFunctions)
+    )
+
+    const action = boundActionCreators.addTodo('Hello')
+    expect(action).toEqual(
+      actionCreators.addTodo('Hello')
+    )
+    expect(store.getState()).toEqual([
+      { id: 1, text: 'Hello' }
+    ])
+    expect(console.error).toHaveBeenCalled()
+    global.console = _console
+  });
+
 })


### PR DESCRIPTION
I have been using `bindActionCreators` for some time and I found that it can be curried. Once curried `bindActionCreators` becomes easier to use moreover it does not break previous codes.

```js
// previous
export default connect(null,
    (dispatch, props) => bindActionCreators({
        addTodo,
        deleteTodo
    }, dispatch)
)(AppComponent);

// after curried
export default connect(null,
    bindActionCreators({
        addTodo,
        deleteTodo
    })
)(AppComponent);
```

I have also added a spec to test this new functionality.