### PR TITLE
Remove warning about router 2/3

### DIFF
--- a/docs/advanced/UsageWithReactRouter.md
+++ b/docs/advanced/UsageWithReactRouter.md
@@ -1,7 +1,5 @@
 # Usage with React Router
 
-_Warning: This guide assumes you are using React Router 2.x or 3.x. The current version of React Router is 4.x. If you have just run `npm install --save react-router`, you will be using a version that does not match this guide._
-
 So you want to do routing with your Redux app. You can use it with [React Router](https://github.com/reactjs/react-router). Redux will be the source of truth for your data and React Router will be the source of truth for your URL. In most of the cases, **it is fine** to have them separate unless you need to time travel and rewind actions that triggers the change URL.
 
 ## Installing React Router


### PR DESCRIPTION
The recent PR by @timdorr for #2300 updated this guide to be compatible with Router v4, so the warning is now very confusing.