### PR TITLE
Add new links to Code Structure

### DIFF
--- a/docs/faq/CodeStructure.md
+++ b/docs/faq/CodeStructure.md
@@ -68,7 +68,7 @@ Find the balance between these two extremes, and you will master Redux.
 - [The Tao of Redux, Part 2 - Practice and Philosophy. Thick and thin reducers.](http://blog.isquaredsoftware.com/2017/05/idiomatic-redux-tao-of-redux-part-2/#thick-and-thin-reducers)
 
 **Discussions**
-- [#384: Recommend that Action constants be named in the past tense](https://github.com/reactjs/redux/issues/384#issuecomment-127393209)
+- [How putting too much logic in action creators could affect debugging](https://github.com/reactjs/redux/issues/384#issuecomment-127393209)
 - [#1165: Where to put business logic / validation?](https://github.com/reactjs/redux/issues/1165)
 - [#1171: Recommendations for best practices regarding action-creators, reducers, and selectors](https://github.com/reactjs/redux/issues/1171)
 - [Stack Overflow: Accessing Redux state in an action creator?](http://stackoverflow.com/questions/35667249/accessing-redux-state-in-an-action-creator/35674575)

--- a/docs/faq/CodeStructure.md
+++ b/docs/faq/CodeStructure.md
@@ -65,7 +65,7 @@ Find the balance between these two extremes, and you will master Redux.
 **Articles**
 - [Where do I put my business logic in a React/Redux application?](https://medium.com/@jeffbski/where-do-i-put-my-business-logic-in-a-react-redux-application-9253ef91ce1)
 - [How to Scale React Applications](https://www.smashingmagazine.com/2016/09/how-to-scale-react-applications/)
-- [The Tao of Redux, Part 2 - Practice and Philosophy](http://blog.isquaredsoftware.com/2017/05/idiomatic-redux-tao-of-redux-part-2/#thick-and-thin-reducers)
+- [The Tao of Redux, Part 2 - Practice and Philosophy. Thick and thin reducers.](http://blog.isquaredsoftware.com/2017/05/idiomatic-redux-tao-of-redux-part-2/#thick-and-thin-reducers)
 
 **Discussions**
 - [#384: Recommend that Action constants be named in the past tense](https://github.com/reactjs/redux/issues/384#issuecomment-127393209)

--- a/docs/faq/CodeStructure.md
+++ b/docs/faq/CodeStructure.md
@@ -65,8 +65,10 @@ Find the balance between these two extremes, and you will master Redux.
 **Articles**
 - [Where do I put my business logic in a React/Redux application?](https://medium.com/@jeffbski/where-do-i-put-my-business-logic-in-a-react-redux-application-9253ef91ce1)
 - [How to Scale React Applications](https://www.smashingmagazine.com/2016/09/how-to-scale-react-applications/)
+- [The Tao of Redux, Part 2 - Practice and Philosophy](http://blog.isquaredsoftware.com/2017/05/idiomatic-redux-tao-of-redux-part-2/#thick-and-thin-reducers)
 
 **Discussions**
+- [#384: Recommend that Action constants be named in the past tense](https://github.com/reactjs/redux/issues/384#issuecomment-127393209)
 - [#1165: Where to put business logic / validation?](https://github.com/reactjs/redux/issues/1165)
-- [#1171: Recommendations for best practices regarding action-creators, reducers, and selectors](https://github.com/reactjs/redux/issues/1171 )
+- [#1171: Recommendations for best practices regarding action-creators, reducers, and selectors](https://github.com/reactjs/redux/issues/1171)
 - [Stack Overflow: Accessing Redux state in an action creator?](http://stackoverflow.com/questions/35667249/accessing-redux-state-in-an-action-creator/35674575)


### PR DESCRIPTION
Add two new links to "Code Structure" FAQ section (https://github.com/reactjs/redux/issues/1785)

I have a question regarding labels for the links, sorry if this question sounds stupid 😸

I looked through the docs and it seems that link labels are always just article/issue name. But in case of issue #384, the actual ticket is more about a naming convention but the comment is about how code structure affects time travel in devtools. Should this be mentioned in link label somehow?