### PR TITLE
Fix Broken "toggle-all" in TodoMVC Example

### DIFF
--- a/examples/todomvc/src/components/MainSection.js
+++ b/examples/todomvc/src/components/MainSection.js
@@ -30,10 +30,13 @@ export default class MainSection extends Component {
     const { todos, actions } = this.props
     if (todos.length > 0) {
       return (
-        <input className="toggle-all"
-               type="checkbox"
-               checked={completedCount === todos.length}
-               onChange={actions.completeAll} />
+        <span>
+          <input className="toggle-all"
+                 type="checkbox"
+                 checked={completedCount === todos.length}
+                 />
+          <label onClick={actions.completeAll}/>
+        </span>
       )
     }
   }

--- a/examples/todomvc/src/components/MainSection.spec.js
+++ b/examples/todomvc/src/components/MainSection.spec.js
@@ -49,7 +49,7 @@ describe('components', () => {
     describe('toggle all input', () => {
       it('should render', () => {
         const { output } = setup()
-        const [ toggle ] = output.props.children
+        const [ toggle ] = output.props.children[0].props.children
         expect(toggle.type).toBe('input')
         expect(toggle.props.type).toBe('checkbox')
         expect(toggle.props.checked).toBe(false)
@@ -64,14 +64,14 @@ describe('components', () => {
           }
         ]
         })
-        const [ toggle ] = output.props.children
+        const [ toggle ] = output.props.children[0].props.children
         expect(toggle.props.checked).toBe(true)
       })
 
       it('should call completeAll on change', () => {
         const { output, props } = setup()
-        const [ toggle ] = output.props.children
-        toggle.props.onChange({})
+        const [ toggle, label ] = output.props.children[0].props.children
+        label.props.onClick({})
         expect(props.actions.completeAll).toBeCalled()
       })
     })


### PR DESCRIPTION
As of todomvc-app-css v2.1.0, the "toggle-all" chevron decoration is no longer applied to the checkbox, but instead to its associated label.

Prior to this commit, the todomvc example did not use a label, so the v2.1.0 change had the effect of hiding the "toggle-all" control.

This commit adds the label -- fixing this bug.

Tests have been updated to reflect these changes.