### PR TITLE
removed isRequired from todos, otherwise demo was broken

### DIFF
--- a/examples/todos/src/components/TodoList.js
+++ b/examples/todos/src/components/TodoList.js
@@ -19,7 +19,7 @@ TodoList.propTypes = {
     id: PropTypes.number.isRequired,
     completed: PropTypes.bool.isRequired,
     text: PropTypes.string.isRequired
-  }).isRequired).isRequired,
+  }).isRequired),
   onTodoClick: PropTypes.func.isRequired
 }
 


### PR DESCRIPTION
With "isRequired" prop, assigned to todos, the demo will fail, as initially there are no todos, when the app starts