### PR TITLE
Explicitly allow undefined in the state parameter of the TS Reducer type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -53,7 +53,7 @@ export interface AnyAction extends Action {
  *
  * @template S State object type.
  */
-export type Reducer<S> = (state: S, action: AnyAction) => S;
+export type Reducer<S> = (state: S | undefined, action: AnyAction) => S;
 
 /**
  * Object whose values correspond to different reducer functions.


### PR DESCRIPTION
Per the documentation and behavior, reducers will initially be called with `undefined` as an initial state. The current Typescript definition of the reducer forces the developer to allow undefined in their state type should they want to explicitly call a reducer with undefined - the primary use case being a test case to ensure that the reducer produces the correct initial state value:

```typescript
// myReducer.ts
export const myReducer: Reducer<State> = (state = initialState, action) => {
  // ...
}
// __tests__/myReducer.ts
it('initializes state correctly' => {
  expect(myReducer(undefined, { type: '@@redux/INIT' })).toEqual(myIntendedInitialState)
})
```

Currently the above results in the following error:

    __tests__/myReducer.ts(9,27): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'number'.

This change resolves that error.