### PR TITLE
Update WritingTests.md

### DIFF
--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -453,7 +453,7 @@ it('calls the function', () => {
 
 it('passes dispatch and getState', () => {
   const { store, invoke } = create()
-  invoke((dispatch, getState) => {
+  invoke(({ dispatch, getState }) => {
     dispatch('TEST DISPATCH')
     getState();
   })


### PR DESCRIPTION
Example for middleware testing should destructure the `store` param that is being passed through `invoke()`. Currently, the example shows `invoke((dispatch, getState) => { ... })` on LINE 456, but it should read as `invoke(({ dispatch, getState }) => { ... })`.