### PR TITLE
Simplify the definition of reducers

### DIFF
--- a/docs/basics/Reducers.md
+++ b/docs/basics/Reducers.md
@@ -1,6 +1,6 @@
 # Reducers
 
-[Actions](./Actions.md) describe the fact that *something happened*, but don't specify how the application's state changes in response. This is the job of reducers.
+**Reducers** specify how the application's state changes in response to [actions](./Actions.md) sent to the store. Remember that actions only describe the fact that *something happened*, but don't specify how.
 
 ## Designing the State Shape
 

--- a/docs/basics/Reducers.md
+++ b/docs/basics/Reducers.md
@@ -1,6 +1,6 @@
 # Reducers
 
-**Reducers** specify how the application's state changes in response to [actions](./Actions.md) sent to the store. Remember that actions only describe the fact that *something happened*, but not how the application's state changes.
+**Reducers** specify how the application's state changes in response to [actions](./Actions.md) sent to the store. Remember that actions only describe the fact that *something happened*, but don't describe how the application's state changes.
 
 ## Designing the State Shape
 

--- a/docs/basics/Reducers.md
+++ b/docs/basics/Reducers.md
@@ -1,6 +1,6 @@
 # Reducers
 
-**Reducers** specify how the application's state changes in response to [actions](./Actions.md) sent to the store. Remember that actions only describe the fact that *something happened*, but don't specify how.
+**Reducers** specify how the application's state changes in response to [actions](./Actions.md) sent to the store. Remember that actions only describe the fact that *something happened*, but not how the application's state changes.
 
 ## Designing the State Shape
 


### PR DESCRIPTION
Instead of defining reducers by what actions are not, define reducers by what they are. A reminder of what actions are is kept in the text, for education purposes.

I am not a react/redux expert so feel free to correct any errors in the new text.

However, wording is subjective and a matter of taste. So, I'll understand if you won't consider merging the change.