### PR TITLE
Adding Further Information links for the "Structuring Reducers" section

### DIFF
--- a/docs/recipes/reducers/BasicReducerStructure.md
+++ b/docs/recipes/reducers/BasicReducerStructure.md
@@ -96,3 +96,13 @@ A typical app's state shape might look roughly like:
     }
 }
 ```
+
+#### Further Information
+
+- [Redux Docs: Reducers](../../basics/Reducers.md)
+- [Redux Docs: Reducing Boilerplate](../ReducingBoilerplate.md)
+- [Redux Docs: Implementing Undo History](../ImplementingUndoHistory.md)
+- [Using Currying to Compose Reducers](http://www.guyzissman.com/posts/pipe-reducers/)
+- [The Power of Higher-Order Reducers](http://slides.com/omnidan/hor#/)
+- [Higher Order Reducers - It just sounds scary](https://medium.com/@danielkagan/high-order-reducers-it-just-sounds-scary-2b9e5dbfc705)
+- [Redux Architecture Guidelines](http://joeellis.la/redux-architecture/)

--- a/docs/recipes/reducers/BasicReducerStructure.md
+++ b/docs/recipes/reducers/BasicReducerStructure.md
@@ -102,7 +102,5 @@ A typical app's state shape might look roughly like:
 - [Redux Docs: Reducers](../../basics/Reducers.md)
 - [Redux Docs: Reducing Boilerplate](../ReducingBoilerplate.md)
 - [Redux Docs: Implementing Undo History](../ImplementingUndoHistory.md)
-- [Using Currying to Compose Reducers](http://www.guyzissman.com/posts/pipe-reducers/)
-- [The Power of Higher-Order Reducers](http://slides.com/omnidan/hor#/)
-- [Higher Order Reducers - It just sounds scary](https://medium.com/@danielkagan/high-order-reducers-it-just-sounds-scary-2b9e5dbfc705)
+- [The 5 Types of React Application State](http://jamesknelson.com/5-types-react-application-state/)
 - [Redux Architecture Guidelines](http://joeellis.la/redux-architecture/)


### PR DESCRIPTION
I have added some links to the end of the [Basic Reducer Structure Page](http://redux.js.org/docs/recipes/reducers/BasicReducerStructure.html). I just committed that single page for now to see if this is what you had in mind and if I am doing it ok. 

I have used a few links from the ''Prerequisite Concepts" page and added a few from the links in your React/Redux links list. 

I wanted to ask if maybe the same link could be in two different pages of the doc, for maybe people who are just looking at a specific page? For example having the same link in "Basic Reducer Structure" and "Splitting Reducer Logic", for something that expands on both. 

Also I wanted to ask if I should do one commit for every page on the "Structuring Reducers" section? 

P.s. Sorry I am late on this. Stuff in life happened

Fixes #2589 