### PR TITLE
Update docs with React v15.5.0

### DIFF
--- a/docs/advanced/ExampleRedditAPI.md
+++ b/docs/advanced/ExampleRedditAPI.md
@@ -208,7 +208,8 @@ export default class Root extends Component {
 #### `containers/AsyncApp.js`
 
 ```js
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { selectSubreddit, fetchPostsIfNeeded, invalidateSubreddit } from '../actions'
 import Picker from '../components/Picker'
@@ -318,7 +319,8 @@ export default connect(mapStateToProps)(AsyncApp)
 #### `components/Picker.js`
 
 ```js
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 
 export default class Picker extends Component {
   render() {
@@ -352,7 +354,8 @@ Picker.propTypes = {
 #### `components/Posts.js`
 
 ```js
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 
 export default class Posts extends Component {
   render() {

--- a/docs/advanced/UsageWithReactRouter.md
+++ b/docs/advanced/UsageWithReactRouter.md
@@ -96,7 +96,8 @@ Unless you are targeting old browsers like IE9, you can always use `browserHisto
 
 #### `components/Root.js`
 ``` js
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Provider } from 'react-redux';
 import { Router, Route, browserHistory } from 'react-router';
 import App from './App';

--- a/docs/basics/ExampleTodoList.md
+++ b/docs/basics/ExampleTodoList.md
@@ -134,7 +134,8 @@ export default todoApp
 #### `components/Todo.js`
 
 ```js
-import React, { PropTypes } from 'react'
+import React, from 'react'
+import PropTypes from 'prop-types'
 
 const Todo = ({ onClick, completed, text }) => (
   <li
@@ -159,7 +160,8 @@ export default Todo
 #### `components/TodoList.js`
 
 ```js
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import Todo from './Todo'
 
 const TodoList = ({ todos, onTodoClick }) => (
@@ -188,7 +190,8 @@ export default TodoList
 
 #### `components/Link.js`
 ```js
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 
 const Link = ({ active, children, onClick }) => {
   if (active) {

--- a/docs/basics/UsageWithReact.md
+++ b/docs/basics/UsageWithReact.md
@@ -114,7 +114,8 @@ These are all normal React components, so we won't examine them in detail. We wr
 #### `components/Todo.js`
 
 ```js
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 
 const Todo = ({ onClick, completed, text }) => (
   <li
@@ -139,7 +140,8 @@ export default Todo
 #### `components/TodoList.js`
 
 ```js
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import Todo from './Todo'
 
 const TodoList = ({ todos, onTodoClick }) => (
@@ -169,7 +171,8 @@ export default TodoList
 #### `components/Link.js`
 
 ```js
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 
 const Link = ({ active, children, onClick }) => {
   if (active) {

--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -266,7 +266,8 @@ To test the components we make a `setup()` helper that passes the stubbed callba
 #### Example
 
 ```js
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import TodoTextInput from './TodoTextInput'
 
 class Header extends Component {


### PR DESCRIPTION
Changing the import of `PropTypes`, from `react` to `prop-types` package, as of React v15.5.0 update.