### PR TITLE
Remove `src` directory from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "dist",
     "lib",
     "es",
-    "src",
     "index.d.ts"
   ],
   "scripts": {


### PR DESCRIPTION
`./src` directory is not used in npm package, only `./es` (as source for ES-module), `./lib` (as a source for old js syntax module) and `./dist` (as UMD module), so it can be removed. It reduces size of installed package by 21.4%