### PR TITLE
Fixed types for dispatched action

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -93,8 +93,8 @@ export function combineReducers<S>(reducers: ReducersMapObject): Reducer<S>;
  * transform, delay, ignore, or otherwise interpret actions or async actions
  * before passing them to the next middleware.
  */
-export interface Dispatch<S> {
-    <A extends Action>(action: A): A;
+export interface Dispatch<A> {
+    <Action extends A>(action: A): A;
 }
 
 /**


### PR DESCRIPTION
I'm very sorry, this pull-request is a really wrong. I'm closing it

<strike>Hi,
I'm not really 100% sure, but I think that I found bug. I have problem with typing in typescript. 
In this case:
```typescript
interface FooAction {
    type: string,
    names: string[]
}

const bar = (dispatch: Dispatch<FooAction>) => {
    return dispatch({
        type: 'test'
    });
}
```
I expect error because dispatched object is not valid FooAction (missing `names` property), but no error there. Problem is probably there: https://github.com/reactjs/redux/blob/master/index.d.ts#L96-L98
When try to update interface for Dispatch to
```typescript
interface Dispatch<A> {
    <Action extends A>(action: A): A;
}
```
I get correct error `Argument of type '{ type: string; }' is not assignable to parameter of type 'FooAction'.
  Property 'names' is missing in type '{ type: string; }'`

Note: When I keep `<A extends Action>` will check only for `type` property and no error throws</strike>