### PR TITLE
MigratingToRedux

### DIFF
--- a/docs/recipes/MigratingToRedux.md
+++ b/docs/recipes/MigratingToRedux.md
@@ -9,8 +9,6 @@ We don't want to lock you in!
 
 [Reducers](../Glossary.md#reducer) capture “the essence” of Flux Stores, so it's possible to gradually migrate an existing Flux project towards Redux, whether you are using [Flummox](http://github.com/acdlite/flummox), [Alt](http://github.com/goatslacker/alt), [traditional Flux](https://github.com/facebook/flux), or any other Flux library.
 
-It is also possible to do the reverse and migrate from Redux to any of these libraries following the same steps.
-
 Your process will look like this:
 
 * Create a function called `createFluxStore(reducer)` that creates a Flux store compatible with your existing app from a reducer function. Internally it might look similar to [`createStore`](../api/createStore.md) ([source](https://github.com/reactjs/redux/blob/master/src/createStore.js)) implementation from Redux. Its dispatch handler should just call the `reducer` for any action, store the next state, and emit change.
@@ -24,6 +22,8 @@ Your process will look like this:
 * Now all that's left to do is to port the UI to [use react-redux](../basics/UsageWithReact.md) or equivalent.
 
 * Finally, you might want to begin using some Redux idioms like middleware to further simplify your asynchronous code.
+
+It is also possible to do the reverse and migrate from Redux to any of the above libraries.
 
 ## From Backbone
 

--- a/docs/recipes/MigratingToRedux.md
+++ b/docs/recipes/MigratingToRedux.md
@@ -23,8 +23,6 @@ Your process will look like this:
 
 * Finally, you might want to begin using some Redux idioms like middleware to further simplify your asynchronous code.
 
-It is also possible to do the reverse and migrate from Redux to any of the above libraries.
-
 ## From Backbone
 
 Backbone's model layer is quite different from Redux, so we don't suggest mixing them. If possible, it is best that you rewrite your app's model layer from scratch instead of connecting Backbone to Redux. However, if a rewrite is not feasible, you may use [backbone-redux](https://github.com/redbooth/backbone-redux) to migrate gradually, and keep the Redux store in sync with Backbone models and collections.


### PR DESCRIPTION
**What does this PR do?**
Clarifies which migration process is being described in the guide.

**Why?**
First, thanks for the docs! This is a big help as we convert our few bits of Flux to Redux.
However, when referencing this guide, a coworker and I were both confused at first glance, thinking the "Your process will look like this" line was referring to the previous line that describes migrating from Redux back to a related lib. 
Suggested edit is to move that line to the end so it's clear it's a note rather than the subject of the steps.