### PR TITLE
Make reducer generics more generic

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -54,13 +54,13 @@ export interface AnyAction extends Action {
  *
  * @template S State object type.
  */
-export type Reducer<S> = (state: S, action: AnyAction) => S;
+export type Reducer<S, A extends Action = AnyAction> = (state: S, action: A) => S;
 
 /**
  * Object whose values correspond to different reducer functions.
  */
-export interface ReducersMapObject {
-  [key: string]: Reducer<any>;
+export interface ReducersMapObject<A extends Action = AnyAction> {
+  [key: string]: Reducer<any, A>;
 }
 
 /**
@@ -81,7 +81,7 @@ export interface ReducersMapObject {
  * @returns A reducer function that invokes every reducer inside the passed
  *   object, and builds a state object with the same shape.
  */
-export function combineReducers<S>(reducers: ReducersMapObject): Reducer<S>;
+export function combineReducers<S>(reducers: ReducersMapObject<A extends Action>): Reducer<S, A>;
 
 
 /* store */


### PR DESCRIPTION
This enforces that the action parameter extends `Action` for strongly typed implementations, and defaults to `AnyAction` for the case where an action may not be explicitly typed.

Enhancement to #2467 
Addresses an issue discovered in a failed build for DefinitelyTyped/DefinitelyTyped#17777