### PR TITLE
Remove a redundant symbol (') from applyMiddleware.md

### DIFF
--- a/docs/api/applyMiddleware.md
+++ b/docs/api/applyMiddleware.md
@@ -14,7 +14,7 @@ Middleware is not baked into [`createStore`](createStore.md) and is not a fundam
 
 #### Returns
 
-(*Function*) A store enhancer that applies the given middleware. The store enhancer signature is `createStore => createStore'` but the easiest way to apply it is to pass it to [`createStore()`](./createStore.md) as the last `enhancer` argument.
+(*Function*) A store enhancer that applies the given middleware. The store enhancer signature is `createStore => createStore` but the easiest way to apply it is to pass it to [`createStore()`](./createStore.md) as the last `enhancer` argument.
 
 #### Example: Custom Logger Middleware
 


### PR DESCRIPTION
just \`createStore => createStore'\` to \`createStore => createStore\`