### PR TITLE
Add listenerID to correctly remove subscription when listener was subscribed repeatedly

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -11,6 +11,8 @@ export const ActionTypes = {
   INIT: '@@redux/INIT'
 }
 
+let listenerID = 1
+
 /**
  * Creates a Redux store that holds the state tree.
  * The only way to change the data in the store is to call `dispatch()` on it.
@@ -104,9 +106,13 @@ export default function createStore(reducer, preloadedState, enhancer) {
     }
 
     let isSubscribed = true
+    let id = listenerID++
 
     ensureCanMutateNextListeners()
-    nextListeners.push(listener)
+    nextListeners.push({
+      id,
+      func: listener
+    })
 
     return function unsubscribe() {
       if (!isSubscribed) {
@@ -116,7 +122,7 @@ export default function createStore(reducer, preloadedState, enhancer) {
       isSubscribed = false
 
       ensureCanMutateNextListeners()
-      const index = nextListeners.indexOf(listener)
+      const index = nextListeners.findIndex(listener => listener.id === id)
       nextListeners.splice(index, 1)
     }
   }
@@ -175,7 +181,7 @@ export default function createStore(reducer, preloadedState, enhancer) {
     const listeners = currentListeners = nextListeners
     for (let i = 0; i < listeners.length; i++) {
       const listener = listeners[i]
-      listener()
+      listener.func.call(undefined)
     }
 
     return action

--- a/test/createStore.spec.js
+++ b/test/createStore.spec.js
@@ -236,6 +236,27 @@ describe('createStore', () => {
     expect(listenerB.mock.calls.length).toBe(2)
   })
 
+  it('correctly remove subscription when listener was subscribed repeatedly', () => {
+    let testString = ''
+    const store = createStore(reducers.todos)
+    const listenerA = () => testString += 'A'
+    const listenerB = () => testString += 'B'
+
+    store.subscribe(listenerA)
+    store.subscribe(listenerB)
+    let unsubscribeA2 = store.subscribe(listenerA)
+
+    store.dispatch(unknownAction())
+    expect(testString).toBe('ABA')
+
+    testString = ''
+
+    unsubscribeA2()
+    store.dispatch(unknownAction())
+    expect(testString).toBe('AB')
+
+  })
+
   it('only removes listener once when unsubscribe is called', () => {
     const store = createStore(reducers.todos)
     const listenerA = jest.fn()


### PR DESCRIPTION
```javascript
const index = nextListeners.indexOf(listener)
nextListeners.splice(index, 1)
```

In createStore.js, use `indexOf(listener)` will only return the first listener when listener was subscribed multiply. If you unsubscribe a listener which isn't the first one, the first one will 
 be removed and listeners' execute sequence will be disorder.

This PR add listenerID to help correctly remove the subscription in this scenario.

bug demo jsfiddle: https://jsfiddle.net/jin5354/m3ahmhL9/