### PR TITLE
Updated the definition of 'Reducer' and 'Dispatch' for TypeScript 2.3+

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -43,7 +43,7 @@ export interface Action {
  *
  * @template S State object type.
  */
-export type Reducer<S> = <A extends Action>(state: S, action: A) => S;
+export type Reducer<S, A extends Action = Action> = (state: S, action: A) => S;
 
 /**
  * Object whose values correspond to different reducer functions.
@@ -93,8 +93,8 @@ export function combineReducers<S>(reducers: ReducersMapObject): Reducer<S>;
  * transform, delay, ignore, or otherwise interpret actions or async actions
  * before passing them to the next middleware.
  */
-export interface Dispatch<S> {
-    <A extends Action>(action: A): A;
+export interface Dispatch<A extends Action = Action> {
+    (action: A): A;
 }
 
 /**
@@ -138,7 +138,7 @@ export interface Store<S> {
    * Note that, if you use a custom middleware, it may wrap `dispatch()` to
    * return something else (for example, a Promise you can await).
    */
-  dispatch: Dispatch<S>;
+  dispatch: Dispatch;
 
   /**
    * Reads the state tree managed by the store.
@@ -254,7 +254,7 @@ export const createStore: StoreCreator;
 /* middleware */
 
 export interface MiddlewareAPI<S> {
-  dispatch: Dispatch<S>;
+  dispatch: Dispatch;
   getState(): S;
 }
 
@@ -268,7 +268,7 @@ export interface MiddlewareAPI<S> {
  * asynchronous API call into a series of synchronous actions.
  */
 export interface Middleware {
-  <S>(api: MiddlewareAPI<S>): (next: Dispatch<S>) => Dispatch<S>;
+  <S>(api: MiddlewareAPI<S>): (next: Dispatch) => Dispatch;
 }
 
 /**
@@ -340,19 +340,19 @@ export interface ActionCreatorsMapObject {
  *   creator wrapped into the `dispatch` call. If you passed a function as
  *   `actionCreator`, the return value will also be a single function.
  */
-export function bindActionCreators<A extends ActionCreator<any>>(actionCreator: A, dispatch: Dispatch<any>): A;
+export function bindActionCreators<A extends ActionCreator<any>>(actionCreator: A, dispatch: Dispatch): A;
 
 export function bindActionCreators<
   A extends ActionCreator<any>,
   B extends ActionCreator<any>
-  >(actionCreator: A, dispatch: Dispatch<any>): B;
+  >(actionCreator: A, dispatch: Dispatch): B;
 
-export function bindActionCreators<M extends ActionCreatorsMapObject>(actionCreators: M, dispatch: Dispatch<any>): M;
+export function bindActionCreators<M extends ActionCreatorsMapObject>(actionCreators: M, dispatch: Dispatch): M;
 
 export function bindActionCreators<
   M extends ActionCreatorsMapObject,
   N extends ActionCreatorsMapObject
-  >(actionCreators: M, dispatch: Dispatch<any>): N;
+  >(actionCreators: M, dispatch: Dispatch): N;
 
 
 /* compose */


### PR DESCRIPTION
Another way to fix #2424 

And update Dispatch to make it more simple. ( confuse by the `S` of `Dispatch<S>`)