### PR TITLE
REPLACE action for replaceReducers

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -44,6 +44,8 @@ function getUnexpectedStateShapeWarningMessage(inputState, reducers, action, une
     unexpectedKeyCache[key] = true
   })
 
+  if (action && action.type == ActionTypes.REPLACE) return
+
   if (unexpectedKeys.length > 0) {
     return (
       `Unexpected ${unexpectedKeys.length > 1 ? 'keys' : 'key'} ` +

--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -44,7 +44,7 @@ function getUnexpectedStateShapeWarningMessage(inputState, reducers, action, une
     unexpectedKeyCache[key] = true
   })
 
-  if (action && action.type == ActionTypes.REPLACE) return
+  if (action && action.type === ActionTypes.REPLACE) return
 
   if (unexpectedKeys.length > 0) {
     return (

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -213,7 +213,7 @@ export default function createStore(reducer, preloadedState, enhancer) {
     }
 
     currentReducer = nextReducer
-    dispatch({ type: ActionTypes.INIT })
+    dispatch({ type: ActionTypes.REPLACE })
   }
 
   /**

--- a/src/utils/actionTypes.js
+++ b/src/utils/actionTypes.js
@@ -5,7 +5,8 @@
  * Do not reference these action types directly in your code.
  */
 var ActionTypes = {
-  INIT: '@@redux/INIT'
+  INIT: '@@redux/INIT',
+  REPLACE: '@@redux/REPLACE'
 }
 
 export default ActionTypes

--- a/src/utils/actionTypes.js
+++ b/src/utils/actionTypes.js
@@ -5,8 +5,8 @@
  * Do not reference these action types directly in your code.
  */
 const ActionTypes = {
-  INIT: '@@redux/INIT',
-  REPLACE: '@@redux/REPLACE'
+  INIT: '@@redux/INIT' + Math.random().toString(36).substring(7).split('').join('.'),
+  REPLACE: '@@redux/REPLACE' + Math.random().toString(36).substring(7).split('').join('.')
 }
 
 export default ActionTypes

--- a/src/utils/actionTypes.js
+++ b/src/utils/actionTypes.js
@@ -4,7 +4,7 @@
  * If the current state is undefined, you must return the initial state.
  * Do not reference these action types directly in your code.
  */
-var ActionTypes = {
+const ActionTypes = {
   INIT: '@@redux/INIT',
   REPLACE: '@@redux/REPLACE'
 }

--- a/test/createStore.spec.js
+++ b/test/createStore.spec.js
@@ -767,4 +767,30 @@ describe('createStore', () => {
       expect(results).toEqual([ { foo: 0, bar: 0, fromRx: true }, { foo: 1, bar: 0, fromRx: true } ])
     })
   })
+
+  it('does not log an error if parts of the current state will be ignored by a nextReducer using combineReducers', () => {
+    const originalConsoleError = console.error
+    console.error = jest.fn()
+
+    const store = createStore(
+      combineReducers({
+        x: (s=0, a) => s,
+        y: combineReducers({
+          z: (s=0, a) => s,
+          w: (s=0, a) => s,
+        }),
+      })
+    )
+
+    store.replaceReducer(
+      combineReducers({
+        y: combineReducers({
+          z: (s=0, a) => s,
+        }),
+      })
+    )
+
+    expect(console.error.mock.calls.length).toBe(0)
+    console.error = originalConsoleError
+  })
 })


### PR DESCRIPTION
Fixes #1636 

Provides a separate private action for when we replace reducers. This allows us to specifically handle this case, which resolves a false dev-only warning for combineReducers currently. 