### PR TITLE
TodoMVC example: add items in the correct order

### DIFF
--- a/examples/todomvc/src/reducers/todos.js
+++ b/examples/todomvc/src/reducers/todos.js
@@ -12,12 +12,12 @@ export default function todos(state = initialState, action) {
   switch (action.type) {
     case ADD_TODO:
       return [
+        ...state,
         {
           id: state.reduce((maxId, todo) => Math.max(todo.id, maxId), -1) + 1,
           completed: false,
           text: action.text
-        },
-        ...state
+        }
       ]
 
     case DELETE_TODO:

--- a/examples/todomvc/src/reducers/todos.spec.js
+++ b/examples/todomvc/src/reducers/todos.spec.js
@@ -41,26 +41,27 @@ describe('todos reducer', () => {
       })
     ).toEqual([
       {
-        text: 'Run the tests',
-        completed: false,
-        id: 1
-      }, {
         text: 'Use Redux',
         completed: false,
         id: 0
+      },
+      {
+        text: 'Run the tests',
+        completed: false,
+        id: 1
       }
     ])
 
     expect(
       todos([
         {
-          text: 'Run the tests',
-          completed: false,
-          id: 1
-        }, {
           text: 'Use Redux',
           completed: false,
           id: 0
+        }, {
+          text: 'Run the tests',
+          completed: false,
+          id: 1
         }
       ], {
         type: types.ADD_TODO,
@@ -68,17 +69,19 @@ describe('todos reducer', () => {
       })
     ).toEqual([
       {
-        text: 'Fix the tests',
-        completed: false,
-        id: 2
-      }, {
-        text: 'Run the tests',
-        completed: false,
-        id: 1
-      }, {
         text: 'Use Redux',
         completed: false,
         id: 0
+      },
+      {
+        text: 'Run the tests',
+        completed: false,
+        id: 1
+      },
+      {
+        text: 'Fix the tests',
+        completed: false,
+        id: 2
       }
     ])
   })
@@ -87,13 +90,14 @@ describe('todos reducer', () => {
     expect(
       todos([
         {
-          text: 'Run the tests',
-          completed: false,
-          id: 1
-        }, {
           text: 'Use Redux',
           completed: false,
           id: 0
+        },
+        {
+          text: 'Run the tests',
+          completed: false,
+          id: 1
         }
       ], {
         type: types.DELETE_TODO,
@@ -271,13 +275,13 @@ describe('todos reducer', () => {
       ])
     ).toEqual([
       {
-        text: 'Write more tests',
-        completed: false,
-        id: 2
-      }, {
         text: 'Write tests',
         completed: false,
         id: 1
+      }, {
+        text: 'Write more tests',
+        completed: false,
+        id: 2
       }
     ])
   })


### PR DESCRIPTION
New TODO items must be added to the bottom instead of at the top.

Closes #2574.