### PR TITLE
Faq general - Discussion links for when should i use Redux

### DIFF
--- a/docs/faq/General.md
+++ b/docs/faq/General.md
@@ -46,10 +46,15 @@ In the end, Redux is just a tool.  It's a great tool, and there's some great rea
 - [Twitter: Redux is useful to eliminate deep prop passing](https://twitter.com/dan_abramov/status/732912085840089088)
 - [Twitter: Don't use Redux unless you're unhappy with local component state](https://twitter.com/dan_abramov/status/725089243836588032)
 - [Twitter: You don't need Redux if your data never changes](https://twitter.com/dan_abramov/status/737036433215610880)
+- [Twitter: If your reducer looks boring, don't use redux](https://twitter.com/dan_abramov/status/802564042648944642)
+- [Reddit: You don't need Redux if your app just fetches something on a single page](https://www.reddit.com/r/reactjs/comments/5exfea/feedback_on_my_first_redux_app/dagglqp/)
 - [Stack Overflow: Why use Redux over Facebook Flux?](http://stackoverflow.com/questions/32461229/why-use-redux-over-facebook-flux)
 - [Stack Overflow: Why should I use Redux in this example?](http://stackoverflow.com/questions/35675339/why-should-i-use-redux-in-this-example)
 - [Stack Overflow: What could be the downsides of using Redux instead of Flux?](http://stackoverflow.com/questions/32021763/what-could-be-the-downsides-of-using-redux-instead-of-flux)
 - [Stack Overflow: When should I add Redux to a React app?](http://stackoverflow.com/questions/36631761/when-should-i-add-redux-to-a-react-app)
+- [Stack Overflow: Redux vs plain React?](http://stackoverflow.com/questions/39260769/redux-vs-plain-react/39261546#39261546)
+- [Stack Overflow: Redux vs plain React?](http://stackoverflow.com/questions/39260769/redux-vs-plain-react/39261546#39261546)
+- [Twitter: Redus is a platform for developers to build customized state management with reusable things](https://twitter.com/acemarke/status/793862722253447168)
 
 
 <a id="general-only-react"></a>

--- a/docs/faq/General.md
+++ b/docs/faq/General.md
@@ -53,8 +53,7 @@ In the end, Redux is just a tool.  It's a great tool, and there's some great rea
 - [Stack Overflow: What could be the downsides of using Redux instead of Flux?](http://stackoverflow.com/questions/32021763/what-could-be-the-downsides-of-using-redux-instead-of-flux)
 - [Stack Overflow: When should I add Redux to a React app?](http://stackoverflow.com/questions/36631761/when-should-i-add-redux-to-a-react-app)
 - [Stack Overflow: Redux vs plain React?](http://stackoverflow.com/questions/39260769/redux-vs-plain-react/39261546#39261546)
-- [Stack Overflow: Redux vs plain React?](http://stackoverflow.com/questions/39260769/redux-vs-plain-react/39261546#39261546)
-- [Twitter: Redus is a platform for developers to build customized state management with reusable things](https://twitter.com/acemarke/status/793862722253447168)
+- [Twitter: Redux is a platform for developers to build customized state management with reusable things](https://twitter.com/acemarke/status/793862722253447168)
 
 
 <a id="general-only-react"></a>


### PR DESCRIPTION
Adding discussions links for FAQ - General

as per [1785](https://github.com/reactjs/redux/issues/1785) `Updates to Existing Questions` section

1. I re-arranged the orders of few titles like *dont use redux* to appear together
2. Omitted this discussion https://twitter.com/dan_abramov/status/801489026687651840 as I felt it might be overwhelming here

@markerikson Please review