### PR TITLE
no need to require `rootReducer` again

### DIFF
--- a/examples/real-world/src/store/configureStore.dev.js
+++ b/examples/real-world/src/store/configureStore.dev.js
@@ -18,8 +18,7 @@ const configureStore = preloadedState => {
   if (module.hot) {
     // Enable Webpack hot module replacement for reducers
     module.hot.accept('../reducers', () => {
-      const nextRootReducer = require('../reducers').default
-      store.replaceReducer(nextRootReducer)
+      store.replaceReducer(rootReducer)
     })
   }
 

--- a/examples/universal/common/store/configureStore.js
+++ b/examples/universal/common/store/configureStore.js
@@ -12,8 +12,7 @@ const configureStore = (preloadedState) => {
   if (module.hot) {
     // Enable Webpack hot module replacement for reducers
     module.hot.accept('../reducers', () => {
-      const nextRootReducer = require('../reducers').default
-      store.replaceReducer(nextRootReducer)
+      store.replaceReducer(rootReducer)
     })
   }
 


### PR DESCRIPTION
[`babel-preset-react-app` does not transform modules to CJS](https://github.com/facebookincubator/create-react-app/blob/master/packages/babel-preset-react-app/index.js#L107-L108) so I don't think we need to require `rootReducer` again