### PR TITLE
fix shopping-cart example to show inventory

### DIFF
--- a/examples/shopping-cart/src/components/Product.js
+++ b/examples/shopping-cart/src/components/Product.js
@@ -1,15 +1,15 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const Product = ({ price, quantity, title }) => (
+const Product = ({ price, inventory, title }) => (
   <div>
-    {title} - &#36;{price}{quantity ? ` x ${quantity}` : null}
+    {title} - &#36;{price}{inventory ? ` x ${inventory}` : null}
   </div>
 )
 
 Product.propTypes = {
   price: PropTypes.number,
-  quantity: PropTypes.number,
+  inventory: PropTypes.number,
   title: PropTypes.string
 }
 

--- a/examples/shopping-cart/src/components/Product.spec.js
+++ b/examples/shopping-cart/src/components/Product.spec.js
@@ -18,9 +18,9 @@ describe('Product component', () => {
     expect(component.text()).toBe('Test Product - $9.99')
   })
 
-  describe('when given quantity', () => {
-    it('should render title, price, and quantity', () => {
-      const { component } = setup({ title: 'Test Product', price: 9.99, quantity: 6 })
+  describe('when given inventory', () => {
+    it('should render title, price, and inventory', () => {
+      const { component } = setup({ title: 'Test Product', price: 9.99, inventory: 6 })
       expect(component.text()).toBe('Test Product - $9.99 x 6')
     })
   })

--- a/examples/shopping-cart/src/components/ProductItem.js
+++ b/examples/shopping-cart/src/components/ProductItem.js
@@ -6,7 +6,8 @@ const ProductItem = ({ product, onAddToCartClicked }) => (
   <div style={{ marginBottom: 20 }}>
     <Product
       title={product.title}
-      price={product.price} />
+      price={product.price}
+      inventory={product.inventory} />
     <button
       onClick={onAddToCartClicked}
       disabled={product.inventory > 0 ? '' : 'disabled'}>

--- a/examples/shopping-cart/src/components/ProductItem.spec.js
+++ b/examples/shopping-cart/src/components/ProductItem.spec.js
@@ -33,7 +33,7 @@ describe('ProductItem component', () => {
 
   it('should render product', () => {
     const { product } = setup(productProps)
-    expect(product.props()).toEqual({ title: 'Product 1', price: 9.99 })
+    expect(product.props()).toEqual({ title: 'Product 1', price: 9.99, inventory: 6 })
   })
 
   it('should render Add To Cart message', () => {


### PR DESCRIPTION
I noticed at https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/shopping-cart that the number of items left in stock isn't shown; I dug around and figured out that the `inventory` prop wasn't being passed down