### PR TITLE
'todo' const removal from reducers/todos.js

### DIFF
--- a/examples/todos/src/reducers/todos.js
+++ b/examples/todos/src/reducers/todos.js
@@ -1,35 +1,19 @@
-const todo = (state, action) => {
-  switch (action.type) {
-    case 'ADD_TODO':
-      return {
-        id: action.id,
-        text: action.text,
-        completed: false
-      }
-    case 'TOGGLE_TODO':
-      if (state.id !== action.id) {
-        return state
-      }
-
-      return {
-        ...state,
-        completed: !state.completed
-      }
-    default:
-      return state
-  }
-}
-
 const todos = (state = [], action) => {
   switch (action.type) {
     case 'ADD_TODO':
       return [
         ...state,
-        todo(undefined, action)
+        {
+          id: action.id,
+          text: action.text,
+          completed: false
+        }
       ]
     case 'TOGGLE_TODO':
-      return state.map(t =>
-        todo(t, action)
+      return state.map(todo =>
+        (todo.id === action.id) 
+          ? {...todo, completed: !todo.completed}
+          : todo
       )
     default:
       return state


### PR DESCRIPTION
Hi there,

What I am proposing is removal of the [todo](https://github.com/reactjs/redux/blob/master/examples/todos/src/reducers/todos.js#L1-L21)  const and [usage of a simpler](https://github.com/dankoknad/redux/blob/todos-example-refactoring/examples/todos/src/reducers/todos.js) (IMHO) and still readable and understandable code. Purpose of this change is to make learning Redux and how to connect Redux to React a bit easier.

While learning awesome Redux and expecially how to connect Redux with React app, I have found that  const *todo* was one of the confusing pieces of code - at least it was for me. It looks exactly like a reducer - but it is **not**. It is helper function which has two arguments: *state*  and *action* (just like reducer), and *switch* statement also sugest to me that it is a reducer (I was just looking for the code patterns at the time of learning). I was thinking (at the time of learning) that *todo* is reducer which are used in another reducer - *todos*. Yep, it's crazy - I know..

Best,
Danko