### PR TITLE
Use Object Literal Shorthand Syntax

### DIFF
--- a/examples/shopping-cart/src/actions/index.js
+++ b/examples/shopping-cart/src/actions/index.js
@@ -3,7 +3,7 @@ import * as types from '../constants/ActionTypes'
 
 const receiveProducts = products => ({
   type: types.RECEIVE_PRODUCTS,
-  products: products
+  products
 })
 
 export const getAllProducts = () => dispatch => {


### PR DESCRIPTION
Looks like it's a miss as its already done at other instances like productId