### PR TITLE
Revamp TypeScript typing with more type safety

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -46,14 +46,14 @@ export interface Action<T = any> {
  * @template S The type of state consumed and produced by this reducer.
  * @template A The type of actions the reducer can potentially respond to.
  */
-export type Reducer<S = {}, A extends Action = Action> = (state: S | undefined, action: A) => S;
+export type Reducer<S = any, A extends Action = Action> = (state: S | undefined, action: A) => S;
 
 /**
  * Object whose values correspond to different reducer functions.
  *
  * @template A The type of actions the reducers can potentially respond to.
  */
-export type ReducersMapObject<S = {}, A extends Action = Action> = {
+export type ReducersMapObject<S = any, A extends Action = Action> = {
   [K in keyof S]: Reducer<S[K], A>;
 }
 
@@ -121,7 +121,7 @@ export interface Unsubscribe {
  * @template A the type of actions which may be dispatched by this store.
  * @template N The type of non-actions which may be dispatched by this store.
  */
-export interface Store<S = {}, A extends Action = Action, N = never> {
+export interface Store<S = any, A extends Action = Action, N = never> {
   /**
    * Dispatches an action. It is the only way to trigger a state change.
    *

--- a/index.d.ts
+++ b/index.d.ts
@@ -75,7 +75,7 @@ export type ReducersMapObject<S = {}, A extends Action = Action> = {
  * @returns A reducer function that invokes every reducer inside the passed
  *   object, and builds a state object with the same shape.
  */
-export function combineReducers<S, A extends Action>(reducers: ReducersMapObject<S, A>): Reducer<S, A>;
+export function combineReducers<S, A extends Action = Action>(reducers: ReducersMapObject<S, A>): Reducer<S, A>;
 
 
 /* store */

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,4 @@
+
 /**
  * An *action* is a plain object that represents an intention to change the
  * state. Actions are the only way to get data into the store. Any data,
@@ -12,11 +13,12 @@
  * Other than `type`, the structure of an action object is really up to you.
  * If you're interested, check out Flux Standard Action for recommendations on
  * how actions should be constructed.
+ *
+ * @template T the type of the action's `type` tag.
  */
-export interface Action {
-  type: any;
+export interface Action<T = any> {
+  type: T;
 }
-
 
 /* reducers */
 
@@ -41,15 +43,18 @@ export interface Action {
  *
  * *Do not put API calls into reducers.*
  *
- * @template S State object type.
+ * @template S The type of state consumed and produced by this reducer.
+ * @template A The type of actions the reducer can potentially respond to.
  */
-export type Reducer<S> = <A extends Action>(state: S | undefined, action: A) => S;
+export type Reducer<S = {}, A extends Action = Action> = (state: S | undefined, action: A) => S;
 
 /**
  * Object whose values correspond to different reducer functions.
+ *
+ * @template A The type of actions the reducers can potentially respond to.
  */
-export type ReducersMapObject<S> = {
-  [K in keyof S]: Reducer<S[K]>;
+export type ReducersMapObject<S = {}, A extends Action = Action> = {
+  [K in keyof S]: Reducer<S[K], A>;
 }
 
 /**
@@ -70,7 +75,7 @@ export type ReducersMapObject<S> = {
  * @returns A reducer function that invokes every reducer inside the passed
  *   object, and builds a state object with the same shape.
  */
-export function combineReducers<S>(reducers: ReducersMapObject<S>): Reducer<S>;
+export function combineReducers<S, A extends Action>(reducers: ReducersMapObject<S, A>): Reducer<S, A>;
 
 
 /* store */
@@ -92,9 +97,12 @@ export function combineReducers<S>(reducers: ReducersMapObject<S>): Reducer<S>;
  * function to handle async actions in addition to actions. Middleware may
  * transform, delay, ignore, or otherwise interpret actions or async actions
  * before passing them to the next middleware.
+ *
+ * @template S unused, here only for backwards compatibility.
+ * @template D the type of things (actions or otherwise) which may be dispatched.
  */
-export interface Dispatch<S> {
-    <A extends Action>(action: A): A;
+export interface Dispatch<S = any, D = Action> {
+    <A extends D>(action: A): A;
 }
 
 /**
@@ -109,9 +117,11 @@ export interface Unsubscribe {
  * There should only be a single store in a Redux app, as the composition
  * happens on the reducer level.
  *
- * @template S State object type.
+ * @template S The type of state held by this store.
+ * @template A the type of actions which may be dispatched by this store.
+ * @template N The type of non-actions which may be dispatched by this store.
  */
-export interface Store<S> {
+export interface Store<S = {}, A extends Action = Action, N = never> {
   /**
    * Dispatches an action. It is the only way to trigger a state change.
    *
@@ -138,7 +148,7 @@ export interface Store<S> {
    * Note that, if you use a custom middleware, it may wrap `dispatch()` to
    * return something else (for example, a Promise you can await).
    */
-  dispatch: Dispatch<S>;
+  dispatch: Dispatch<any, A | N>;
 
   /**
    * Reads the state tree managed by the store.
@@ -182,7 +192,7 @@ export interface Store<S> {
    *
    * @param nextReducer The reducer for the store to use instead.
    */
-  replaceReducer(nextReducer: Reducer<S>): void;
+  replaceReducer(nextReducer: Reducer<S, A>): void;
 }
 
 /**
@@ -191,11 +201,13 @@ export interface Store<S> {
  * `createStore(reducer, preloadedState)` exported from the Redux package, from
  * store creators that are returned from the store enhancers.
  *
- * @template S State object type.
+ * @template S The type of state to be held by the store.
+ * @template A The type of actions which may be dispatched.
+ * @template D The type of all things which may be dispatched.
  */
 export interface StoreCreator {
-  <S>(reducer: Reducer<S>, enhancer?: StoreEnhancer<S>): Store<S>;
-  <S>(reducer: Reducer<S>, preloadedState: S, enhancer?: StoreEnhancer<S>): Store<S>;
+  <S, A extends Action, N>(reducer: Reducer<S, A>, enhancer?: StoreEnhancer<N>): Store<S, A, N>;
+  <S, A extends Action, N>(reducer: Reducer<S, A>, preloadedState: S, enhancer?: StoreEnhancer<N>): Store<S, A, N>;
 }
 
 /**
@@ -215,10 +227,11 @@ export interface StoreCreator {
  * provided by the developer tools. It is what makes time travel possible
  * without the app being aware it is happening. Amusingly, the Redux
  * middleware implementation is itself a store enhancer.
+ *
  */
-export type StoreEnhancer<S> = (next: StoreEnhancerStoreCreator<S>) => StoreEnhancerStoreCreator<S>;
-export type GenericStoreEnhancer = <S>(next: StoreEnhancerStoreCreator<S>) => StoreEnhancerStoreCreator<S>;
-export type StoreEnhancerStoreCreator<S> = (reducer: Reducer<S>, preloadedState?: S) => Store<S>;
+export type StoreEnhancer<N = never> = (next: StoreEnhancerStoreCreator<N>) => StoreEnhancerStoreCreator<N>;
+export type GenericStoreEnhancer<N = never> = StoreEnhancer<N>;
+export type StoreEnhancerStoreCreator<N = never> = <S = any, A extends Action = Action>(reducer: Reducer<S, A>, preloadedState?: S) => Store<S, A, N>;
 
 /**
  * Creates a Redux store that holds the state tree.
@@ -253,8 +266,8 @@ export const createStore: StoreCreator;
 
 /* middleware */
 
-export interface MiddlewareAPI<S> {
-  dispatch: Dispatch<S>;
+export interface MiddlewareAPI<S = any, D = Action> {
+  dispatch: Dispatch<any, D>;
   getState(): S;
 }
 
@@ -268,7 +281,7 @@ export interface MiddlewareAPI<S> {
  * asynchronous API call into a series of synchronous actions.
  */
 export interface Middleware {
-  <S>(api: MiddlewareAPI<S>): (next: Dispatch<S>) => Dispatch<S>;
+  <S = any, D = Action>(api: MiddlewareAPI<S, D>): (next: Dispatch<any, D>) => Dispatch<any, D>;
 }
 
 /**
@@ -317,8 +330,8 @@ export interface ActionCreator<A> {
 /**
  * Object whose values are action creator functions.
  */
-export interface ActionCreatorsMapObject {
-  [key: string]: ActionCreator<any>;
+export interface ActionCreatorsMapObject<A = any> {
+  [key: string]: ActionCreator<A>;
 }
 
 /**
@@ -340,19 +353,19 @@ export interface ActionCreatorsMapObject {
  *   creator wrapped into the `dispatch` call. If you passed a function as
  *   `actionCreator`, the return value will also be a single function.
  */
-export function bindActionCreators<A extends ActionCreator<any>>(actionCreator: A, dispatch: Dispatch<any>): A;
+export function bindActionCreators<A, C extends ActionCreator<A>>(actionCreator: C, dispatch: Dispatch<any, A>): C;
 
 export function bindActionCreators<
   A extends ActionCreator<any>,
   B extends ActionCreator<any>
-  >(actionCreator: A, dispatch: Dispatch<any>): B;
+  >(actionCreator: A, dispatch: Dispatch<any, any>): B;
 
-export function bindActionCreators<M extends ActionCreatorsMapObject>(actionCreators: M, dispatch: Dispatch<any>): M;
+export function bindActionCreators<A, M extends ActionCreatorsMapObject<A>>(actionCreators: M, dispatch: Dispatch<any, A>): M;
 
 export function bindActionCreators<
-  M extends ActionCreatorsMapObject,
-  N extends ActionCreatorsMapObject
-  >(actionCreators: M, dispatch: Dispatch<any>): N;
+  M extends ActionCreatorsMapObject<any>,
+  N extends ActionCreatorsMapObject<any>
+  >(actionCreators: M, dispatch: Dispatch<any, any>): N;
 
 
 /* compose */

--- a/index.d.ts
+++ b/index.d.ts
@@ -101,7 +101,7 @@ export function combineReducers<S, A extends Action = Action>(reducers: Reducers
  * @template S unused, here only for backwards compatibility.
  * @template D the type of things (actions or otherwise) which may be dispatched.
  */
-export interface Dispatch<S = any, D = Action> {
+export interface Dispatch<D = Action> {
     <A extends D>(action: A): A;
 }
 
@@ -148,7 +148,7 @@ export interface Store<S = any, A extends Action = Action, N = never> {
    * Note that, if you use a custom middleware, it may wrap `dispatch()` to
    * return something else (for example, a Promise you can await).
    */
-  dispatch: Dispatch<any, A | N>;
+  dispatch: Dispatch<A | N>;
 
   /**
    * Reads the state tree managed by the store.
@@ -267,7 +267,7 @@ export const createStore: StoreCreator;
 /* middleware */
 
 export interface MiddlewareAPI<S = any, D = Action> {
-  dispatch: Dispatch<any, D>;
+  dispatch: Dispatch<D>;
   getState(): S;
 }
 
@@ -281,7 +281,7 @@ export interface MiddlewareAPI<S = any, D = Action> {
  * asynchronous API call into a series of synchronous actions.
  */
 export interface Middleware {
-  <S = any, D = Action>(api: MiddlewareAPI<S, D>): (next: Dispatch<any, D>) => Dispatch<any, D>;
+  <S = any, D = Action>(api: MiddlewareAPI<S, D>): (next: Dispatch<D>) => Dispatch<D>;
 }
 
 /**
@@ -353,19 +353,19 @@ export interface ActionCreatorsMapObject<A = any> {
  *   creator wrapped into the `dispatch` call. If you passed a function as
  *   `actionCreator`, the return value will also be a single function.
  */
-export function bindActionCreators<A, C extends ActionCreator<A>>(actionCreator: C, dispatch: Dispatch<any, A>): C;
+export function bindActionCreators<A, C extends ActionCreator<A>>(actionCreator: C, dispatch: Dispatch<A>): C;
 
 export function bindActionCreators<
   A extends ActionCreator<any>,
   B extends ActionCreator<any>
-  >(actionCreator: A, dispatch: Dispatch<any, any>): B;
+  >(actionCreator: A, dispatch: Dispatch<any>): B;
 
-export function bindActionCreators<A, M extends ActionCreatorsMapObject<A>>(actionCreators: M, dispatch: Dispatch<any, A>): M;
+export function bindActionCreators<A, M extends ActionCreatorsMapObject<A>>(actionCreators: M, dispatch: Dispatch<A>): M;
 
 export function bindActionCreators<
   M extends ActionCreatorsMapObject<any>,
   N extends ActionCreatorsMapObject<any>
-  >(actionCreators: M, dispatch: Dispatch<any, any>): N;
+  >(actionCreators: M, dispatch: Dispatch<any>): N;
 
 
 /* compose */

--- a/index.d.ts
+++ b/index.d.ts
@@ -98,7 +98,6 @@ export function combineReducers<S, A extends Action = Action>(reducers: Reducers
  * transform, delay, ignore, or otherwise interpret actions or async actions
  * before passing them to the next middleware.
  *
- * @template S unused, here only for backwards compatibility.
  * @template D the type of things (actions or otherwise) which may be dispatched.
  */
 export interface Dispatch<D = Action> {

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "rollup-plugin-replace": "^1.1.1",
     "rollup-plugin-uglify": "^1.0.1",
     "rxjs": "^5.0.0-beta.6",
-    "typescript": "^2.1.0",
+    "typescript": "^2.4.2",
     "typescript-definition-tester": "0.0.5"
   },
   "npmName": "redux",

--- a/test/typescript/compose.ts
+++ b/test/typescript/compose.ts
@@ -36,4 +36,4 @@ const t11: number = compose(stringToNumber, numberToString, stringToNumber,
 
 
 const funcs = [stringToNumber, numberToString, stringToNumber];
-const t12 = compose(...funcs)('bar', 42, true);
+const t12 = compose(...funcs)('bar');

--- a/test/typescript/reducers.ts
+++ b/test/typescript/reducers.ts
@@ -11,15 +11,15 @@ interface AddTodoAction extends Action {
 }
 
 
-const todosReducer: Reducer<TodosState> = (state: TodosState,
-                                           action: Action): TodosState => {
-  switch (action.type) {
-    case 'ADD_TODO':
-      return [...state, (<AddTodoAction>action).text]
-    default:
-      return state
+const todosReducer: Reducer<TodosState, AddTodoAction> =
+  (state = [], action) => {
+    switch (action.type) {
+      case 'ADD_TODO':
+        return [...state, action.text]
+      default:
+        return state
+    }
   }
-}
 
 const todosState: TodosState = todosReducer([], {
   type: 'ADD_TODO',
@@ -47,7 +47,8 @@ type RootState = {
   counter: CounterState;
 }
 
-const rootReducer: Reducer<RootState> = combineReducers({
+
+const rootReducer = combineReducers<RootState, Action | AddTodoAction>({
   todos: todosReducer,
   counter: counterReducer,
 })

--- a/test/typescript/store.ts
+++ b/test/typescript/store.ts
@@ -15,7 +15,7 @@ const reducer: Reducer<State> = (state: State, action: Action): State => {
 
 /* createStore */
 
-const store: Store<State> = createStore<State>(reducer);
+const store: Store<State> = createStore(reducer);
 
 const storeWithPreloadedState: Store<State> = createStore(reducer, {
   todos: []


### PR DESCRIPTION
This fixes many issues with the current TypeScript typings, while remaining mostly* backwards compatible:

- Add a type parameter to `Action` tracking the type of the `type` tag.
- Stop using the irrelevant state type param on `Dispatch` (but keep it around for backwards compatibility).
- Add a type parameter to `Dispatch` which is the type of things which may be dispatched (previously `Dispatch` had a polymorphic apply which allowed anything to be dispatched).
- Add type parameters `A` and `N` to `Store` which respectively track the actions it may dispatch and all other non-action things which may be dispatched. Then its `dispatch` method can take `A | N`.
- Add a type parameter `A` to `Reducer` which tracks the actions it understands, instead of just using `AnyAction`.
- Use [type parameter defaulting](https://blog.mariusschulz.com/2017/06/02/typescript-2-3-generic-parameter-defaults) everywhere to make this as backwards-compatible as possible.

With these changes, type inference for a lot of redux functions improves dramatically, and thus we get more type safety with less effort. I won't pretend these are perfect; in particular I think the middleware/enhancer functions could use some work to make the `N` variables accumulate as appropriate, but it's hopefully a step in the right direction.

As part of this, upgraded the TypeScript dependency to `^2.4.2`.

\* As you can see from some of the modified testcases, in a few rare cases it's necessary to modify type parameter annotations, e.g. when calling `combineReducers`.