### PR TITLE
Rollup update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11008,9 +11008,9 @@
       }
     },
     "rollup": {
-      "version": "0.50.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.50.0.tgz",
-      "integrity": "sha512-7RqCBQ9iwsOBPkjYgoIaeUij606mSkDMExP0NT7QDI3bqkHYQHrQ83uoNIXwPcQm/vP2VbsUz3kiyZZ1qPlLTQ==",
+      "version": "0.51.8",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.51.8.tgz",
+      "integrity": "sha512-e7FwWxqb4vhdonmwRH06nqC9wR6h1kZojK2D+lN1xjiB8FDtAKgy7o+r8fCXVzQZ1ZCdcVlls3mTq5g6u38Jew==",
       "dev": true
     },
     "rollup-plugin-babel": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "glob": "^7.1.1",
     "jest": "^21.2.1",
     "rimraf": "^2.6.2",
-    "rollup": "^0.50.0",
+    "rollup": "^0.51.8",
     "rollup-plugin-babel": "^3.0.2",
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-replace": "^2.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,5 @@
 import nodeResolve from 'rollup-plugin-node-resolve'
 import babel from 'rollup-plugin-babel'
-import { list as babelHelpersList } from 'babel-helpers'
 import replace from 'rollup-plugin-replace'
 import uglify from 'rollup-plugin-uglify'
 
@@ -20,7 +19,6 @@ if (env === 'es' || env === 'cjs') {
   config.plugins.push(
     babel({
       plugins: ['external-helpers'],
-      externalHelpersWhitelist: babelHelpersList.filter(helperName => helperName !== 'asyncGenerator')
     })
   )
 }
@@ -35,7 +33,6 @@ if (env === 'development' || env === 'production') {
     babel({
       exclude: 'node_modules/**',
       plugins: ['external-helpers'],
-      externalHelpersWhitelist: babelHelpersList.filter(helperName => helperName !== 'asyncGenerator')
     }),
     replace({
       'process.env.NODE_ENV': JSON.stringify(env)


### PR DESCRIPTION
`rollup@0.50` doesn't require an `externalHelpersWhitelist`. It's capable of removing `asyncGenerator` babel helper on its own.