### PR TITLE
update docs to use babel-preset-env instead of es2015

### DIFF
--- a/docs/recipes/UsingObjectSpreadOperator.md
+++ b/docs/recipes/UsingObjectSpreadOperator.md
@@ -52,11 +52,11 @@ return getAddedIds(state.cart).map(id => ({
 }))
 ```
 
-Since the object spread syntax is still a [Stage 3](https://github.com/sebmarkbage/ecmascript-rest-spread#status-of-this-proposal) proposal for ECMAScript you'll need to use a transpiler such as [Babel](http://babeljs.io/) to use it in production. You can use your existing `es2015` preset, install [`babel-plugin-transform-object-rest-spread`](http://babeljs.io/docs/plugins/transform-object-rest-spread/) and add it individually to the `plugins` array in your `.babelrc`.
+Since the object spread syntax is still a [Stage 3](https://github.com/sebmarkbage/ecmascript-rest-spread#status-of-this-proposal) proposal for ECMAScript you'll need to use a transpiler such as [Babel](http://babeljs.io/) to use it in production. You should use [`env`](https://github.com/babel/babel/tree/master/packages/babel-preset-env) preset, install [`babel-plugin-transform-object-rest-spread`](http://babeljs.io/docs/plugins/transform-object-rest-spread/) and add it individually to the `plugins` array in your `.babelrc`.
 
 ```json
 {
-  "presets": ["es2015"],
+  "presets": ["@babel/preset-env"],
   "plugins": ["transform-object-rest-spread"]
 }
 ```

--- a/docs/recipes/UsingObjectSpreadOperator.md
+++ b/docs/recipes/UsingObjectSpreadOperator.md
@@ -52,7 +52,7 @@ return getAddedIds(state.cart).map(id => ({
 }))
 ```
 
-Since the object spread syntax is still a [Stage 3](https://github.com/sebmarkbage/ecmascript-rest-spread#status-of-this-proposal) proposal for ECMAScript you'll need to use a transpiler such as [Babel](http://babeljs.io/) to use it in production. You should use [`env`](https://github.com/babel/babel/tree/master/packages/babel-preset-env) preset, install [`babel-plugin-transform-object-rest-spread`](http://babeljs.io/docs/plugins/transform-object-rest-spread/) and add it individually to the `plugins` array in your `.babelrc`.
+Since the object spread syntax is still a [Stage 3](https://github.com/sebmarkbage/ecmascript-rest-spread#status-of-this-proposal) proposal for ECMAScript you'll need to use a transpiler such as [Babel](http://babeljs.io/) to use it in production. You should use the [`env`](https://github.com/babel/babel/tree/master/packages/babel-preset-env) preset, install [`babel-plugin-transform-object-rest-spread`](http://babeljs.io/docs/plugins/transform-object-rest-spread/) and add it individually to the `plugins` array in your `.babelrc`.
 
 ```json
 {

--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -17,11 +17,11 @@ To use it together with [Babel](http://babeljs.io), you will need to install `ba
 npm install --save-dev babel-jest
 ```
 
-and configure it to use ES2015 features in `.babelrc`:
+and configure it to use [babel-preset-env](https://github.com/babel/babel/tree/master/packages/babel-preset-env) features in `.babelrc`:
 
 ```js
 {
-  "presets": ["es2015"]
+   "presets": ["@babel/preset-env"]
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -60,11 +60,6 @@
   },
   "homepage": "http://redux.js.org",
   "dependencies": {
-    "gitbook-plugin-algolia": "^1.0.7",
-    "gitbook-plugin-anchorjs": "^1.1.1",
-    "gitbook-plugin-edit-link": "^2.0.2",
-    "gitbook-plugin-github": "^2.0.0",
-    "gitbook-plugin-prism": "^2.3.0",
     "loose-envify": "^1.1.0",
     "symbol-observable": "^1.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -60,6 +60,11 @@
   },
   "homepage": "http://redux.js.org",
   "dependencies": {
+    "gitbook-plugin-algolia": "^1.0.7",
+    "gitbook-plugin-anchorjs": "^1.1.1",
+    "gitbook-plugin-edit-link": "^2.0.2",
+    "gitbook-plugin-github": "^2.0.0",
+    "gitbook-plugin-prism": "^2.3.0",
     "loose-envify": "^1.1.0",
     "symbol-observable": "^1.0.3"
   },


### PR DESCRIPTION
With reference to issue #2735 updating docs to use babel-preset-env instead of es2015.