### PR TITLE
fix assertReducerShape

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -69,17 +69,6 @@ function assertReducerShape(reducers) {
       )
     }
 
-    const type = '@@redux/PROBE_UNKNOWN_ACTION_' + Math.random().toString(36).substring(7).split('').join('.')
-    if (typeof reducer(undefined, { type }) === 'undefined') {
-      throw new Error(
-        `Reducer "${key}" returned undefined when probed with a random type. ` +
-        `Don't try to handle ${ActionTypes.INIT} or other actions in "redux/*" ` +
-        `namespace. They are considered private. Instead, you must return the ` +
-        `current state for any unknown actions, unless it is undefined, ` +
-        `in which case you must return the initial state, regardless of the ` +
-        `action type. The initial state may not be undefined, but can be null.`
-      )
-    }
   })
 }
 


### PR DESCRIPTION
Hi, I remove the part that you check the private namespace is used or not.

I think the code is no use for the condition.
If the namespace is used, the reducer should return a initial state instead of undefined. 
Otherwise if it really return undefined it should block at the previous error.
Only check is undefined or not is not working for check the private namespace is used or not.

I think it should check the initial state and the state return from the reducer which give private namespace action are deep different or not.
However it will reduce lot's performance I think.

Thanks!
