### PR TITLE
[TypeScript] Add Dispatch default any type parameter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -104,7 +104,7 @@ export function combineReducers<S>(reducers: ReducersMapObject): Reducer<S>;
  * transform, delay, ignore, or otherwise interpret actions or async actions
  * before passing them to the next middleware.
  */
-export interface Dispatch<S> {
+export interface Dispatch<S = any> {
     <A extends Action>(action: A): A;
 }
 


### PR DESCRIPTION
Since` <S>` in generic `Dispatch` is not used in its interface definition. 
And `Dispatch<any>` pattern is commonly used in TypeScript redux projects.