### PR TITLE
Ignoring eslint rule for defined class properties

### DIFF
--- a/examples/real-world/src/components/Explore.js
+++ b/examples/real-world/src/components/Explore.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-undef */
+
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 

--- a/examples/real-world/src/components/List.js
+++ b/examples/real-world/src/components/List.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-undef */
+
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 

--- a/examples/real-world/src/containers/App.js
+++ b/examples/real-world/src/containers/App.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-undef */
+
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'

--- a/examples/real-world/src/containers/RepoPage.js
+++ b/examples/real-world/src/containers/RepoPage.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-undef */
+
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'

--- a/examples/real-world/src/containers/UserPage.js
+++ b/examples/real-world/src/containers/UserPage.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-undef */
+
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'


### PR DESCRIPTION
Fixes https://github.com/reactjs/redux/issues/2469

This is the _simplest_ solution so the example continues to run, whether or not users have installed the top-level redux node modules. However, it may not be the approach the maintainers want to take, so feedback welcome!