### PR TITLE
remove unnecessary path to file from docs

### DIFF
--- a/docs/api/compose.md
+++ b/docs/api/compose.md
@@ -21,7 +21,7 @@ This example demonstrates how to use `compose` to enhance a [store](Store.md) wi
 import { createStore, applyMiddleware, compose } from 'redux'
 import thunk from 'redux-thunk'
 import DevTools from './containers/DevTools'
-import reducer from '../reducers/index'
+import reducer from '../reducers'
 
 const store = createStore(
   reducer,


### PR DESCRIPTION
When require is given the path of a folder, node.js will look for an index.js file in that folder so no need for /index