### PR TITLE
Add tests and move routes within <Router> for the real-world example

### DIFF
--- a/examples/real-world/package.json
+++ b/examples/real-world/package.json
@@ -26,6 +26,6 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "eject": "react-scripts eject",
-    "test": "react-scripts test"
+    "test": "react-scripts test --env=jsdom"
   }
 }

--- a/examples/real-world/src/containers/Root.dev.js
+++ b/examples/real-world/src/containers/Root.dev.js
@@ -13,9 +13,9 @@ const Root = ({ store }) => (
       <div>
         <Route path="/" component={App} />
         <Route path="/:login/:name"
-              component={RepoPage} />
+               component={RepoPage} />
         <Route path="/:login"
-              component={UserPage} />
+               component={UserPage} />
         <DevTools />
       </div>
     </Router>

--- a/examples/real-world/src/containers/Root.dev.js
+++ b/examples/real-world/src/containers/Root.dev.js
@@ -2,21 +2,23 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Provider } from 'react-redux'
 import DevTools from './DevTools'
-import { Route } from 'react-router-dom'
+import { BrowserRouter as Router, Route } from 'react-router-dom'
 import App from './App'
 import UserPage from './UserPage'
 import RepoPage from './RepoPage'
 
 const Root = ({ store }) => (
   <Provider store={store}>
-    <div>
-      <Route path="/" component={App} />
-      <Route path="/:login/:name"
-             component={RepoPage} />
-      <Route path="/:login"
-             component={UserPage} />
-      <DevTools />
-    </div>
+    <Router>
+      <div>
+        <Route path="/" component={App} />
+        <Route path="/:login/:name"
+              component={RepoPage} />
+        <Route path="/:login"
+              component={UserPage} />
+        <DevTools />
+      </div>
+    </Router>
   </Provider>
 )
 

--- a/examples/real-world/src/containers/Root.dev.spec.js
+++ b/examples/real-world/src/containers/Root.dev.spec.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import Root from './Root.dev'
+import configureStore from '../store/configureStore'
+
+const store = configureStore()
+
+it('renders without crashing', () => {
+  const div = document.createElement('div')
+  ReactDOM.render(<Root store={store} />, div)
+})

--- a/examples/real-world/src/containers/Root.prod.js
+++ b/examples/real-world/src/containers/Root.prod.js
@@ -1,22 +1,27 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Provider } from 'react-redux'
-import { Route } from 'react-router-dom'
+import { BrowserRouter as Router, Route } from 'react-router-dom'
 import App from './App'
 import UserPage from './UserPage'
 import RepoPage from './RepoPage'
 
 const Root = ({ store }) => (
   <Provider store={store}>
-    <Route path="/" component={App} />
-      <Route path="/:login/:name"
-             component={RepoPage} />
-      <Route path="/:login"
-             component={UserPage} />
+    <Router>
+      <div>
+        <Route path="/" component={App} />
+        <Route path="/:login/:name"
+              component={RepoPage} />
+        <Route path="/:login"
+              component={UserPage} />
+      </div>
+    </Router>
   </Provider>
 )
 
 Root.propTypes = {
   store: PropTypes.object.isRequired,
 }
+
 export default Root

--- a/examples/real-world/src/containers/Root.prod.js
+++ b/examples/real-world/src/containers/Root.prod.js
@@ -12,9 +12,9 @@ const Root = ({ store }) => (
       <div>
         <Route path="/" component={App} />
         <Route path="/:login/:name"
-              component={RepoPage} />
+               component={RepoPage} />
         <Route path="/:login"
-              component={UserPage} />
+               component={UserPage} />
       </div>
     </Router>
   </Provider>

--- a/examples/real-world/src/containers/Root.prod.spec.js
+++ b/examples/real-world/src/containers/Root.prod.spec.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import Root from './Root.prod'
+import configureStore from '../store/configureStore'
+
+const store = configureStore()
+
+it('renders without crashing', () => {
+  const div = document.createElement('div')
+  ReactDOM.render(<Root store={store} />, div)
+})

--- a/examples/real-world/src/index.js
+++ b/examples/real-world/src/index.js
@@ -1,14 +1,11 @@
 import React from 'react'
 import { render } from 'react-dom'
-import { BrowserRouter as Router } from 'react-router-dom'
 import Root from './containers/Root'
 import configureStore from './store/configureStore'
 
 const store = configureStore()
 
 render(
-  <Router>
-    <Root store={store} />
-  </Router>,
+  <Root store={store} />,
   document.getElementById('root')
 )


### PR DESCRIPTION
My first PR to an OSS project! 🎉 

**Potential issue**
- Writing a render test of the `<Root/>` component in the "real-world" example yields the following error message
```
Invariant Violation: You should not use <Route> or withRouter() outside a <Router>
```
While there currently aren't any tests rendering the Root component, it may be worth fixing the structure of the components to avoid future questions on why a render test of the `<Root/ >` component fails.

**Proposed changes**
- Move Routes within `<Router>` - followed this guide [https://github.com/reactjs/redux/blob/master/docs/advanced/UsageWithReactRouter.md](https://github.com/reactjs/redux/blob/master/docs/advanced/UsageWithReactRouter.md)
- Add tests - I had originally mocked out the store with `redux-mock-store` but then received a console.error in regards to DevTools not being properly configured.

I'm not sure if my difficulties testing the Root component were a symptom of not having the `<Provider>` within `src/index.js` or whether I wasn't mocking something correctly - most examples I've seen have the `<Provider>` within `src/index.js` without any test files.