### PR TITLE
Fixed the definition of 'Reducer<S>' for TypeScript 2.4.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,17 @@ export interface Action {
   type: any;
 }
 
+/**
+ * An Action type which accepts any other properties.
+ * This is mainly for the use of the `Reducer` type.
+ * This is not part of `Action` itself to prevent users who are extending `Action.
+ * @private
+ */
+export interface AnyAction extends Action {
+  // Allows any extra properties to be defined in an action.
+  [extraProps: string]: any;
+}
+
 
 /* reducers */
 
@@ -43,7 +54,7 @@ export interface Action {
  *
  * @template S State object type.
  */
-export type Reducer<S> = <A extends Action>(state: S, action: A) => S;
+export type Reducer<S> = (state: S, action: AnyAction) => S;
 
 /**
  * Object whose values correspond to different reducer functions.


### PR DESCRIPTION
This is going to be a bit roundabout, but bear with me. 😄 

Stricter checks on generics in TypeScript 2.4 correctly errored on the fact that reducers passed to `combineReducers` were expected to be more general than they actually needed to be.

Since the `A` type parameter was never used as part of the return type -  it was only used as a constraint - the appropriate next step was to replace the parameter type of `A` with the `Action` type directly:

```ts
export type Reducer<S> = (state: S, action: Action) => S;
```

However, because of excess property checks, this introduced errors when object literals were passed directly to a reducer. For example:

```ts
const rootReducer: Reducer<RootState> = combineReducers({
  todos: todosReducer,
  counter: counterReducer,
})

const rootState: RootState = rootReducer(undefined, {
  type: 'ADD_TODO',
  text: 'test',
//~~~~~~~~~~~~ excess property
})
```

Thus, I created a new `AnyAction` which is just `Action` with an index signature. This type is separate from `Action` to avoid polluting subtypes of `Action` with an index signature.