### PR TITLE
feat(es-modules): native es-module support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11133,7 +11133,7 @@
       "integrity": "sha512-vmvP5y/oJIJmXKHY36PIjVeI/46Sny6BMBa7/ou2zsNz1PiqU/Gtcz1GujnHz5Qlxncv+J9VlWmttnshqFj3Kg==",
       "dev": true,
       "requires": {
-        "symbol-observable": "1.0.4"
+        "symbol-observable": "1.1.0"
       }
     },
     "safe-buffer": {
@@ -11420,9 +11420,9 @@
       "dev": true
     },
     "symbol-observable": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
-      "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.1.0.tgz",
+      "integrity": "sha512-dQoid9tqQ+uotGhuTKEY11X4xhyYePVnqGSoSm3OGKh2E8LZ6RPULp1uXTctk33IeERlrRJYoVSBglsL05F5Uw=="
     },
     "symbol-tree": {
       "version": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "homepage": "http://redux.js.org",
   "dependencies": {
     "loose-envify": "^1.1.0",
-    "symbol-observable": "^1.0.3"
+    "symbol-observable": "^1.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/applyMiddleware.js
+++ b/src/applyMiddleware.js
@@ -1,4 +1,4 @@
-import compose from './compose'
+import compose from './compose.js'
 
 /**
  * Creates a store enhancer that applies middleware to the dispatch method

--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -1,6 +1,6 @@
-import ActionTypes from './utils/actionTypes'
-import warning from './utils/warning'
-import isPlainObject from './utils/isPlainObject'
+import ActionTypes from './utils/actionTypes.js'
+import warning from './utils/warning.js'
+import isPlainObject from './utils/isPlainObject.js'
 
 function getUndefinedStateErrorMessage(key, action) {
   const actionType = action && action.type

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -1,7 +1,7 @@
-import $$observable from 'symbol-observable'
+import $$observable from '../node_modules/symbol-observable/es/index.js'
 
-import ActionTypes from './utils/actionTypes'
-import isPlainObject from './utils/isPlainObject'
+import ActionTypes from './utils/actionTypes.js'
+import isPlainObject from './utils/isPlainObject.js'
 
 /**
  * Creates a Redux store that holds the state tree.

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
-import createStore from './createStore'
-import combineReducers from './combineReducers'
-import bindActionCreators from './bindActionCreators'
-import applyMiddleware from './applyMiddleware'
-import compose from './compose'
-import warning from './utils/warning'
-import __DO_NOT_USE__ActionTypes from './utils/actionTypes'
+import createStore from './createStore.js'
+import combineReducers from './combineReducers.js'
+import bindActionCreators from './bindActionCreators.js'
+import applyMiddleware from './applyMiddleware.js'
+import compose from './compose.js'
+import warning from './utils/warning.js'
+import __DO_NOT_USE__ActionTypes from './utils/actionTypes.js'
 
 /*
  * This is a dummy function to check if the function name has been altered by minification.


### PR DESCRIPTION
adds changes required to run redux via native es-modules in supported browsers

As requested in #2628 

`symbol-ovservable@1.0.0` added support. 

This PR simply ensures correct paths and file extensions, therefore allows to be imported via native es-modules in the browser.
