### PR TITLE
[DOCS] Change "state mutated" to "state changed"

### DIFF
--- a/docs/recipes/ComputingDerivedData.md
+++ b/docs/recipes/ComputingDerivedData.md
@@ -52,7 +52,7 @@ In the above example, `mapStateToProps` calls `getVisibleTodos` to calculate `to
 
 We would like to replace `getVisibleTodos` with a memoized selector that recalculates `todos` when the value of `state.todos` or `state.visibilityFilter` changes, but not when changes occur in other (unrelated) parts of the state tree.
 
-Reselect provides a function `createSelector` for creating memoized selectors. `createSelector` takes an array of input-selectors and a transform function as its arguments. If the Redux state tree is mutated in a way that causes the value of an input-selector to change, the selector will call its transform function with the values of the input-selectors as arguments and return the result. If the values of the input-selectors are the same as the previous call to the selector, it will return the previously computed value instead of calling the transform function.
+Reselect provides a function `createSelector` for creating memoized selectors. `createSelector` takes an array of input-selectors and a transform function as its arguments. If the Redux state tree is changed in a way that causes the value of an input-selector to change, the selector will call its transform function with the values of the input-selectors as arguments and return the result. If the values of the input-selectors are the same as the previous call to the selector, it will return the previously computed value instead of calling the transform function.
 
 Let's define a memoized selector named `getVisibleTodos` to replace the non-memoized version above:
 


### PR DESCRIPTION
One of the basic principles of Redux - its state should never mutate. Rephrase sentence to prevent confusion about Redux state changes.