### PR TITLE
use mapped type for combineReducers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -59,8 +59,8 @@ export type Reducer<S> = (state: S, action: AnyAction) => S;
 /**
  * Object whose values correspond to different reducer functions.
  */
-export interface ReducersMapObject {
-  [key: string]: Reducer<any>;
+export type ReducersMapObject<TState> = {
+  [key in keyof TState]: Reducer<TState[key]>;
 }
 
 /**
@@ -81,7 +81,7 @@ export interface ReducersMapObject {
  * @returns A reducer function that invokes every reducer inside the passed
  *   object, and builds a state object with the same shape.
  */
-export function combineReducers<S>(reducers: ReducersMapObject): Reducer<S>;
+export function combineReducers<S>(reducers: ReducersMapObject<S>): Reducer<S>;
 
 
 /* store */


### PR DESCRIPTION
Enforces using valid property names for reducers, and having the reducers return valid objects. 

Uses TypeScript 2.x feature https://www.typescriptlang.org/docs/handbook/advanced-types.html#mapped-types