### PR TITLE
Recursively Prune State on store.replaceReducer

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -218,7 +218,7 @@ export default function createStore(reducer, preloadedState, enhancer) {
     }
 
     if (process.env.NODE_ENV !== 'production') {
-      const currentStateShape = reducer(undefined, { type: ActionTypes.INIT })
+      const currentStateShape = currentReducer(undefined, { type: ActionTypes.INIT })
       const nextStateShape = nextReducer(undefined, { type: ActionTypes.INIT })
       currentState = pruneState(currentState, currentStateShape, nextStateShape)
     }

--- a/test/createStore.spec.js
+++ b/test/createStore.spec.js
@@ -734,4 +734,30 @@ describe('createStore', () => {
       expect(results).toEqual([ { foo: 0, bar: 0, fromRx: true }, { foo: 1, bar: 0, fromRx: true } ])
     })
   })
+
+  it('does not log an error if parts of the current state will be ignored by a nextReducer using combineReducers', () => {
+    const originalConsoleError = console.error
+    console.error = jest.fn()
+
+    const store = createStore(
+      combineReducers({
+        x: (s=0, a) => s,
+        y: combineReducers({
+          z: (s=0, a) => s,
+          w: (s=0, a) => s,
+        }),
+      })
+    )
+
+    store.replaceReducer(
+      combineReducers({
+        y: combineReducers({
+          z: (s=0, a) => s,
+        }),
+      })
+    )
+
+    expect(console.error.mock.calls.length).toBe(0)
+    console.error = originalConsoleError
+  })
 })


### PR DESCRIPTION
Resolves #1636 -- Prevents combineReducers from warning about unexpected keys after calling replaceReducer.

Adds recursive `pruneState` function to createStore, which uses the differences between the current and next state shapes to determine which state branches have been removed (are not acknowledged by the next reducer).  The removed state branches are then removed from the current state.

The state shape is defined here as the union of every path which begins at the state tree root and terminates at a non-plain-object leaf (boolean, number, string, array, etc).

Properties of a plain object which do not appear in the current or next shape are not pruned.  This covers the use case where a plain object is being used as a dynamic collection of key-value pairs.

If any plain object is unchanged by the pruning process, the original object is returned instead of a new one.

The state shape for a given reducer is determined by invoking it with an undefined state and the INIT action.

The combineReducers warning does not appear in production, so this pruning process also does not take place in production.

Added unit test which fails (generates warning) when the pruning process does not take place.
