### PR TITLE
Remove Markdown syntax from code block

### DIFF
--- a/docs/recipes/UsingImmutableJS.md
+++ b/docs/recipes/UsingImmutableJS.md
@@ -276,7 +276,7 @@ import { Iterable } from 'immutable';
 export const toJS = (WrappedComponent) =>
    (wrappedComponentProps) => {
        const KEY = 0;
-       const **VALUE = 1;
+       const VALUE = 1;
 
        const propsJS = Object.entries(wrappedComponentProps)
             .reduce((newProps, wrappedComponentProp)  => {


### PR DESCRIPTION
I think the `**` prior to `VALUE` in the Immutable sample HOC is a typo.