### PR TITLE
Simplify createStore(), remove nextListeners & ensureCanMutateNextListeners()

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -57,14 +57,7 @@ export default function createStore(reducer, preloadedState, enhancer) {
   let currentReducer = reducer
   let currentState = preloadedState
   let currentListeners = []
-  let nextListeners = currentListeners
   let isDispatching = false
-
-  function ensureCanMutateNextListeners() {
-    if (nextListeners === currentListeners) {
-      nextListeners = currentListeners.slice()
-    }
-  }
 
   /**
    * Reads the state tree managed by the store.
@@ -105,8 +98,7 @@ export default function createStore(reducer, preloadedState, enhancer) {
 
     let isSubscribed = true
 
-    ensureCanMutateNextListeners()
-    nextListeners.push(listener)
+    currentListeners = currentListeners.concat(listener)
 
     return function unsubscribe() {
       if (!isSubscribed) {
@@ -115,9 +107,9 @@ export default function createStore(reducer, preloadedState, enhancer) {
 
       isSubscribed = false
 
-      ensureCanMutateNextListeners()
-      const index = nextListeners.indexOf(listener)
-      nextListeners.splice(index, 1)
+      currentListeners = currentListeners.slice()
+      const index = currentListeners.indexOf(listener)
+      currentListeners.splice(index, 1)
     }
   }
 
@@ -172,7 +164,7 @@ export default function createStore(reducer, preloadedState, enhancer) {
       isDispatching = false
     }
 
-    const listeners = currentListeners = nextListeners
+    const listeners = currentListeners
     for (let i = 0; i < listeners.length; i++) {
       const listener = listeners[i]
       listener()


### PR DESCRIPTION
- If we treat `currentListeners` as a read-only array, `createStore()`'s implementation can be simplified. 
- `nextListeners` and `ensureCanMutateNextListeners()` are unnecessary when we assign new arrays to `currentListeners` but never mutate it.
- The code is easier to follow when we don't have to keep track of current vs. next listeners.
- `dispatch()` remains free of the cost of creating new arrays.