### PR TITLE
Better middleware order in TS test

### DIFF
--- a/test/typescript/middleware.ts
+++ b/test/typescript/middleware.ts
@@ -60,5 +60,5 @@ storeWithThunkMiddleware.dispatch(
 
 const storeWithMultipleMiddleware = createStore(
   reducer,
-  applyMiddleware(loggerMiddleware, thunkMiddleware)
+  applyMiddleware(thunkMiddleware, loggerMiddleware)
 )


### PR DESCRIPTION
Not that it matters much, but the `logger` and `thunk` middlewares in the TS test code are in the "wrong" order. This PR switches them around to follow real-world usage.