### PR TITLE
Annotate action.js headings

### DIFF
--- a/docs/advanced/AsyncActions.md
+++ b/docs/advanced/AsyncActions.md
@@ -47,7 +47,7 @@ We'll use separate types in this tutorial.
 
 Let's start by defining the several synchronous action types and action creators we need in our example app. Here, the user can select a subreddit to display:
 
-#### `actions.js`
+#### `actions.js` (Synchronous)
 
 ```js
 export const SELECT_SUBREDDIT = 'SELECT_SUBREDDIT'
@@ -309,7 +309,7 @@ When an action creator returns a function, that function will get executed by th
 
 We can still define these special thunk action creators inside our `actions.js` file:
 
-#### `actions.js`
+#### `actions.js` (Asynchronous)
 
 ```js
 import fetch from 'isomorphic-fetch'
@@ -427,7 +427,7 @@ store
 
 The nice thing about thunks is that they can dispatch results of each other:
 
-#### `actions.js`
+#### `actions.js` (with `fetch`)
 
 ```js
 import fetch from 'isomorphic-fetch'


### PR DESCRIPTION
As it stands, there are multiple headings entitled `action.js`. On the official docs page, it offers a anchor to each heading, but this doesn't work because it will just match the `id` of the first `#### action.js` heading. This change adds some context, which will—in turn—make each heading unique.