### PR TITLE
add a hook to redux-devtools-extension

### DIFF
--- a/examples/todos/src/index.js
+++ b/examples/todos/src/index.js
@@ -5,7 +5,10 @@ import { Provider } from 'react-redux'
 import App from './components/App'
 import reducer from './reducers'
 
-const store = createStore(reducer)
+const store = createStore(
+  reducer,
+   window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+)
 
 render(
   <Provider store={store}>


### PR DESCRIPTION
I think `examples/todos` is the most important example for React Redux, so it is worth considering to add the [redux-devtools-extension](https://github.com/zalmoxisus/redux-devtools-extension) middleware if users have the extension in Chrome.

It looks like:


<img width="663" alt="screen shot 2017-04-27 at 13 45 38" src="https://cloud.githubusercontent.com/assets/101800/25468294/e0021162-2b4f-11e7-8761-4c6d3862e3ec.png">
