### PR TITLE
Do not warn if replaceReducer causes reducer shape to change

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -196,6 +196,17 @@ export default function createStore(reducer, preloadedState, enhancer) {
       throw new Error('Expected the nextReducer to be a function.')
     }
 
+    const reducerShape = nextReducer({}, {})
+
+    if (typeof currentState === 'object' && Array.isArray(currentState) === false) {
+      currentState = Object.keys(currentState).reduce((targetShape, key) => {
+        if (key in reducerShape) {
+          targetShape[key] = currentState[key]
+        }
+        return targetShape
+      }, {})
+    }
+
     currentReducer = nextReducer
     dispatch({ type: ActionTypes.INIT })
   }

--- a/test/createStore.spec.js
+++ b/test/createStore.spec.js
@@ -601,6 +601,21 @@ describe('createStore', () => {
     ).not.toThrow()
   })
 
+  it('does not warn if replaceReducer changes reducer shape', () => {
+    const preSpy = console.error
+    const spy = jest.fn()
+    console.error = spy
+
+    const store = createStore(combineReducers({ foo: reducers.todos }))
+    expect(spy.mock.calls.length).toBe(0)
+
+    store.replaceReducer(combineReducers({ bar: reducers.todos }))
+    expect(spy.mock.calls.length).toBe(0)
+
+    spy.mockClear()
+    console.error = preSpy    
+  })
+
   it('throws if listener is not a function', () => {
     const store = createStore(reducers.todos)
 


### PR DESCRIPTION
Attempts to solve issue #1636.
`replaceReducer` calls the new reducer with empty objects as parameter to get the desired state shape, then filters out the keys in the current state that don't exist in the new one.
Added new test to verify functionality.
My first PR to Redux, please be gentle :)