### PR TITLE
Warns when type of reducers passed is invalid to avoid silent failure

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -106,8 +106,11 @@ export default function combineReducers(reducers) {
     const key = reducerKeys[i]
 
     if (process.env.NODE_ENV !== 'production') {
-      if (typeof reducers[key] === 'undefined') {
+      const reducerUnderInspection = reducers[key]
+      if (typeof reducerUnderInspection === 'undefined') {
         warning(`No reducer provided for key "${key}"`)
+      } else if (typeof reducerUnderInspection !== 'function') {
+        warning(`Reducer provided for "${key}" is not a function. Received a ${typeof key}.`)
       }
     }
 

--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -106,11 +106,12 @@ export default function combineReducers(reducers) {
     const key = reducerKeys[i]
 
     if (process.env.NODE_ENV !== 'production') {
-      const reducerUnderInspection = reducers[key]
-      if (typeof reducerUnderInspection === 'undefined') {
+      if (typeof reducers[key] === 'undefined') {
         warning(`No reducer provided for key "${key}"`)
-      } else if (typeof reducerUnderInspection !== 'function') {
-        warning(`Reducer provided for "${key}" is not a function. Received a ${typeof key}.`)
+      } if (key === '__esModule') {
+        warning(`Passing a whole ES Module to combine reducers is discouraged.`)
+      } else if (typeof reducers[key] !== 'function') {
+        warning(`Reducer provided for "${key}" is not a function. Received type: ${typeof key}.`)
       }
     }
 

--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -108,7 +108,7 @@ export default function combineReducers(reducers) {
     if (process.env.NODE_ENV !== 'production') {
       if (typeof reducers[key] === 'undefined') {
         warning(`No reducer provided for key "${key}"`)
-      } if (key === '__esModule') {
+      } else if (key === '__esModule') {
         warning(`Passing a whole ES Module to combine reducers is discouraged.`)
       } else if (typeof reducers[key] !== 'function') {
         warning(`Reducer provided for "${key}" is not a function. Received type: ${typeof key}.`)

--- a/test/combineReducers.spec.js
+++ b/test/combineReducers.spec.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 import { combineReducers } from '../src'
 import createStore, { ActionTypes } from '../src/createStore'
+import * as reducers from './helpers/reducers'
 
 describe('Utils', () => {
   describe('combineReducers', () => {
@@ -30,21 +31,27 @@ describe('Utils', () => {
         stack: (state = []) => state
       })
 
-      expect(spy.mock.calls[0][0]).toMatch(
-        /Reducer provided for "fake" is not a function/
-      )
-
-      expect(spy.mock.calls[1][0]).toMatch(
-          /Reducer provided for "broken" is not a function/
-      )
-
-      expect(spy.mock.calls[2][0]).toMatch(
-          /Reducer provided for "another" is not a function/
-      )
+      expect(spy).toHaveBeenLastCalledWith('Reducer provided for "another" is not a function. Received type: string.')
+      expect(spy).toHaveBeenCalledTimes(3)
 
       expect(
         Object.keys(reducer({ }, { type: 'push' }))
       ).toEqual([ 'stack' ])
+
+      spy.mockClear()
+      console.error = preSpy
+    })
+
+    it('warns if a module imported with * syntax is passed', () => {
+      const preSpy = console.error
+      const spy = jest.fn()
+      console.error = spy
+
+      combineReducers(reducers)
+      expect(spy).toHaveBeenCalledWith(`Passing a whole ES Module to combine reducers is discouraged.`)
+
+      spy.mockClear()
+      console.error = preSpy
     })
 
     it('warns if a reducer prop is undefined', () => {
@@ -54,15 +61,11 @@ describe('Utils', () => {
 
       let isNotDefined
       combineReducers({ isNotDefined })
-      expect(spy.mock.calls[0][0]).toMatch(
-        /No reducer provided for key "isNotDefined"/
-      )
+      expect(spy).toHaveBeenCalledWith('No reducer provided for key "isNotDefined"')
 
       spy.mockClear()
       combineReducers({ thing: undefined })
-      expect(spy.mock.calls[0][0]).toMatch(
-        /No reducer provided for key "thing"/
-      )
+      expect(spy).toHaveBeenCalledWith('No reducer provided for key "thing"')
 
       spy.mockClear()
       console.error = preSpy

--- a/test/combineReducers.spec.js
+++ b/test/combineReducers.spec.js
@@ -18,13 +18,29 @@ describe('Utils', () => {
       expect(s2).toEqual({ counter: 1, stack: [ 'a' ] })
     })
 
-    it('ignores all props which are not a function', () => {
+    it('warns on props which are not a function and excludes them', () => {
+      const preSpy = console.error
+      const spy = jest.fn()
+      console.error = spy
+
       const reducer = combineReducers({
         fake: true,
         broken: 'string',
         another: { nested: 'object' },
         stack: (state = []) => state
       })
+
+      expect(spy.mock.calls[0][0]).toMatch(
+        /Reducer provided for "fake" is not a function/
+      )
+
+      expect(spy.mock.calls[1][0]).toMatch(
+          /Reducer provided for "broken" is not a function/
+      )
+
+      expect(spy.mock.calls[2][0]).toMatch(
+          /Reducer provided for "another" is not a function/
+      )
 
       expect(
         Object.keys(reducer({ }, { type: 'push' }))

--- a/test/createStore.spec.js
+++ b/test/createStore.spec.js
@@ -6,7 +6,7 @@ import $$observable from 'symbol-observable'
 
 describe('createStore', () => {
   it('exposes the public API', () => {
-    const store = createStore(combineReducers(reducers))
+    const store = createStore(reducers.todos)
     const methods = Object.keys(store)
 
     expect(methods.length).toBe(4)


### PR DESCRIPTION
Attempts to solve issue #1398 .

Undefined reducers are still checked for intuitive debugging.
Warnings are now given to the console if a passed reducer is not a function.
Warnings are also given to the console if a whole es module imported via the * syntax is passed to combineReducers.