### PR TITLE
Update WritingTests.md

### DIFF
--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -80,7 +80,7 @@ For async action creators using [Redux Thunk](https://github.com/gaearon/redux-t
 #### Example
 
 ```js
-import fetch from 'isomorphic-fetch'
+import 'isomorphic-fetch'
 
 function fetchTodosRequest() {
   return {


### PR DESCRIPTION
https://github.com/wheresrhys/fetch-mock/issues/104

I wrangled with why the testing for `'isomorphic-fetch'` and `'fetch-mock'` didn't work before finding the above issue, and realizing that you must `import 'isomorphic-fetch'` as a global for `'fetch-mock'` to override it. Wanted to update the docs so the next person doesn't have the same issue :)