### PR TITLE
writing tests for middleware example changed

### DIFF
--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -453,7 +453,7 @@ it('calls the function', () => {
 it('passes dispatch and getState', () => {
   const { store, invoke } = create()
   invoke((dispatch, getState) => {
-    dispatch('TEST DISPATCH');
+    dispatch('TEST DISPATCH')
     getState();
   })
   expect(store.dispatch).toHaveBeenCalledWith('TEST DISPATCH')

--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -461,7 +461,7 @@ it('passes dispatch and getState', () => {
 });
 ```
 
-In some cases, you will need to modify the 'create' function to use different mock implementations of `getState` and `next`.
+In some cases, you will need to modify the `create` function to use different mock implementations of `getState` and `next`.
 
 ### Glossary
 

--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -436,20 +436,20 @@ const create = () => {
 We test that our middleware is calling the `getState`, `dispatch`, and `next` functions at the right time.
 
 ```js
-it(`passes through non-function action`, () => {
+it('passes through non-function action', () => {
   const { next, invoke } = create()
   invoke({})
   expect(next).toHaveBeenCalled()
 })
 
-it(`calls the function`, () => {
+it('calls the function', () => {
   const { invoke } = create()
   const fn = jest.fn()
   invoke(fn)
   expect(fn).toHaveBeenCalled()
 });
 
-it(`passes dispatch and getState`, () => {
+it('passes dispatch and getState', () => {
   const { store, invoke } = create()
   invoke((dispatch, getState) => {
     dispatch('TEST DISPATCH');

--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -433,7 +433,7 @@ const create = () => {
 };
 ```
 
-Finally, we test that our middleware is calling the `getState`, `dispatch`, and `next` functions at the right time.
+We test that our middleware is calling the `getState`, `dispatch`, and `next` functions at the right time.
 
 ```js
 it(`passes through non-function action`, () => {
@@ -459,6 +459,8 @@ it(`passes dispatch and getState`, () => {
   expect(store.getState).toHaveBeenCalled()
 });
 ```
+
+In some cases, you will need to modify the 'create' function to use different mock implementations of `getState` and `next`.
 
 ### Glossary
 

--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -403,49 +403,61 @@ Middleware functions wrap behavior of `dispatch` calls in Redux, so to test this
 
 #### Example
 
+First, we'll need a middleware function. This is similar to the real [redux-thunk](https://github.com/gaearon/redux-thunk/blob/master/src/index.js).
+
 ```js
-import * as types from '../../constants/ActionTypes'
-import singleDispatch from '../../middleware/singleDispatch'
-
-const createFakeStore = fakeData => ({
-  getState() {
-    return fakeData
+const thunk = ({ dispatch, getState }) => next => action => {
+  if (typeof action === 'function') {
+    return action(dispatch, getState)
   }
-})
 
-const dispatchWithStoreOf = (storeData, action) => {
-  let dispatched = null
-  const dispatch = singleDispatch(createFakeStore(storeData))(
-    actionAttempt => (dispatched = actionAttempt)
-  )
-  dispatch(action)
-  return dispatched
+  return next(action)
 }
+```
 
-describe('middleware', () => {
-  it('should dispatch if store is empty', () => {
-    const action = {
-      type: types.ADD_TODO
-    }
+We need to create a fake `getState`, `dispatch`, and `next` functions. We use `jest.fn()` to create stubs, but with other test frameworks you would likely use sinon.
 
-    expect(dispatchWithStoreOf({}, action)).toEqual(action)
-  })
+The invoke function runs our middleware in the same way Redux does.
 
-  it('should not dispatch if store already has type', () => {
-    const action = {
-      type: types.ADD_TODO
-    }
+```js
+const create = () => {
+  const store = {
+    getState: jest.fn(() => ({})),
+    dispatch: jest.fn(),
+  };
+  const next = jest.fn()
 
-    expect(
-      dispatchWithStoreOf(
-        {
-          [types.ADD_TODO]: 'dispatched'
-        },
-        action
-      )
-    ).toNotExist()
-  })
+  const invoke = (action) => thunk(store)(next)(action)
+
+  return {store, next, invoke}
+};
+```
+
+Finally, we test that our middleware is calling the `getState`, `dispatch`, and `next` functions at the right time.
+
+```js
+it(`passes through non-function action`, () => {
+  const { next, invoke } = create()
+  invoke({})
+  expect(next).toHaveBeenCalled()
 })
+
+it(`calls the function`, () => {
+  const { invoke } = create()
+  const fn = jest.fn()
+  invoke(fn)
+  expect(fn).toHaveBeenCalled()
+});
+
+it(`passes dispatch and getState`, () => {
+  const { store, invoke } = create()
+  invoke((dispatch, getState) => {
+    dispatch('TEST DISPATCH');
+    getState();
+  })
+  expect(store.dispatch).toHaveBeenCalledWith('TEST DISPATCH')
+  expect(store.getState).toHaveBeenCalled()
+});
 ```
 
 ### Glossary

--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -436,10 +436,11 @@ const create = () => {
 We test that our middleware is calling the `getState`, `dispatch`, and `next` functions at the right time.
 
 ```js
-it('passes through non-function action', () => {
+it(`passes through non-function action`, () => {
   const { next, invoke } = create()
-  invoke({})
-  expect(next).toHaveBeenCalled()
+  const action = {type: 'TEST'}
+  invoke(action)
+  expect(next).toHaveBeenCalledWith(action)
 })
 
 it('calls the function', () => {


### PR DESCRIPTION
I think thunk is a better example than 'singleDispatch'. The example is also more copy/paste-able.