### PR TITLE
Make ReducersMapObject more typesafe

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -59,8 +59,8 @@ export type Reducer<S> = (state: S, action: AnyAction) => S;
 /**
  * Object whose values correspond to different reducer functions.
  */
-export interface ReducersMapObject {
-  [key: string]: Reducer<any>;
+export type ReducersMapObject<S = any> = {
+  [P in keyof S]?: Reducer<S[P]>;
 }
 
 /**
@@ -81,7 +81,7 @@ export interface ReducersMapObject {
  * @returns A reducer function that invokes every reducer inside the passed
  *   object, and builds a state object with the same shape.
  */
-export function combineReducers<S>(reducers: ReducersMapObject): Reducer<S>;
+export function combineReducers<S>(reducers: ReducersMapObject<S>): Reducer<S>;
 
 
 /* store */


### PR DESCRIPTION
This will catch misspelling of properties inside combineReducers and complain if reducers don't reduce the correct child state type.

("S = any" for backwards compatibility)