### PR TITLE
docs(observable): es-observable GitHub repo moved to tc39

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -204,7 +204,7 @@ export default function createStore(reducer, preloadedState, enhancer) {
    * Interoperability point for observable/reactive libraries.
    * @returns {observable} A minimal observable of state changes.
    * For more information, see the observable proposal:
-   * https://github.com/zenparsing/es-observable
+   * https://github.com/tc39/proposal-observable
    */
   function observable() {
     const outerSubscribe = subscribe


### PR DESCRIPTION
The repository still redirects, but it makes sense to use the name that's now in use