### PR TITLE
Update markdown syntax on DataFlow.md

### DIFF
--- a/docs/basics/DataFlow.md
+++ b/docs/basics/DataFlow.md
@@ -48,7 +48,7 @@ The data lifecycle in any Redux app follows these 4 steps:
     let nextState = todoApp(previousState, action)
    ```
 
-    Note that a reducer is a pure function. It only *computes* the next state. It should be completely predictable: calling it with the same inputs many times should produce the same outputs. It shouldn't perform any side effects like API calls or router transitions. These should happen before an action is dispatched.
+  Note that a reducer is a pure function. It only *computes* the next state. It should be completely predictable: calling it with the same inputs many times should produce the same outputs. It shouldn't perform any side effects like API calls or router transitions. These should happen before an action is dispatched.
 
 3. **The root reducer may combine the output of multiple reducers into a single state tree.**
 


### PR DESCRIPTION
Minor markdown fix for documentation. I noticed that there was text being rendered in a code block (due to 4 space indent instead of 2 spaces), when it most likely should just be rendered as normal text.