### PR TITLE
Make middleware API dispatch pass through all call arguments

### DIFF
--- a/src/applyMiddleware.js
+++ b/src/applyMiddleware.js
@@ -24,7 +24,7 @@ export default function applyMiddleware(...middlewares) {
 
     const middlewareAPI = {
       getState: store.getState,
-      dispatch: (action) => dispatch(action)
+      dispatch: (...args) => dispatch(...args)
     }
     chain = middlewares.map(middleware => middleware(middlewareAPI))
     dispatch = compose(...chain)(store.dispatch)

--- a/test/applyMiddleware.spec.js
+++ b/test/applyMiddleware.spec.js
@@ -92,6 +92,26 @@ describe('applyMiddleware', () => {
     })
   })
 
+    it('passes through all arguments of dispatch calls from within middleware', () => {
+        const spy = jest.fn()
+        const testCallArgs = ['test']
+        function multiArgMiddleware() {
+            return next => (action, callArgs) => {
+                if (Array.isArray(callArgs)) {
+                    return action(...callArgs)
+                }
+                return next(action)
+            }
+        }
+        function dummyMiddleware({ dispatch }) {
+            return next => action => dispatch(action, testCallArgs)
+        }
+
+        const store = createStore(reducers.todos, applyMiddleware(multiArgMiddleware, dummyMiddleware))
+        store.dispatch(spy)
+        expect(spy.mock.calls[0]).toEqual(testCallArgs)
+    })
+
   it('keeps unwrapped dispatch available while middleware is initializing', () => {
     // This is documenting the existing behavior in Redux 3.x.
     // We plan to forbid this in Redux 4.x.


### PR DESCRIPTION
As discussed in #2501, there's a bit of inconsistency as you can call `store.dispatch` with multiple arguments just fine, but in context of middlewares (say, thunk) only the first one is passed through. This PR tries to fix that.