### PR TITLE
Improve combineReducers type def with keyof

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -59,9 +59,9 @@ export type Reducer<S> = (state: S, action: AnyAction) => S;
 /**
  * Object whose values correspond to different reducer functions.
  */
-export interface ReducersMapObject {
-  [key: string]: Reducer<any>;
-}
+export type ReducersMapObject<S extends { [key: string]: any }> = {
+  [K in keyof S]: Reducer<S[K]>;
+};
 
 /**
  * Turns an object whose values are different reducer functions, into a single
@@ -81,7 +81,7 @@ export interface ReducersMapObject {
  * @returns A reducer function that invokes every reducer inside the passed
  *   object, and builds a state object with the same shape.
  */
-export function combineReducers<S>(reducers: ReducersMapObject): Reducer<S>;
+export function combineReducers<S>(reducers: ReducersMapObject<S>): Reducer<S>;
 
 
 /* store */

--- a/index.d.ts
+++ b/index.d.ts
@@ -383,7 +383,6 @@ type Func3<T1, T2, T3, R> = (a1: T1, a2: T2, a3: T3, ...args: any[]) => R;
  *   to left. For example, `compose(f, g, h)` is identical to doing
  *   `(...args) => f(g(h(...args)))`.
  */
-export function compose(): <R>(a: R) => R;
 
 export function compose<F extends Function>(f: F): F;
 

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "rollup-plugin-replace": "^1.1.1",
     "rollup-plugin-uglify": "^2.0.1",
     "rxjs": "^5.0.0-beta.6",
-    "typescript": "^1.8.0",
+    "typescript": "^2.5.2",
     "typescript-definition-tester": "0.0.4"
   },
   "npmName": "redux",


### PR DESCRIPTION
With this change, the following code will _now_ fail the TypeScript static check. At present it does not fail.

```ts
type State = {
  a: A;
  b: B;
  c: C;
};

function aReducer(state: A, action: AnyAction): A;
function bReducer(state: B, action: AnyAction): B;
function cReducer(state: C, action: AnyAction): C;

// should fail: no key "c" using cReducer
combineReducers<State>({
  a: aReducer,
  b: bReducer
});

// should fail: "a" is using wrong reducer
combineReducers<State>({
  a: bReducer,
  b: bReducer,
  c: cReducer
});
```

 Previously, you could have passed _any_ object to `combineReducers` and the checker was OK with it. e.g.

```ts
combineReducers<State>({
  fart: () => { return null };
});
```

The definition for compose was broken for TypeScript @ 2.X so I fixed that as well by removing [this line](https://github.com/reactjs/redux/pull/2607/files#diff-b52768974e6bc0faccb7d4b75b162c99L386).