### PR TITLE
Remove usage of `check:src` npm script from contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,12 +65,6 @@ The result will be in the `dist` folder.
 
 ### Testing and Linting
 
-To run both linting and testing at once, run the following:
-
-```
-npm run check:src
-```
-
 To only run linting:
 
 ```


### PR DESCRIPTION
CONTRIBUTING.md [contains](https://github.com/reactjs/redux/blob/master/CONTRIBUTING.md#testing-and-linting) missed `check:src` script, that was removed in https://github.com/reactjs/redux/commit/35cb4a914ea501c13534888eb01103d756e3619e. 

In this PR I'm adding `check` npm script, that includes lint and test and fix CONTRIBUTING.md.