### PR TITLE
Restructure ecosystem page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@
   * [Core Concepts](/docs/introduction/CoreConcepts.md)
   * [Three Principles](/docs/introduction/ThreePrinciples.md)
   * [Prior Art](/docs/introduction/PriorArt.md)
+  * [Learning Resources](/docs/introduction/LearningResources.md)
   * [Ecosystem](/docs/introduction/Ecosystem.md)
   * [Examples](/docs/introduction/Examples.md)
 * [Basics](/docs/basics/README.md)

--- a/docs/introduction/Ecosystem.md
+++ b/docs/introduction/Ecosystem.md
@@ -1,101 +1,807 @@
 # Ecosystem
 
-Redux is a tiny library, but its contracts and APIs are carefully chosen to spawn an ecosystem of tools and extensions.
+Redux is a tiny library, but its contracts and APIs are carefully chosen to spawn an ecosystem of tools and extensions, and the community has created a wide variety of helpful addons, libraries, and tools.  You don't need to use any of these addons to use Redux, but they can help make it easier to implement features and solve problems in your application.
 
-For an extensive list of everything related to Redux, we recommend [Awesome Redux](https://github.com/xgrommx/awesome-redux). It contains examples, boilerplates, middleware, utility libraries, and more. [React/Redux Links](https://github.com/markerikson/react-redux-links) contains tutorials and other useful resources for anyone learning React or Redux, and [Redux Ecosystem Links](https://github.com/markerikson/redux-ecosystem-links) lists many Redux-related libraries and addons.
+For an extensive catalog of libraries, addons, and tools related to Redux, check out the [Redux Ecosystem Links](https://github.com/markerikson/redux-ecosystem-links) list. Also, the [React/Redux Links](https://github.com/markerikson/react-redux-links) list contains tutorials and other useful resources for anyone learning React or Redux.
 
-On this page we will only feature a few of them that the Redux maintainers have vetted personally. Don't let this discourage you from trying the rest of them! The ecosystem is growing too fast, and we have a limited time to look at everything. Consider these the “staff picks”, and don't hesitate to submit a PR if you've built something wonderful with Redux.
-
-
-## Using Redux
-
-### Bindings
-
-* [react-redux](https://github.com/gaearon/react-redux) — React
-* [ng-redux](https://github.com/wbuchwalter/ng-redux) — Angular
-* [ng2-redux](https://github.com/wbuchwalter/ng2-redux) — Angular 2
-* [backbone-redux](https://github.com/redbooth/backbone-redux) — Backbone
-* [redux-falcor](https://github.com/ekosz/redux-falcor) — Falcor
-* [deku-redux](https://github.com/troch/deku-redux) — Deku
-* [polymer-redux](https://github.com/tur-nr/polymer-redux) - Polymer
-* [ember-redux](https://github.com/toranb/ember-redux) - Ember.js
-
-### Middleware
-
-* [redux-thunk](http://github.com/gaearon/redux-thunk) — The easiest way to write async action creators
-* [redux-promise](https://github.com/acdlite/redux-promise) — [FSA](https://github.com/acdlite/flux-standard-action)-compliant promise middleware
-* [redux-axios-middleware](https://github.com/svrcekmichal/redux-axios-middleware) — Redux middleware for fetching data with axios HTTP client
-* [redux-observable](https://github.com/redux-observable/redux-observable/) — RxJS middleware for action side effects using "Epics"
-* [redux-cycles](https://github.com/cyclejs-community/redux-cycles) — Handle Redux async actions using Cycle.js
-* [redux-logger](https://github.com/fcomb/redux-logger) — Log every Redux action and the next state
-* [redux-immutable-state-invariant](https://github.com/leoasis/redux-immutable-state-invariant) — Warns about state mutations in development
-* [redux-unhandled-action](https://github.com/socialtables/redux-unhandled-action) — Warns about actions that produced no state changes in development
-* [redux-analytics](https://github.com/markdalgleish/redux-analytics) — Analytics middleware for Redux
-* [redux-gen](https://github.com/weo-edu/redux-gen) — Generator middleware for Redux
-* [redux-saga](https://github.com/yelouafi/redux-saga) — An alternative side effect model for Redux apps
-* [redux-action-tree](https://github.com/cerebral/redux-action-tree) — Composable Cerebral-style signals for Redux
-* [apollo-client](https://github.com/apollostack/apollo-client) — A simple caching client for any GraphQL server and UI framework built on top of Redux
-
-### Routing
-
-* [react-router-redux](https://github.com/reactjs/react-router-redux) — Ruthlessly simple bindings to keep React Router and Redux in sync
-* [redial](https://github.com/markdalgleish/redial) — Universal data fetching and route lifecycle management for React that works great with Redux
-* [redux-little-router](https://github.com/FormidableLabs/redux-little-router) — A tiny router for Redux that lets the URL do the talking
-
-### Components
-
-* [redux-form](https://github.com/erikras/redux-form) — Keep React form state in Redux
-* [react-redux-form](https://github.com/davidkpiano/react-redux-form) — Create forms easily in React with Redux
-* [redux-resource](https://github.com/jmeas/redux-resource) — Manage remote resources with Redux
-
-### Enhancers
-
-* [redux-batched-subscribe](https://github.com/tappleby/redux-batched-subscribe) — Customize batching and debouncing calls to the store subscribers
-* [redux-history-transitions](https://github.com/johanneslumpe/redux-history-transitions) — History transitions based on arbitrary actions
-* [redux-optimist](https://github.com/ForbesLindesay/redux-optimist) — Optimistically apply actions that can be later committed or reverted
-* [redux-optimistic-ui](https://github.com/mattkrick/redux-optimistic-ui) — A reducer enhancer to enable type-agnostic optimistic updates
-* [redux-undo](https://github.com/omnidan/redux-undo) — Effortless undo/redo and action history for your reducers
-* [redux-ignore](https://github.com/omnidan/redux-ignore) — Ignore redux actions by array or filter function
-* [redux-recycle](https://github.com/omnidan/redux-recycle) — Reset the redux state on certain actions
-* [redux-batched-actions](https://github.com/tshelburne/redux-batched-actions) — Dispatch several actions with a single subscriber notification
-* [redux-search](https://github.com/treasure-data/redux-search) — Automatically index resources in a web worker and search them without blocking
-* [redux-electron-store](https://github.com/samiskin/redux-electron-store) — Store enhancers that synchronize Redux stores across Electron processes
-* [redux-loop](https://github.com/raisemarketplace/redux-loop) — Sequence effects purely and naturally by returning them from your reducers
-* [redux-side-effects](https://github.com/salsita/redux-side-effects) — Utilize Generators for declarative yielding of side effects from your pure reducers
-
-### Utilities
-
-* [reselect](https://github.com/faassen/reselect) — Efficient derived data selectors inspired by NuclearJS
-* [normalizr](https://github.com/paularmstrong/normalizr) — Normalize nested API responses for easier consumption by the reducers
-* [redux-actions](https://github.com/acdlite/redux-actions) — Reduces the boilerplate in writing reducers and action creators
-* [redux-act](https://github.com/pauldijou/redux-act) — An opinionated library for making reducers and action creators
-* [redux-transducers](https://github.com/acdlite/redux-transducers) — Transducer utilities for Redux
-* [redux-immutable](https://github.com/gajus/redux-immutable) — Used to create an equivalent function of Redux `combineReducers` that works with [Immutable.js](https://facebook.github.io/immutable-js/) state.
-* [redux-tcomb](https://github.com/gcanti/redux-tcomb) — Immutable and type-checked state and actions for Redux
-* [redux-mock-store](https://github.com/arnaudbenard/redux-mock-store) — Mock redux store for testing your app
-* [redux-actions-assertions](https://github.com/dmitry-zaets/redux-actions-assertions) — Assertions for Redux actions testing
-* [redux-bootstrap](https://github.com/remojansen/redux-bootstrap) — Bootstrapping function for Redux applications
-* [redux-data-structures](https://redux-data-structures.js.org/) — Reducer factory (higher-order functions) for counters, maps, lists (queues, stacks), sets, etc.
-
-### DevTools
-
-* [Redux DevTools](http://github.com/gaearon/redux-devtools) — An action logger with time travel UI, hot reloading and error handling for the reducers, [first demoed at React Europe](https://www.youtube.com/watch?v=xsSnOQynTHs)
-* [Redux DevTools Extension](https://github.com/zalmoxisus/redux-devtools-extension) — A Chrome extension wrapping Redux DevTools and providing additional functionality
-
-### DevTools Monitors
-
-* [Log Monitor](https://github.com/gaearon/redux-devtools-log-monitor) — The default monitor for Redux DevTools with a tree view
-* [Dock Monitor](https://github.com/gaearon/redux-devtools-dock-monitor) — A resizable and movable dock for Redux DevTools monitors
-* [Slider Monitor](https://github.com/calesce/redux-slider-monitor) — A custom monitor for Redux DevTools to replay recorded Redux actions
-* [Inspector](https://github.com/alexkuz/redux-devtools-inspector) — A custom monitor for Redux DevTools that lets you filter actions, inspect diffs, and pin deep paths in the state to observe their changes
-* [Diff Monitor](https://github.com/whetstone/redux-devtools-diff-monitor) — A monitor for Redux Devtools that diffs the Redux store mutations between actions
-* [Filterable Log Monitor](https://github.com/bvaughn/redux-devtools-filterable-log-monitor/) — Filterable tree view monitor for Redux DevTools
-* [Chart Monitor](https://github.com/romseguy/redux-devtools-chart-monitor) — A chart monitor for Redux DevTools
-* [Filter Actions](https://github.com/zalmoxisus/redux-devtools-filter-actions) — Redux DevTools composable monitor with the ability to filter actions
+This page lists some of the Redux-related addons that the Redux maintainers have vetted personally, or that have shown widespread adoption in the community. Don't let this discourage you from trying the rest of them! The ecosystem is growing too fast, and we have a limited time to look at everything. Consider these the “staff picks”, and don't hesitate to submit a PR if you've built something wonderful with Redux.
 
 
-### Community Conventions
+## Table of Contents
 
-* [Flux Standard Action](https://github.com/acdlite/flux-standard-action) — A human-friendly standard for Flux action objects
-* [Canonical Reducer Composition](https://github.com/gajus/canonical-reducer-composition) — An opinionated standard for nested reducer composition
-* [Ducks: Redux Reducer Bundles](https://github.com/erikras/ducks-modular-redux) — A proposal for bundling reducers, action types and actions
+- [Library Integration and Bindings](#library-integration-and-bindings)
+- [Reducers](#reducers)
+    - [Reducer Combination](#reducer-combination)
+    - [Reducer Composition](#reducer-composition)
+    - [Higher-Order Reducers](#higher-order-reducers)
+- [Actions](#actions)
+- [Utilities](#utilities)
+- [Store](#store)
+    - [Change Subscriptions](#change-subscriptions)
+    - [Batching](#batching)
+    - [Persistence](#persistence)
+- [Immutable Data](#immutable-data)
+    - [Data Structures](#data-structures)
+    - [Immutable Update Utilities](#immutable-update-utilities)
+    - [Immutable/Redux Interop](#immutable-redux-interop)
+- [Side Effects](#side-effects)
+     - [Widely Used](#widely-used)
+     - [Promises](#promises)
+- [Middleware](#middleware)
+     - [Networks and Sockets](#networks-and-sockets)
+     - [Async Behavior](#async-behavior)
+     - [Analytics](#analytics)
+- [Entities and Collections](#entities-and-collections)
+- [Component State and Encapsulation](#component-state-and-encapsulation)
+- [Dev Tools](#dev-tools)
+     - [Debuggers and Viewers](#debuggers-and-viewers)
+     - [Logging](#logging)
+     - [Mutation Detection](#mutation-detection)
+- [Testing](#testing)
+- [Routing](#routing)
+- [Forms](#forms)
+- [Higher-Level Abstractions](#higher-level-abstractions)
+- [Community Conventions](#community-conventions)
+
+
+
+## Library Integration and Bindings
+
+**[reactjs/react-redux](https://github.com/reactjs/react-redux)**  
+The official React bindings for Redux, maintained by the Redux team
+
+**[angular-redux/ng-redux](https://github.com/angular-redux/ng-redux)**  
+Angular 1 bindings for Redux
+
+**[angular-redux/store](https://github.com/angular-redux/store)**  
+Angular 2+ bindings for Redux
+
+**[ember-redux/ember-redux](https://github.com/ember-redux/ember-redux)**  
+Ember bindings for Redux
+
+**[glimmer-redux/glimmer-redux](glimmer-redux/glimmer-redux)**  
+Redux bindings for Ember's Glimmer component engine
+
+**[revue/revue](https://github.com/revue/revue)**  
+Redux bindings for Vue
+
+**[tur-nr/polymer-redux](https://github.com/tur-nr/polymer-redux)**  
+Redux bindings for Polymer
+
+
+## Reducers
+
+#### Reducer Combination
+
+**[ryo33/combineSectionReducers](https://github.com/ryo33/combine-section-reducers)**  
+An expanded version of `combineReducers`, which allows passing `state` as a third argument to all slice reducers.
+
+**[KodersLab/topologically-combine-reducers](https://github.com/KodersLab/topologically-combine-reducers)**  
+A `combineReducers` variation that allows defining cross-slice dependencies for ordering and data passing
+```js
+var masterReducer = topologicallyCombineReducers(
+    {auth, users, todos}, 
+    // define the dependency tree
+    { auth: ['users'], todos: ['auth'] }
+);
+```
+
+#### Reducer Composition
+
+**[acdlite/reduce-reducers](https://github.com/acdlite/reduce-reducers)**  
+Provides sequential composition of reducers at the same level
+```js
+const combinedReducer = combineReducers({users, posts, comments});
+const rootReducer = reduceReducers(combinedReducer, otherTopLevelFeatureReducer);
+```
+
+**[mhelmer/redux-xforms](https://github.com/mhelmer/redux-xforms)**  
+A collection of composable reducer transformers
+```js
+const createByFilter = (predicate, mapActionToKey) => compose(
+  withInitialState({}), // inject initial state as {}
+  withFilter(predicate), // let through if action has filterName
+  updateSlice(mapActionToKey), // update a single key in the state
+  isolateSlice(mapActionToKey) // run the reducer on a single state slice
+)
+```
+
+**[adrienjt/redux-data-structures](https://github.com/adrienjt/redux-data-structures)**  
+Reducer factory functions for common data structures: counters, maps, lists (queues, stacks), sets
+```js
+const myCounter = counter({
+  incrementActionTypes: ['INCREMENT'],
+  decrementActionTypes: ['DECREMENT'],
+});
+```
+
+#### Higher-Order Reducers
+
+**[omnidan/redux-undo](https://github.com/omnidan/redux-undo)**  
+Effortless undo/redo and action history for your reducers
+
+**[omnidan/redux-ignore](https://github.com/omnidan/redux-ignore)**  
+Ignore redux actions by array or filter function
+
+**[omnidan/redux-recycle](https://github.com/omnidan/redux-recycle)**  
+Reset the redux state on certain actions
+
+**[ForbesLindesay/redux-optimist](https://github.com/ForbesLindesay/redux-optimist)**  
+A reducer enhancer to enable type-agnostic optimistic updates
+
+
+## Actions
+
+**[reduxactions/redux-actions](https://github.com/reduxactions/redux-actions)**  
+Flux Standard Action utilities for Redux
+```js
+const increment = createAction('INCREMENT');
+const reducer = handleActions({ [increment] : (state, action) => state + 1 }, 0);
+const store = createStore(reducer);
+store.dispatch(increment());
+```
+
+**[BerkeleyTrue/redux-create-types](https://github.com/BerkeleyTrue/redux-create-types)**  
+Creates standard and async action types based on namespaces
+```js
+export const types = createTypes( [ 'openModal', createAsyncTypes('fetch') ], 'app');
+// { openModal : "app.openModal", fetch : { start : "app.fetch.start", complete: 'app.fetch.complete' } }
+```
+
+**[maxhallinan/kreighter](https://github.com/maxhallinan/kreighter)**  
+Generates action creators based on types and expected fields
+```js
+const formatTitle = (id, title) => ({
+  id, title: toTitleCase(title),
+});
+const updateBazTitle = fromType('UPDATE_BAZ_TITLE', formatTitle);
+updateBazTitle(1, 'foo bar baz');
+// -> { type: 'UPDATE_BAZ_TITLE', id: 1, title: 'Foo Bar Baz', }
+```
+
+
+## Utilities
+
+**[reactjs/reselect](https://github.com/reactjs/reselect)**  
+Creates composable memoized selector functions for efficiently deriving data from the store state
+```js
+const taxSelector = createSelector(
+  [subtotalSelector, taxPercentSelector],
+  (subtotal, taxPercent) => subtotal * (taxPercent / 100)
+)
+```
+
+**[paularmstrong/normalizr](https://github.com/paularmstrong/normalizr)**  
+Normalizes nested JSON according to a schema
+```js
+const user = new schema.Entity('users');
+const comment = new schema.Entity('comments', { commenter: user});
+const article = new schema.Entity('articles', { author: user, comments: [ comment ] });
+const normalizedData = normalize(originalData, article);
+```
+
+**[planttheidea/selectorator](https://github.com/planttheidea/selectorator)**  
+Abstractions over Reselect for common selector use cases
+```js
+const getBarBaz = createSelector(['foo.bar', 'baz'], 
+    (bar, baz) => `${bar} ${baz}`
+);
+getBarBaz({foo: {bar: 'a'}, baz: 'b'}); // "a b"
+```
+
+
+## Store
+
+#### Change Subscriptions
+
+**[jprichardson/redux-watch](https://github.com/jprichardson/redux-watch)**  
+Watch for state changes based on key paths or selectors
+```js
+let w = watch(() => mySelector(store.getState()) );
+store.subscribe( w((newVal, oldVal) => {
+  console.log(newval, oldVal)
+}))
+```
+
+
+**[ashaffer/redux-subscribe](https://github.com/ashaffer/redux-subscribe)**  
+Centralized subscriptions to state changes based on paths
+```js
+store.dispatch( subscribe("users.byId.abcd", "subscription1", () => {} );
+```
+
+#### Batching
+
+**[tappleby/redux-batched-subscribe](https://github.com/tappleby/redux-batched-subscribe)**  
+Store enhancer that can debounce subscription notifications
+```js
+const debounceNotify = _.debounce(notify => notify());
+const store = createStore(reducer, intialState, batchedSubscribe(debounceNotify));
+```
+
+**[manaflair/redux-batch](https://github.com/manaflair/redux-batch)**  
+Store enhancer that allows dispatching arrays of actions
+```js
+const store = createStore(reducer, reduxBatch);
+store.dispatch([ {type : "INCREMENT"}, {type : "INCREMENT"} ]);
+```
+
+**[laysent/redux-batch-actions-enhancer](https://github.com/laysent/redux-batch-actions-enhancer)**  
+Store enhancer that accepts batched actions
+```js
+const store = createStore(reducer, initialState, batch().enhancer);
+store.dispatch(createAction({type : "INCREMENT"}, {type : "INCREMENT"}));
+```
+
+**[tshelburne/redux-batched-actions](https://github.com/tshelburne/redux-batched-actions)**  
+Higher-order reducer that handles batched actions
+```js
+const store = createStore(enableBatching(reducer), initialState)
+store.dispatch(batchActions([ {type : "INCREMENT"}, {type : "INCREMENT"} ]))
+```
+
+#### Persistence
+
+
+**[rt2zz/redux-persist]()**  
+Persist and rehydrate a Redux store, with many extensible options
+```js
+const store = createStore( reducer, autoRehydrate());
+persistStore(store);
+```
+
+**[react-stack/redux-storage]()**  
+Persistence layer for Redux with flexible backends
+```js
+const reducer = storage.reducer(combineReducers(reducers));
+const engine = createEngineLocalStorage('my-save-key');
+const storageMiddleware = storage.createMiddleware(engine);
+const store = createStore(reducer, applyMiddleware(storageMiddleware));
+```
+
+**[redux-offline/redux-offline]()**  
+Persistent store for Offline-First apps, with support for optimistic UIs
+```js
+const store = createStore(reducer, offline(offlineConfig));
+store.dispatch({ 
+  type: 'FOLLOW_USER_REQUEST',
+  meta: { offline: { effect: { }, commit: { }, rollback: { } } }
+});
+```
+
+
+## Immutable Data
+
+#### Data Structures
+
+**[facebook/immutable-js]()**  
+Immutable persistent data collections for Javascript
+```js
+const map1 = Map({ a: 1, b: 2, c: 3 })
+const map2 = map1.set('b', 50)
+map1.get('b') // 2
+map2.get('b') // 50
+```
+
+**[rtfeldman/seamless-immutable]()**  
+Frozen immutable arrays/objects, backwards-compatible with JS
+```js
+const array = Immutable(["totally", "immutable", {a : 42}]);
+array[0] = "edited"; // does nothing
+```
+
+**[planttheidea/crio]()**  
+Immutable JS objects with a natural API
+```js
+const foo = crio(['foo']);
+const fooBar = foo.push('bar'); // new array: ['foo', 'bar']
+```
+
+
+**[aearly/icepick]()**  
+Utilities for treating frozen JS objects as persistent immutable collections.
+```js
+const newObj = icepick.assocIn({c : {d : "bar" } }, ["c", "d"], "baz");
+const obj3 = icepicke.merge(obj1, obj2);
+```
+
+#### Immutable Update Utilities
+
+**[kolodny/immutability-helper]()**  
+A drop-in replacement for react-addons-update
+```js
+const newData = update(myData, {
+  x: {y: {z: {$set: 7}}},
+  a: {b: {$push: [9]}}
+});
+```
+
+**[mariocasciaro/object-path-immutable]()**  
+Simpler alternative to immutability-helpers and Immutable.js
+```js
+const newObj = immutable(obj)
+                   .set('a.b', 'f')
+                   .del(['a', 'c', 0])
+                   .value()
+```
+
+
+
+**[debitoor/dot-prop-immutable]()**  
+Immutable version of the dot-prop lib, with some extensions
+```js
+const newState = dotProp.set(state, `todos.${index}.complete`, true)
+const endOfArray = dotProp.get(obj, 'foo.$end')
+```
+
+**[hex13/transmutable]()**  
+Immutable updates with normal mutative code, using Proxies
+```js
+const copy = transform(foo, stage => {
+    stage.bar.baz = 123; 
+});
+```
+
+#### Immutable/Redux Interop
+
+**[gajus/redux-immutable]()**  
+combineReducers equivalent that works with Immutable.js Maps
+```js
+const initialState = Immutable.Map();
+const rootReducer = combineReducers({});
+const store = createStore(rootReducer, initialState);
+```
+
+**[eadmundo/redux-seamless-immutable]()**  
+combineReducers equivalent that works with seamless-immutable values
+```js
+import { combineReducers } from 'redux-seamless-immutable';
+const rootReducer = combineReducers({ userReducer, posts
+```
+
+
+## Side Effects
+
+#### Widely Used
+
+**[gaearon/redux-thunk](https://github.com/gaearon/redux-thunk)**  
+Dispatch functions, which are called and given `dispatch` and `getState` as parameters. This acts as a loophole for AJAX calls and other async behavior.
+
+**Best for**: getting started, simple async and complex synchronous logic.
+```js
+function fetchData(someValue) {
+    return (dispatch, getState) => {
+        dispatch({type : "REQUEST_STARTED"});
+        
+        myAjaxLib.post("/someEndpoint", {data : someValue})
+            .then(response => dispatch({type : "REQUEST_SUCCEEDED", payload : response})
+            .catch(error => dispatch({type : "REQUEST_FAILED", error : error});    
+    };
+}
+
+function addTodosIfAllowed(todoText) {
+    return (dispatch, getState) => {
+        const state = getState();
+        
+        if(state.todos.length < MAX_TODOS) {
+            dispatch({type : "ADD_TODO", text : todoText});
+        }    
+    }
+}
+```
+
+
+**[redux-saga/redux-saga](https://github.com/redux-saga/redux-saga)**  
+Handle async logic using synchronous-looking generator functions. Sagas return descriptions of effects, which are executed by the saga middleware, and act like "background threads" for JS applications.
+
+**Best for**: complex async logic, decoupled workflows
+```js
+function* fetchData(action) {
+    const {someValue} = action;
+    try {
+        const result = yield call(myAjaxLib.post, "/someEndpoint", {data : someValue});
+        yield put({type : "REQUEST_SUCCEEDED", payload : response});
+    }
+    catch(error) {
+        yield put({type : "REQUEST_FAILED", error : error});
+    }
+}
+
+function* addTodosIfAllowed(action) {
+    const {todoText} = action;
+    const todos = yield select(state => state.todos);
+    
+    if(todos.length < MAX_TODOS) {
+        yield put({type : "ADD_TODO", text : todoText});
+    }
+}
+```
+
+**[redux-observable/redux-observable](https://github.com/redux-observable/redux-observable)**  
+
+Handle async logic using RxJS observable chains called "epics". 
+Compose and cancel async actions to create side effects and more.
+
+Best for: complex async logic, decoupled workflows
+```js
+const loginRequestEpic = (action$) => 
+    action$.ofType(LOGIN_REQUEST)
+        .mergeMap(({ payload: { username, password } }) => 
+            Observable.from(postLogin(username, password))
+                .map(loginSuccess)
+                .catch(loginFailure)
+         );
+         
+const loginSuccessfulEpic = (action$) => 
+    action$.ofType(LOGIN_SUCCESS)
+        .delay(2000)
+        .mergeMap(({ payload: { msg } }) =>
+            showMessage(msg)
+        );
+        
+const rootEpic = combineEpics(loginRequestEpic, loginSuccessfulEpic);
+```
+
+
+**[redux-loop/redux-loop](https://github.com/redux-loop/redux-loop)**  
+
+A port of the Elm Architecture to Redux that allows you to sequence your effects naturally and purely by returning them from your reducers. Reducers now return both a state value and a side effect description.
+
+Best for: trying to be as much like Elm as possible in Redux+JS
+```js
+export const reducer = (state = {}, action) => {
+    switch(action.type) {
+        case ActionType.LOGIN_REQUEST:
+            const {username, password} = action.payload;
+            return loop(
+                {pending : true},
+                Effect.promise(loginPromise, username, password)
+            );
+        case ActionType.LOGIN_SUCCESS:
+            const {user, msg} = action.payload;
+            return loop(
+                {pending : false, user},
+                Effect.promise(delayMessagePromise, msg, 2000)
+            );
+        case ActionType.LOGIN_FAILURE:
+            return {pending : false, err : action.payload};
+        default : return state;
+    }
+}
+```
+
+**[jeffbski/redux-logic](https://github.com/jeffbski/redux-logic)**  
+
+Side effects lib built with observables, but allows use of callbacks, promises, async/await, or observables. Provides declarative processing of actions.
+
+Best for: very decoupled async logic
+```js
+const loginLogic = createLogic({
+    type : Actions.LOGIN_REQUEST,
+    
+    process({getState, action}, dispatch, done) {
+        const {username, password} = action.payload;
+        
+        postLogin(username, password)
+            .then( ({user, msg}) => {
+                dispatch(loginSucceeded(user));
+                
+                setTimeout(() => dispatch(showMessage(msg)), 2000);
+            },
+            (err) => dispatch(loginFailure(err))
+        )
+        .then(done);
+    }
+});
+```
+
+#### Promises
+
+**[acdlite/redux-promise](https://github.com/acdlite/redux-promise)**  
+Dispatch promises as action payloads, and have FSA-compliant actions dispatched as the promise resolves or rejects.
+```js
+dispatch({type : "FETCH_DATA", payload : myAjaxLib.get("/data") });
+// will dispatch either {type : "FETCH_DATA", payload : response} if resolved, 
+// or dispatch {type : "FETCH_DATA", payload : error, error : true} if rejected
+```
+
+
+**[lelandrichardson/redux-pack](https://github.com/lelandrichardson/redux-pack)**  
+Sensible, declarative, convention-based promise handling that guides users in a good direction without exposing the full power of dispatch.
+```js
+dispatch({type : "FETCH_DATA", payload : myAjaxLib.get("/data") });
+
+// in a reducer:
+        case "FETCH_DATA": =
+            return handle(state, action, {
+                start: prevState => ({
+                  ...prevState,
+                  isLoading: true,
+                  fooError: null
+                }),
+                finish: prevState => ({ ...prevState, isLoading: false }),
+                failure: prevState => ({ ...prevState, fooError: payload }),
+                success: prevState => ({ ...prevState, foo: payload }),
+            });
+```
+
+
+
+## Middleware
+
+#### Networks and Sockets
+
+**[svrcekmichal/redux-axios-middleware](https://github.com/svrcekmichal/redux-axios-middleware)**  
+Fetches data with Axios and dispatches start/success/fail actions
+```js
+export const loadCategories() => ({ type: 'LOAD', payload: { request : { url: '/categories'} } });
+```
+
+**[agraboso/redux-api-middleware](https://github.com/agraboso/redux-api-middleware)**  
+Reads API call actions, fetches, and dispatches FSAs
+```js
+const fetchUsers = () => ({
+  [CALL_API]: { endpoint: 'http://www.example.com/api/users', method: 'GET', types: ['REQUEST', 'SUCCESS', 'FAILURE'] }
+});
+```
+
+**[itaylor/redux-socket.io](https://github.com/itaylor/redux-socket.io)**  
+An opinionated connector between socket.io and redux.
+```js
+const store = createStore(reducer, applyMiddleware(socketIoMiddleware));
+store.dispatch({type : "server/hello", data : "Hello!"});
+```
+
+**[tiberiuc/redux-react-firebase](https://github.com/tiberiuc/redux-react-firebase)**  
+Integration between Firebase, React, and Redux
+
+
+#### Async Behavior
+
+**[rt2zz/redux-action-buffer](https://github.com/rt2zz/redux-action-buffer)** 
+Buffers all actions into a queue until a breaker condition is met, at which point the queue is released
+
+**[wyze/redux-debounce](https://github.com/wyze/redux-debounce)** 
+FSA-compliant middleware for Redux to debounce actions.
+
+**[mathieudutour/redux-queue-offline](https://github.com/mathieudutour/redux-queue-offline)** 
+Queue actions when offline and dispatch them when getting back online.
+
+
+#### Analytics
+
+**[rangle/redux-beacon](https://github.com/rangle/redux-beacon)** 
+Integrates with any analytics services, can track while offline, and decouples analytics logic from app logic
+
+**[hyperlab/redux-insights](https://github.com/hyperlab/redux-insights)** 
+Analytics and tracking with an easy API for writing your own adapters
+
+**[markdalgleish/redux-analytics](https://github.com/markdalgleish/redux-analytics)** 
+Watches for Flux Standard Actions with meta analytics values and processes them
+
+
+## Entities and Collections
+
+**[tommikaikkonen/redux-orm](https://github.com/tommikaikkonen/redux-orm)**  
+A simple immutable ORM to manage relational data in your Redux store.
+
+**[Versent/redux-crud](https://github.com/Versent/redux-crud)**  
+Convention-based actions and reducers for CRUD logic
+
+**[kwelch/entities-reducer](https://github.com/kwelch/entities-reducer)**  
+A higher-order reducer that handles data from Normalizr
+
+**[amplitude/redux-query](https://github.com/amplitude/redux-query)**  
+Declare colocated data dependencies with your components, run queries when components mount, perform optimistic updates, and trigger server changes with Redux actions.
+
+**[cantierecreativo/redux-bees](https://github.com/cantierecreativo/redux-bees)**  
+Declarative JSON-API interaction that normalizes data, with a React HOC that can run queries
+
+**[GetAmbassador/redux-clerk](https://github.com/GetAmbassador/redux-clerk)**  
+Async CRUD handling with normalization, optimistic updates, sync/async action creators, selectors, and an extendable reducer.
+
+**[shoutem/redux-io](https://github.com/shoutem/redux-io)**  
+JSON-API abstraction with async CRUD, normalization, optimistic updates, caching, data status, and error handling.
+
+**[jmeas/redux-resource](https://github.com/jmeas/redux-resource)**  
+A tiny but powerful system for managing 'resources': data that is persisted to remote servers.
+
+
+## Component State and Encapsulation
+
+**[tonyhb/redux-ui](https://github.com/tonyhb/redux-ui)**  
+"Block-level scoping" for UI state. Decorated components declare data fields, which become props and can be updated by nested children.
+```js
+@ui({ 
+    key: 'some-name', state: {  uiVar1: '', uiVar2: (props, state) => state.someValue }, reducer : (state, action) => { } 
+})
+class YourComponent extends React.Component {}
+```
+
+**[threepointone/redux-react-local](https://github.com/threepointone/redux-react-local)**  
+Local component state in Redux, with handling for component actions
+```js
+@local({
+  ident: 'counter', initial: 0, reducer : (state, action) => action.me ? state + 1 : state }
+})
+class Counter extends React.Component {
+```
+
+
+**[epeli/lean-redux](https://github.com/epeli/lean-redux)**  
+Makes component state in Redux as easy as setState
+```js
+const DynamicCounters = connectLean(
+    scope: "dynamicCounters",
+    getInitialState() => ({counterCount : 1}),
+    addCounter, removeCOunter
+)(CounterList);
+```
+
+**[ioof-holdings/redux-subspace](https://github.com/ioof-holdings/redux-subspace)**  
+Creates isolated "sub-stores" for decoupled micro front-ends, with integration for React, sagas, and observables
+```js
+const reducer = combineReducers({
+    subApp1: namespaced('subApp1')(counter),
+    subApp2: namespaced('subApp2')(counter)
+});
+
+const subApp1Store = subspace((state) => state.subApp1, 'subApp1')(store)
+const subApp2Store = subspace((state) => state.subApp2, 'subApp2')(store)
+
+subApp1Store.dispatch({ type: 'INCREMENT' })
+console.log('store state:', store.getState()) // { "subApp1": { value: 2 }, "subApp2": { value: 1 } }
+```
+
+
+**[DataDog/redux-doghouse](https://github.com/DataDog/redux-doghouse)**  
+Aims to make reusable components easier to build with Redux by scoping actions and reducers to a particular instance of a component.
+```js
+const scopeableActions = new ScopedActionFactory(actionCreators);
+const actionCreatorsScopedToA = scopeableActions.scope('a');
+actionCreatorsScopedToA.foo('bar'); //{ type: SET_FOO, value: 'bar', scopeID: 'a' }
+
+const boundScopeableActions = bindScopedActionFactories(scopeableActions, store.dispatch);
+const scopedReducers = scopeReducers(reducers);
+```
+
+
+## Dev Tools
+
+#### Debuggers and Viewers
+
+**[gaearon/redux-devtools](https://github.com/gaearon/redux-devtools)**  
+
+Dan Abramov's original Redux DevTools implementation, built for in-app display of state and time-travel debugging
+
+**[zalmoxisus/redux-devtools-extension](https://github.com/zalmoxisus/redux-devtools-extension)**  
+
+Mihail Diordiev's browser extension, which bundles multiple state monitor views and adds integration with the browser's own dev tools
+
+**[infinitered/reactotron](https://github.com/infinitered/reactotron)**  
+
+A cross-platform Electron app for inspecting React and React Native apps, including app state, API requests, perf, errors, sagas, and action dispatching.
+
+#### DevTools Monitors
+
+**[Log Monitor](https://github.com/gaearon/redux-devtools-log-monitor)**  
+The default monitor for Redux DevTools with a tree view
+
+**[Dock Monitor](https://github.com/gaearon/redux-devtools-dock-monitor)**  
+A resizable and movable dock for Redux DevTools monitors
+
+**[Slider Monitor](https://github.com/calesce/redux-slider-monitor)**  
+A custom monitor for Redux DevTools to replay recorded Redux actions
+
+**[Inspector](https://github.com/alexkuz/redux-devtools-inspector)**  
+A custom monitor for Redux DevTools that lets you filter actions, inspect diffs, and pin deep paths in the state to observe their changes
+
+**[Diff Monitor](https://github.com/whetstone/redux-devtools-diff-monitor)**  
+A monitor for Redux Devtools that diffs the Redux store mutations between actions
+
+**[Filterable Log Monitor](https://github.com/bvaughn/redux-devtools-filterable-log-monitor/)**  
+Filterable tree view monitor for Redux DevTools
+
+**[Chart Monitor](https://github.com/romseguy/redux-devtools-chart-monitor)**  
+A chart monitor for Redux DevTools
+
+**[Filter Actions](https://github.com/zalmoxisus/redux-devtools-filter-actions)**  
+Redux DevTools composable monitor with the ability to filter actions
+
+
+#### Logging
+
+**[evgenyrodionov/redux-logger](https://github.com/evgenyrodionov/redux-logger)**  
+Logging middleware that shows actions, states, and diffs
+
+**[inakianduaga/redux-state-history](https://github.com/inakianduaga/redux-state-history)**  
+Enhancer that provides time-travel and efficient action recording capabilities, including import/export of action logs and action playback.
+
+**[joshwcomeau/redux-vcr](https://github.com/joshwcomeau/redux-vcr)**  
+Record and replay user sessions in real-time
+
+**[socialtables/redux-unhandled-action](https://github.com/socialtables/redux-unhandled-action)**  
+Warns about actions that produced no state changes in development
+
+
+#### Mutation Detection
+
+**[leoasis/redux-immutable-state-invariant](https://github.com/leoasis/redux-immutable-state-invariant)**  
+Middleware that throws an error when you try to mutate your state either inside a dispatch or between dispatches.
+
+**[flexport/mutation-sentinel](https://github.com/flexport/mutation-sentinel)**  
+Helps you deeply detect mutations at runtime and enforce immutability in your codebase.
+
+**[mmahalwy/redux-pure-connect](https://github.com/mmahalwy/redux-pure-connect)**  
+Check and log whether react-redux's connect method is passed `mapState` functions that create impure props.
+
+
+
+## Testing
+
+**[arnaudbenard/redux-mock-store](https://github.com/arnaudbenard/redux-mock-store)**  
+A mock store that saves dispatched actions in an array for assertions
+
+**[Workable/redux-test-belt](https://github.com/Workable/redux-test-belt)**  
+Extends the store API to make it easier assert, isolate, and manipulate the store
+
+**[conorhastings/redux-test-recorder](https://github.com/conorhastings/redux-test-recorder)**  
+Middleware to automatically generate reducers tests based on actions in the app
+
+**[wix/redux-testkit](https://github.com/wix/redux-testkit)**  
+Complete and opinionated testkit for testing Redux projects (reducers, selectors, actions, thunks)
+
+**[jfairbank/redux-saga-test-plan](https://github.com/jfairbank/redux-saga-test-plan)**  
+Makes integration and unit testing of sagas a breeze
+
+
+## Routing
+
+**[ReactTraining/react-router-redux](https://github.com/ReactTraining/react-router/tree/master/packages/react-router-redux)**  
+Keep your state in sync with your router
+
+**[FormidableLabs/redux-little-router](https://github.com/FormidableLabs/redux-little-router)**  
+A tiny router for Redux applications that lets the URL do the talking
+
+**[faceyspacey/redux-first-router](https://github.com/faceyspacey/redux-first-router)**  
+Seamless Redux-first routing. Think of your app in states, not routes, not components, while keeping the address bar in sync. Everything is state. Connect your components and just dispatch flux standard actions.
+
+
+## Forms
+
+**[erikras/redux-form](https://github.com/erikras/redux-form)**  
+A full-featured library to enable a React HTML form to store its state in Redux. 
+
+**[davidkpiano/react-redux-form](https://github.com/davidkpiano/react-redux-form)**  
+React Redux Form is a collection of reducer creators and action creators that make implementing even the most complex and custom forms with React and Redux simple and performant.
+
+
+## Higher-Level Abstractions
+
+**[keajs/kea](https://github.com/keajs/kea)**  
+An abstraction over Redux, Redux-Saga and Reselect. Provides a framework for your app’s actions, reducers, selectors and sagas. It empowers Redux, making it as simple to use as setState. It reduces boilerplate and redundancy, while retaining composability.
+
+**[jumpsuit/jumpstate](https://github.com/jumpsuit/jumpstate)**  
+A simplified layer over Redux. No action creators or explicit dispatching, with a built-in simple side effects system.
+
+**[TheComfyChair/redux-scc](https://github.com/TheComfyChair/redux-scc)**  
+Takes a defined structure and uses 'behaviors' to create a set of actions, reducer responses and selectors.
+
+**[Bloomca/redux-tiles](https://github.com/Bloomca/redux-tiles)**  
+Provides minimal abstraction on top of Redux, to allow easy composability, easy async requests, and sane testability.
+
+
+## Community Conventions
+
+**[Flux Standard Action](https://github.com/acdlite/flux-standard-action)**  
+A human-friendly standard for Flux action objects
+
+**[Canonical Reducer Composition](https://github.com/gajus/canonical-reducer-composition)**  
+An opinionated standard for nested reducer composition
+
+**[Ducks: Redux Reducer Bundles](https://github.com/erikras/ducks-modular-redux)**  
+A proposal for bundling reducers, action types and actions
+
+
+
+

--- a/docs/introduction/Ecosystem.md
+++ b/docs/introduction/Ecosystem.md
@@ -6,45 +6,6 @@ For an extensive list of everything related to Redux, we recommend [Awesome Redu
 
 On this page we will only feature a few of them that the Redux maintainers have vetted personally. Don't let this discourage you from trying the rest of them! The ecosystem is growing too fast, and we have a limited time to look at everything. Consider these the “staff picks”, and don't hesitate to submit a PR if you've built something wonderful with Redux.
 
-## Learning Redux
-
-### Screencasts
-
-* **[Getting Started with Redux](https://egghead.io/series/getting-started-with-redux)** — Learn the basics of Redux directly from its creator (30 free videos)
-* **[Learn Redux](https://learnredux.com)** — Build a simple photo app that will simplify the core ideas behind Redux, React Router and React.js
-
-### Example Apps
-
-* [Official Examples](Examples.md) — A few official examples covering different Redux techniques
-* [SoundRedux](https://github.com/andrewngu/sound-redux) — A SoundCloud client built with Redux
-* [grafgiti](https://github.com/mohebifar/grafgiti) — Create graffiti on your GitHub contributions wall
-* [React-lego](https://github.com/peter-mouland/react-lego) — How to plug into React, one block at a time.
-
-### Tutorials and Articles
-
-* [Redux Tutorial](https://github.com/happypoulp/redux-tutorial)
-* [Redux Egghead Course Notes](https://github.com/tayiorbeii/egghead.io_redux_course_notes)
-* [Integrating Data with React Native](http://makeitopen.com/docs/en/1-3-data.html)
-* [What the Flux?! Let's Redux.](https://blog.andyet.com/2015/08/06/what-the-flux-lets-redux)
-* [Leveling Up with React: Redux](https://css-tricks.com/learning-react-redux/)
-* [A cartoon intro to Redux](https://code-cartoons.com/a-cartoon-intro-to-redux-3afb775501a6)
-* [Understanding Redux](http://www.youhavetolearncomputers.com/blog/2015/9/15/a-conceptual-overview-of-redux-or-how-i-fell-in-love-with-a-javascript-state-container)
-* [Handcrafting an Isomorphic Redux Application (With Love)](https://medium.com/@bananaoomarang/handcrafting-an-isomorphic-redux-application-with-love-40ada4468af4)
-* [Full-Stack Redux Tutorial](http://teropa.info/blog/2015/09/10/full-stack-redux-tutorial.html)
-* [Getting Started with React, Redux, and Immutable](http://www.theodo.fr/blog/2016/03/getting-started-with-react-redux-and-immutable-a-test-driven-tutorial-part-2/)
-* [Secure Your React and Redux App with JWT Authentication](https://auth0.com/blog/2016/01/04/secure-your-react-and-redux-app-with-jwt-authentication/)
-* [Understanding Redux Middleware](https://medium.com/@meagle/understanding-87566abcfb7a)
-* [Angular 2 — Introduction to Redux](https://medium.com/google-developer-experts/angular-2-introduction-to-redux-1cf18af27e6e)
-* [Apollo Client: GraphQL with React and Redux](https://medium.com/apollo-stack/apollo-client-graphql-with-react-and-redux-49b35d0f2641)
-* [Using redux-saga To Simplify Your Growing React Native Codebase](https://shift.infinite.red/using-redux-saga-to-simplify-your-growing-react-native-codebase-2b8036f650de)
-* [Build an Image Gallery Using Redux Saga](http://joelhooks.com/blog/2016/03/20/build-an-image-gallery-using-redux-saga)
-* [Working with VK API (in Russian)](https://www.gitbook.com/book/maxfarseer/redux-course-ru/details)
-
-### Talks
-
-* [Live React: Hot Reloading and Time Travel](http://youtube.com/watch?v=xsSnOQynTHs) — See how constraints enforced by Redux make hot reloading with time travel easy
-* [Cleaning the Tar: Using React within the Firefox Developer Tools](https://www.youtube.com/watch?v=qUlRpybs7_c) — Learn how to gradually migrate existing MVC applications to Redux
-* [Redux: Simplifying Application State](https://www.youtube.com/watch?v=okdC5gcD-dM) — An intro to Redux architecture
 
 ## Using Redux
 
@@ -138,16 +99,3 @@ On this page we will only feature a few of them that the Redux maintainers have 
 * [Flux Standard Action](https://github.com/acdlite/flux-standard-action) — A human-friendly standard for Flux action objects
 * [Canonical Reducer Composition](https://github.com/gajus/canonical-reducer-composition) — An opinionated standard for nested reducer composition
 * [Ducks: Redux Reducer Bundles](https://github.com/erikras/ducks-modular-redux) — A proposal for bundling reducers, action types and actions
-
-### Translations
-
-* [中文文档](http://camsong.github.io/redux-in-chinese/) — Chinese
-* [繁體中文文件](https://github.com/chentsulin/redux) — Traditional Chinese
-* [Redux in Russian](https://github.com/rajdee/redux-in-russian) — Russian
-* [Redux en Español](http://es.redux.js.org/) - Spanish
-
-## More
-
-[Awesome Redux](https://github.com/xgrommx/awesome-redux) is an extensive list of Redux-related repositories.  
-[React-Redux Links](https://github.com/markerikson/react-redux-links) is a curated list of high-quality articles, tutorials, and related content for React, Redux, ES6, and more.  
-[Redux Ecosystem Links](https://github.com/markerikson/redux-ecosystem-links) is a categorized collection of Redux-related libraries, addons, and utilities.

--- a/docs/introduction/Ecosystem.md
+++ b/docs/introduction/Ecosystem.md
@@ -422,7 +422,7 @@ function* addTodosIfAllowed(action) {
 Handle async logic using RxJS observable chains called "epics". 
 Compose and cancel async actions to create side effects and more.
 
-Best for: complex async logic, decoupled workflows
+**Best for**: complex async logic, decoupled workflows
 ```js
 const loginRequestEpic = (action$) => 
     action$.ofType(LOGIN_REQUEST)
@@ -447,7 +447,7 @@ const rootEpic = combineEpics(loginRequestEpic, loginSuccessfulEpic);
 
 A port of the Elm Architecture to Redux that allows you to sequence your effects naturally and purely by returning them from your reducers. Reducers now return both a state value and a side effect description.
 
-Best for: trying to be as much like Elm as possible in Redux+JS
+**Best for**: trying to be as much like Elm as possible in Redux+JS
 ```js
 export const reducer = (state = {}, action) => {
     switch(action.type) {
@@ -474,7 +474,7 @@ export const reducer = (state = {}, action) => {
 
 Side effects lib built with observables, but allows use of callbacks, promises, async/await, or observables. Provides declarative processing of actions.
 
-Best for: very decoupled async logic
+**Best for**: very decoupled async logic
 ```js
 const loginLogic = createLogic({
     type : Actions.LOGIN_REQUEST,

--- a/docs/introduction/LearningResources.md
+++ b/docs/introduction/LearningResources.md
@@ -1,0 +1,399 @@
+# Learning Resources
+
+The Redux docs are intended to teach the basic concepts of Redux, as well as explain key concepts for use in real-world applications.  However, the docs can't cover everything.  Happily, there's many other great resources available for learning Redux.  We encourage you to check them out.  Many of them cover topics that are beyond the scope of the docs, or describe the same topics in other ways that may work better for your learning style.
+
+This page includes our recommendations for some of the best external resources available to learn Redux.  For an additional extensive list of tutorials, articles, and other resources on React, Redux, Javascript, and related topics, see the [React/Redux Links list](https://github.com/markerikson/react-redux-links).
+
+
+## Basic Introductions
+
+*Tutorials that teach the basic concepts of Redux and how to use it*
+
+- **Getting Started with Redux - Video Series**  
+  https://egghead.io/series/getting-started-with-redux  
+  https://github.com/tayiorbeii/egghead.io_redux_course_notes  
+  Dan Abramov, the creator of Redux, demonstrates various concepts in 30 short (2-5 minute) videos.  The linked Github repo contains notes and transcriptions of the videos.
+
+- **Building React Applications with Idiomatic Redux - Video Series**  
+  https://egghead.io/series/building-react-applications-with-idiomatic-redux  
+  https://github.com/tayiorbeii/egghead.io_idiomatic_redux_course_notes  
+  Dan Abramov's second video tutorial series, continuing directly after the first.  Includes lessons on store initial state, using Redux with React Router, using "selector" functions, normalizing state, use of Redux middleware, async action creators, and more.  The linked Github repo contains notes and transcriptions of the videos.
+  
+- **Live React: Hot Reloading and Time Travel**  
+  http://youtube.com/watch?v=xsSnOQynTHs
+  Dan Abramov's original conference talk that introduced Redux.  See how constraints enforced by Redux make hot reloading with time travel easy
+  
+- **A Cartoon Guide to Redux**  
+  https://code-cartoons.com/a-cartoon-intro-to-redux-3afb775501a6  
+  A high-level description of Redux, with friendly cartoons to help illustrate the ideas. 
+
+- **Leveling Up with React: Redux**  
+  https://css-tricks.com/learning-react-redux/  
+  A very well-written introduction to Redux and its related concepts, with some nifty cartoon-ish diagrams.
+  
+- **An Introduction to Redux**  
+  https://www.smashingmagazine.com/2016/06/an-introduction-to-redux/  
+  An overview and intro to the basic concepts of Redux.  Looks at the benefits of using Redux, how it differs from MVC or Flux, and its relation to functional programming.
+  
+- **Redux Tutorial**  
+  https://www.pshrmn.com/tutorials/react/redux/  
+  A short, clear tutorial that introduces basic Redux terms, shows how to split reducer functions, and describes the Redux store API.
+  
+  
+- **Redux: From Twitter Hype to Production**  
+  http://slides.com/jenyaterpil/redux-from-twitter-hype-to-production#/  
+  An extremely well-produced slideshow that visually steps through core Redux concepts, usage with React, project organization, and side effects with thunks and sagas.  Has some absolutely _fantastic_ animated diagrams demonstrating how data flows through a React+Redux architecture.
+  
+- **DevGuides: Introduction to Redux**  
+  http://devguides.io/redux/  
+  A tutorial that covers several aspects of Redux, including actions, reducers, usage with React, and middleware.
+
+
+
+## Using Redux With React
+
+*Explanations of the React-Redux bindings and the `connect` function*
+
+- **Why Redux is Useful in React Apps**  
+  https://www.fullstackreact.com/articles/redux-with-mark-erikson/  
+  An explanation of some of the benefits of using Redux with React, including sharing data between components and hot module reloading.
+   
+
+- **What Does Redux Do? (and when should you use it?)**  
+  https://daveceddia.com/what-does-redux-do/  
+  An excellent summary of how Redux helps solve data flow problems in a React app.
+  
+- **How Redux Works: A Counter-Example**  
+  https://daveceddia.com/how-does-redux-work/  
+  A great follow-up to the previous article.  It explains how to use Redux and React-Redux, by first showing a React component that stores a value in its internal state, and then refactoring it to use Redux instead.  Along the way, the article explains important Redux terms and concepts, and how they all fit together to make the Redux data flow work properly.
+  
+- **Redux and React: An Introduction**  
+  http://jakesidsmith.com/blog/post/2017-11-18-redux-and-react-an-introduction/  
+  A great introduction to Redux's core concepts, with explanations of how to use the React-Redux package to use Redux with React.
+
+- **React Redux Tutorial**  
+   https://www.pshrmn.com/tutorials/react/react-redux  
+   A clear, easy-to-read explanation of how to use the React-Redux `connect` API. 
+
+
+## Project-Based Tutorials
+
+*Tutorials that teach Redux concepts by building projects, including larger  "real-world"-type applications*
+  
+- **Practical Redux**  
+  http://blog.isquaredsoftware.com/2016/10/practical-redux-part-0-introduction/  
+  http://blog.isquaredsoftware.com/series/practical-redux/  
+  An ongoing series of posts intended to demonstrate a number of specific Redux techniques by building a sample application, based on the MekHQ application for managing Battletech campaigns.  Written by Redux co-maintainer Mark Erikson.  Covers topics like managing relational data, connecting multiple components and lists, complex reducer logic for features, handling forms, showing modal dialogs, and much more.
+
+- **Building a Simple CRUD App with React + Redux**  
+  http://www.thegreatcodeadventure.com/building-a-simple-crud-app-with-react-redux-part-1/  
+  A nifty 8-part series that demonstrates building a CRUD app, including routing, AJAX calls, and the various CRUD aspects.  Very well written, with some useful diagrams as well.
+  
+- **The Soundcloud Client in React + Redux**  
+  http://www.robinwieruch.de/the-soundcloud-client-in-react-redux/  
+  A detailed walkthrough demonstrating project setup, routing, authentication, fetching of remote data, and wrapping of a stateful library.
+  
+- **Full-Stack Redux Tutorial**  
+  http://teropa.info/blog/2015/09/10/full-stack-redux-tutorial.html  
+  A full-blown, in-depth tutorial that builds up a complete client-server application.
+
+- **Getting Started with React, Redux and Immutable: a Test-Driven Tutorial**  
+  http://www.theodo.fr/blog/2016/03/getting-started-with-react-redux-and-immutable-a-test-driven-tutorial-part-1/  
+  http://www.theodo.fr/blog/2016/03/getting-started-with-react-redux-and-immutable-a-test-driven-tutorial-part-2/  
+  Another solid, in-depth tutorial, similar to the "Full-Stack" tutorial.  Builds a client-only TodoMVC app, and demonstrates a good project setup (including a Mocha+JSDOM-based testing configuration).  Well-written, covers many concepts, and very easy to follow.
+  
+- **Redux Hero: An Intro to Redux and Reselect**  
+  https://decembersoft.com/posts/redux-hero-part-1-a-hero-is-born-a-fun-introduction-to-redux-js/  
+  An introduction to Redux and related libraries through building a small RPG-style game
+  
+ 
+## Redux Implementation
+
+*Explanations of how Redux works internally, by writing miniature reimplementations*
+
+- **Build Yourself a Redux**  
+  https://zapier.com/engineering/how-to-build-redux/  
+  An excellent in-depth "build a mini-Redux" article, which covers not only Redux's core, but also `connect` and middleware as well.
+  
+- **Connect.js explained**  
+  https://gist.github.com/gaearon/1d19088790e70ac32ea636c025ba424e  
+  A very simplified version of React Redux's `connect()` function that illustrates the basic implementation
+  
+- **Let's Write Redux!**  
+  http://www.jamasoftware.com/blog/lets-write-redux/  
+  Walks through writing a miniature version of Redux step-by-step, to help explain the concepts and implementation.
+
+
+## Reducers
+
+*Articles discussing ways to write reducer functions*
+
+- **Taking Advantage of `combineReducers`**  
+  http://randycoulman.com/blog/2016/11/22/taking-advantage-of-combinereducers/  
+  Examples of using `combineReducers` multiple times to produce a state tree, and some thoughts on tradeoffs in various approaches to reducer logic.
+  
+- **The Power of Higher-Order Reducers**  
+  http://slides.com/omnidan/hor#/  
+  A slideshow from the author of redux-undo and other libraries, explaining the concept of higher-order reducers and how they can be used
+  
+- **Reducer composition with Higher Order Reducers**  
+  https://medium.com/@mange_vibration/reducer-composition-with-higher-order-reducers-35c3977ed08f  
+  Some great examples of writing small functions that can be composed together to perform larger specific reducer tasks, such as providing initial state, filtering, updating specific keys, and more.
+  
+- **Higher Order Reducers - It just sounds scary**  
+  https://medium.com/@danielkagan/high-order-reducers-it-just-sounds-scary-2b9e5dbfc705  
+  Explains how reducers can be composed like Lego bricks to create reusable and testable reducer logic.
+  
+  
+## Selectors
+
+*Explanations of how and why to use selector functions to read values from state*
+  
+- **ReactCasts #8: Selectors in Redux**  
+  https://www.youtube.com/watch?v=frT3to2ACCw  
+  A great overview of why and how to use selector functions to retrieve data from the store, and derive additional data from store values
+  
+- **Optimizing React Redux Application Development with Reselect**  
+  https://codebrahma.com/reselect-tutorial-optimizing-react-redux-application-development-with-reselect/  
+  A good tutorial on Reselect.  Covers the concept of "selector functions", how to use Reselect's API, and how to use memoized selectors to improve performance.
+  
+- **Usage of Reselect in a React-Redux Application**  
+  https://dashbouquet.com/blog/frontend-development/usage-of-reselect-in-a-react-redux-application  
+  Discusses the importance of memoized selectors for performance, and good practices for using Reselect.
+  
+- **React, Reselect, and Redux**  
+  https://medium.com/@parkerdan/react-reselect-and-redux-b34017f8194c  
+  An explanation of how Reselect's memoized selector functions are useful in Redux apps, and how to create unique selector instances for each component instance.
+  
+
+## Normalization
+
+*How to structure the Redux store like a database for best performance*
+
+- **Querying a Redux Store**  
+  https://medium.com/@adamrackis/querying-a-redux-store-37db8c7f3b0f  
+  A look at best practices for organizing and storing data in Redux, including normalizing data and use of selector functions.
+  
+- **Normalizing Redux Stores for Maximum Code Reuse**  
+  https://medium.com/@adamrackis/normalizing-redux-stores-for-maximum-code-reuse-ae6e3844ae95  
+  Thoughts on how normalized Redux stores enable some useful data handling approaches, with examples of using selector functions to denormalize hierarchical data.
+  
+- **Redux Normalizr: Improve your State Management**  
+  http://www.robinwieruch.de/the-soundcloud-client-in-react-redux-normalizr/  
+  A tutorial describing how to use Normalizr for improved data management of nested data in Redux
+  
+- **Advanced Redux Entity Normalization**  
+  https://medium.com/@dcousineau/advanced-redux-entity-normalization-f5f1fe2aefc5  
+  Describes a "keyWindow" concept for tracking subsets of entities in state, similar to an SQL "view".  A useful extension to the idea of normalized data.
+
+
+
+## Middleware
+
+*Explanations and examples of how middleware work and how to write them* 
+
+- **Exploring Redux Middlewares**  
+  http://blog.krawaller.se/posts/exploring-redux-middleware/  
+  Understanding middlewares through a series of small experiments
+
+- **Redux Middleware Tutorial**  
+  http://www.pshrmn.com/tutorials/react/redux-middleware/  
+  An overview of what middleware is, how `applyMiddleware` works, and how to write middleware.
+  
+- **ReactCasts #6: Redux Middleware**  
+  https://www.youtube.com/watch?v=T-qtHI1qHIg  
+  A screencast that describes how middleware fit into Redux, their uses, and how to implement a custom middleware 
+  
+- **A Beginner's Guide to Redux Middleware**  
+  https://www.codementor.io/reactjs/tutorial/beginner-s-guide-to-redux-middleware  
+  A useful explanation of middleware use cases, with numerous examples
+
+
+## Side Effects - Basics
+
+*Introductions to handling async behavior in Redux*
+
+- **Stack Overflow: Dispatching Redux Actions with a Timeout**  
+  http://stackoverflow.com/questions/35411423/how-to-dispatch-a-redux-action-with-a-timeout/35415559#35415559  
+  Dan Abramov explains the basics of managing async behavior in Redux, walking through a progressive series of approaches (inline async calls, async action creators, thunk middleware).
+  
+- **Stack Overflow: Why do we need middleware for async flow in Redux?**  
+  http://stackoverflow.com/questions/34570758/why-do-we-need-middleware-for-async-flow-in-redux/34599594#34599594  
+  Dan Abramov gives reasons for using thunks and async middleware, and some useful patterns for using thunks.
+  
+- **What the heck is a "thunk"?**  
+  https://daveceddia.com/what-is-a-thunk/  
+  A quick explanation for what the word "thunk" means in general, and for Redux specifically.
+
+- **Thunks in Redux: The Basics**  
+  https://medium.com/fullstack-academy/thunks-in-redux-the-basics-85e538a3fe60  
+  A detailed look at what thunks are, what they solve, and how to use them.
+
+
+  
+  
+## Side Effects - Advanced
+
+*Advanced tools and techniques for managing async behavior*
+
+- **What is the right way to do asynchronous operations in Redux?**  
+  https://decembersoft.com/posts/what-is-the-right-way-to-do-asynchronous-operations-in-redux/  
+  An excellent look at the most popular libraries for Redux side effects, with comparisons of how each one works.
+  
+- **Redux 4 Ways**  
+  https://medium.com/react-native-training/redux-4-ways-95a130da0cdc  
+  Side-by-side comparisons of implementing some basic data fetching using thunks, sagas, observables, and a promise middleware
+
+- **Idiomatic Redux: Thoughts on Thunks, Sagas, Abstractions, and Reusability**  
+  http://blog.isquaredsoftware.com/2017/01/idiomatic-redux-thoughts-on-thunks-sagas-abstraction-and-reusability/  
+  A response to several "thunks are bad" concerns, arguing that thunks (and sagas) are still a valid approach for managing complex sync logic and async side effects.
+  
+- **Javascript Power Tools: Redux-Saga**  
+  http://formidable.com/blog/2017/javascript-power-tools-redux-saga/  
+  http://formidable.com/blog/2017/composition-patterns-in-redux-saga/  
+  http://formidable.com/blog/2017/real-world-redux-saga-patterns/  
+  A fantastic series that teaches the concepts, implementation, and benefits behind Redux-Saga, including how ES6 generators are used to control function flow, how sagas can be composed together to accomplish concurrency, and practical use cases for sagas.
+  
+- **Exploring Redux Sagas**  
+  https://medium.com/onfido-tech/exploring-redux-sagas-cc1fca2015ee  
+  An excellent article that explores how to use sagas to provide a glue layer to implement decoupled business logic in a Redux application.
+  
+- **Taming Redux with Sagas**  
+  https://objectpartners.com/2017/11/20/taming-redux-with-sagas/  
+  A good overview of Redux-Saga, including info on generator functions, use cases for sagas, using sagas to deal with promises, and testing sagas.
+  
+- **Reactive Redux State with RxJS**  
+  https://ivanjov.com/reactive-redux-state-with-rxjs/  
+  Describes the concept of "Reactive PRogramming" and the RxJS library, and shows how to use redux-observable to fetch data, along with examples of testing.
+  
+- **Using redux-observable to handle asynchronous logic in Redux**  
+  https://medium.com/dailyjs/using-redux-observable-to-handle-asynchronous-logic-in-redux-d49194742522  
+  An extended post that compares a thunk-based implementation of handling a line-drawing example vs an observable-based implementation.
+
+
+## Thinking in Redux
+
+*Deeper looks at how Redux is meant to be used, and why it works the way it does*
+
+- **You Might Not Need Redux**  
+  https://medium.com/@dan_abramov/you-might-not-need-redux-be46360cf367  
+  Dan Abramov discusses the tradeoffs involved in using Redux.
+  
+- **Idiomatic Redux: The Tao of Redux, Part 1 - Implementation and Intent**
+  http://blog.isquaredsoftware.com/2017/05/idiomatic-redux-tao-of-redux-part-1/  
+  A deep dive into how Redux actually works, the constraints it asks you to follow, and the intent behind its design and usage.
+  
+- **Idiomatic Redux: The Tao of Redux, Part 2 - Practice and Philosophy**  
+  http://blog.isquaredsoftware.com/2017/05/idiomatic-redux-tao-of-redux-part-2/  
+  A follow-up look at why common Redux usage patterns exist, other ways that Redux can be used, and thoughts on the pros and cons of those different patterns and approaches.
+  
+- **What's So Great About Redux?**  
+  https://medium.freecodecamp.org/whats-so-great-about-redux-ac16f1cc0f8b  
+  https://storify.com/acemarke/redux-pros-cons-and-limitations  
+  https://twitter.com/modernserf/status/886426115874717697  
+  Deep and fascinating analysis of how Redux compares to OOP and message-passing, how typical Redux usage can devolve towards Java-like "setter" functions with more boilerplate, and something of a plea for a higher-level "blessed" abstraction on top of Redux to make it easier to work with and learn for newbies.  Very worth reading.  The author originally wrote a tweetstorm, which is captured in the Storify link, and wrote the blog post to expand on those thoughts.  Finally, he followed up with a few more thoughts on abstract vs concrete examples in another shorter tweet thread.
+
+
+## Redux Architecture
+
+*Patterns and practices for structuring larger Redux applications*
+
+- **Avoiding Accidental Complexity When Structuring Your App State**  
+  https://hackernoon.com/avoiding-accidental-complexity-when-structuring-your-app-state-6e6d22ad5e2a  
+  An excellent set of guidelines for organizing your Redux store structure.
+  
+- **Redux Step by Step: A Simple and Robust Workflow for Real Life Apps**  
+  https://hackernoon.com/redux-step-by-step-a-simple-and-robust-workflow-for-real-life-apps-1fdf7df46092  
+  A follow-up to the "Accidental Complexity" article, discussing principle
+  
+- **Things I Wish I Knew About Redux**  
+  https://medium.com/horrible-hacks/things-i-wish-i-knew-about-redux-9924abf2f9e0  
+  https://www.reddit.com/r/javascript/comments/4taau2/things_i_wish_i_knew_about_redux/  
+  A number of excellent tips and lessons learned after building an app with Redux.  Includes info on connecting components, selecting data, and app/project structure.  Additional discussion on Reddit.
+
+- **React+Redux: Tips and Best Practices for Clean, Reliable, & Maintainable Code**    
+  https://speakerdeck.com/goopscoop/react-plus-redux-tips-and-best-practices-for-clean-reliable-and-scalable-code  
+  An excellent slideshow with a wide variety of tips and suggestions, including keeping action creators simple and data manipulation in reducers, abstracting away API calls, avoiding spreading props, and more.
+
+- **Redux for state management in large web apps**  
+  https://www.mapbox.com/blog/redux-for-state-management-in-large-web-apps/  
+  Excellent discussion and examples of idiomatic Redux architecture, and how Mapbox applies those approaches to their Mapbox Studio application.
+
+
+## Apps and Examples
+
+- **React-Redux RealWorld Example: TodoMVC for the Real World**  
+  https://github.com/GoThinkster/redux-review  
+  An example full-stack "real world" application built with Redux.  Demos a Medium-like social blogging site that includes JWT authentication, CRUD, favoriting articles, following users, routing, and more.  The RealWorld project also includes many other implementations of the front and back ends of the site, specifically intended to show how different server and client implementations of the same project and API spec compare with each other.
+
+- **Project Mini-Mek**  
+  https://github.com/markerikson/project-minimek  
+  A sample app to demonstrate various useful Redux techniques, accompanying the "Practical Redux" blog series at http://blog.isquaredsoftware.com/series/practical-redux
+  
+- **react-redux-yelp-clone**  
+  https://github.com/mohamed-ismat/react-redux-yelp-clone  
+  An adaptation of the "Yelp Clone" app by FullStackReact.  It extends the original by using Redux and Redux Saga instead of local state, as well as React Router v4, styled-components, and other modern standards.  Based on the React-Boilerplate starter kit.
+  
+- **WordPress-Calypso**  
+  https://github.com/Automattic/wp-calypso  
+  The new JavaScript- and API-powered WordPress.com
+  
+- **Sound-Redux**  
+  https://github.com/andrewngu/sound-redux  
+  A Soundcloud client built with React / Redux
+  
+- **Winamp2-js**  
+  https://jordaneldredge.com/projects/winamp2-js/  
+  https://github.com/captbaritone/winamp2-js  
+  An in-browser recreation of Winamp2, built with React and Redux. Actually plays MP3s, and lets you load in local MP3 files.
+  
+- **Tello**  
+  https://github.com/joshwcomeau/Tello  
+  A simple and delightful way to track and manage TV shows
+  
+- **io-808**  
+  https://github.com/vincentriemer/io-808  
+  An attempt at a fully recreated web-based TR-808 drum machine
+  
+
+  
+## Redux Docs Translations
+
+- [中文文档](http://camsong.github.io/redux-in-chinese/) — Chinese
+- [繁體中文文件](https://github.com/chentsulin/redux) — Traditional Chinese
+- [Redux in Russian](https://github.com/rajdee/redux-in-russian) — Russian
+- [Redux en Español](http://es.redux.js.org/) - Spanish
+
+
+## Books
+
+- **Redux in Action**  
+  https://www.manning.com/books/redux-in-action  
+  A comprehensive book that covers many key aspects of using Redux, including the basics of reducers and actions and use with React, complex middlewares and side effects, application structure, performance, testing, and much more.  Does a great job of explaining the pros, cons, and tradeoffs of many approaches to using Redux.  Personally recommended by Redux co-maintainer Mark Erikson.
+
+- **The Complete Redux Book**  
+  https://leanpub.com/redux-book  
+  How do I manage a large state in production? Why do I need store enhancers? What is the best way to handle form validations?  Get the answers to all these questions and many more using simple terms and sample code. Learn everything you need to use Redux to build complex and production-ready web applications.  (Note: now permanently free!)
+  
+  
+
+## Courses
+
+- **Modern React with Redux, by Stephen Grider (paid)**  
+  https://www.udemy.com/react-redux/  
+  Master the fundamentals of React and Redux with this tutorial as you develop apps with React Router, Webpack, and ES6.  This course will get you up and running quickly, and teach you the core knowledge you need to deeply understand and build React components and structure applications with Redux.
+  
+- **Redux, by Tyler McGinnis (paid)**  
+  https://tylermcginnis.com/courses/redux/  
+  When learning Redux, you need to learn it in the context of an app big enough to see the benefits. That's why this course is huge. A better name might be 'Real World Redux. If you're sick of "todo list" Redux tutorials, you've come to the right place. In this course we'll talk all about what makes Redux special for managing state in your application. We'll build an actual "real world" application so you can see how Redux handles edge cases like optimistic updates and error handling. We'll also cover many other technologies that work well with Redux, Firebase, and CSS Modules.
+  
+- **Learn Redux, by Wes Bos (free)**  
+  https://learnredux.com/  
+  A video course that walks through building 'Reduxstagram' — a simple photo app that will simplify the core ideas behind Redux, React Router and React.js
+
+
+## More Resources
+
+- [React-Redux Links](https://github.com/markerikson/react-redux-links) is a curated list of high-quality articles, tutorials, and related content for React, Redux, ES6, and more.  
+- [Redux Ecosystem Links](https://github.com/markerikson/redux-ecosystem-links) is a categorized collection of Redux-related libraries, addons, and utilities.
+- [Awesome Redux](https://github.com/xgrommx/awesome-redux) is an extensive list of Redux-related repositories.  

--- a/docs/introduction/LearningResources.md
+++ b/docs/introduction/LearningResources.md
@@ -1,399 +1,399 @@
-# Learning Resources
-
-The Redux docs are intended to teach the basic concepts of Redux, as well as explain key concepts for use in real-world applications.  However, the docs can't cover everything.  Happily, there's many other great resources available for learning Redux.  We encourage you to check them out.  Many of them cover topics that are beyond the scope of the docs, or describe the same topics in other ways that may work better for your learning style.
-
-This page includes our recommendations for some of the best external resources available to learn Redux.  For an additional extensive list of tutorials, articles, and other resources on React, Redux, Javascript, and related topics, see the [React/Redux Links list](https://github.com/markerikson/react-redux-links).
-
-
-## Basic Introductions
-
-*Tutorials that teach the basic concepts of Redux and how to use it*
-
-- **Getting Started with Redux - Video Series**  
-  https://egghead.io/series/getting-started-with-redux  
-  https://github.com/tayiorbeii/egghead.io_redux_course_notes  
-  Dan Abramov, the creator of Redux, demonstrates various concepts in 30 short (2-5 minute) videos.  The linked Github repo contains notes and transcriptions of the videos.
-
-- **Building React Applications with Idiomatic Redux - Video Series**  
-  https://egghead.io/series/building-react-applications-with-idiomatic-redux  
-  https://github.com/tayiorbeii/egghead.io_idiomatic_redux_course_notes  
-  Dan Abramov's second video tutorial series, continuing directly after the first.  Includes lessons on store initial state, using Redux with React Router, using "selector" functions, normalizing state, use of Redux middleware, async action creators, and more.  The linked Github repo contains notes and transcriptions of the videos.
-  
-- **Live React: Hot Reloading and Time Travel**  
-  http://youtube.com/watch?v=xsSnOQynTHs
-  Dan Abramov's original conference talk that introduced Redux.  See how constraints enforced by Redux make hot reloading with time travel easy
-  
-- **A Cartoon Guide to Redux**  
-  https://code-cartoons.com/a-cartoon-intro-to-redux-3afb775501a6  
-  A high-level description of Redux, with friendly cartoons to help illustrate the ideas. 
-
-- **Leveling Up with React: Redux**  
-  https://css-tricks.com/learning-react-redux/  
-  A very well-written introduction to Redux and its related concepts, with some nifty cartoon-ish diagrams.
-  
-- **An Introduction to Redux**  
-  https://www.smashingmagazine.com/2016/06/an-introduction-to-redux/  
-  An overview and intro to the basic concepts of Redux.  Looks at the benefits of using Redux, how it differs from MVC or Flux, and its relation to functional programming.
-  
-- **Redux Tutorial**  
-  https://www.pshrmn.com/tutorials/react/redux/  
-  A short, clear tutorial that introduces basic Redux terms, shows how to split reducer functions, and describes the Redux store API.
-  
-  
-- **Redux: From Twitter Hype to Production**  
-  http://slides.com/jenyaterpil/redux-from-twitter-hype-to-production#/  
-  An extremely well-produced slideshow that visually steps through core Redux concepts, usage with React, project organization, and side effects with thunks and sagas.  Has some absolutely _fantastic_ animated diagrams demonstrating how data flows through a React+Redux architecture.
-  
-- **DevGuides: Introduction to Redux**  
-  http://devguides.io/redux/  
-  A tutorial that covers several aspects of Redux, including actions, reducers, usage with React, and middleware.
-
-
-
-## Using Redux With React
-
-*Explanations of the React-Redux bindings and the `connect` function*
-
-- **Why Redux is Useful in React Apps**  
-  https://www.fullstackreact.com/articles/redux-with-mark-erikson/  
-  An explanation of some of the benefits of using Redux with React, including sharing data between components and hot module reloading.
-   
-
-- **What Does Redux Do? (and when should you use it?)**  
-  https://daveceddia.com/what-does-redux-do/  
-  An excellent summary of how Redux helps solve data flow problems in a React app.
-  
-- **How Redux Works: A Counter-Example**  
-  https://daveceddia.com/how-does-redux-work/  
-  A great follow-up to the previous article.  It explains how to use Redux and React-Redux, by first showing a React component that stores a value in its internal state, and then refactoring it to use Redux instead.  Along the way, the article explains important Redux terms and concepts, and how they all fit together to make the Redux data flow work properly.
-  
-- **Redux and React: An Introduction**  
-  http://jakesidsmith.com/blog/post/2017-11-18-redux-and-react-an-introduction/  
-  A great introduction to Redux's core concepts, with explanations of how to use the React-Redux package to use Redux with React.
-
-- **React Redux Tutorial**  
-   https://www.pshrmn.com/tutorials/react/react-redux  
-   A clear, easy-to-read explanation of how to use the React-Redux `connect` API. 
-
-
-## Project-Based Tutorials
-
-*Tutorials that teach Redux concepts by building projects, including larger  "real-world"-type applications*
-  
-- **Practical Redux**  
-  http://blog.isquaredsoftware.com/2016/10/practical-redux-part-0-introduction/  
-  http://blog.isquaredsoftware.com/series/practical-redux/  
-  An ongoing series of posts intended to demonstrate a number of specific Redux techniques by building a sample application, based on the MekHQ application for managing Battletech campaigns.  Written by Redux co-maintainer Mark Erikson.  Covers topics like managing relational data, connecting multiple components and lists, complex reducer logic for features, handling forms, showing modal dialogs, and much more.
-
-- **Building a Simple CRUD App with React + Redux**  
-  http://www.thegreatcodeadventure.com/building-a-simple-crud-app-with-react-redux-part-1/  
-  A nifty 8-part series that demonstrates building a CRUD app, including routing, AJAX calls, and the various CRUD aspects.  Very well written, with some useful diagrams as well.
-  
-- **The Soundcloud Client in React + Redux**  
-  http://www.robinwieruch.de/the-soundcloud-client-in-react-redux/  
-  A detailed walkthrough demonstrating project setup, routing, authentication, fetching of remote data, and wrapping of a stateful library.
-  
-- **Full-Stack Redux Tutorial**  
-  http://teropa.info/blog/2015/09/10/full-stack-redux-tutorial.html  
-  A full-blown, in-depth tutorial that builds up a complete client-server application.
-
-- **Getting Started with React, Redux and Immutable: a Test-Driven Tutorial**  
-  http://www.theodo.fr/blog/2016/03/getting-started-with-react-redux-and-immutable-a-test-driven-tutorial-part-1/  
-  http://www.theodo.fr/blog/2016/03/getting-started-with-react-redux-and-immutable-a-test-driven-tutorial-part-2/  
-  Another solid, in-depth tutorial, similar to the "Full-Stack" tutorial.  Builds a client-only TodoMVC app, and demonstrates a good project setup (including a Mocha+JSDOM-based testing configuration).  Well-written, covers many concepts, and very easy to follow.
-  
-- **Redux Hero: An Intro to Redux and Reselect**  
-  https://decembersoft.com/posts/redux-hero-part-1-a-hero-is-born-a-fun-introduction-to-redux-js/  
-  An introduction to Redux and related libraries through building a small RPG-style game
-  
- 
-## Redux Implementation
-
-*Explanations of how Redux works internally, by writing miniature reimplementations*
-
-- **Build Yourself a Redux**  
-  https://zapier.com/engineering/how-to-build-redux/  
-  An excellent in-depth "build a mini-Redux" article, which covers not only Redux's core, but also `connect` and middleware as well.
-  
-- **Connect.js explained**  
-  https://gist.github.com/gaearon/1d19088790e70ac32ea636c025ba424e  
-  A very simplified version of React Redux's `connect()` function that illustrates the basic implementation
-  
-- **Let's Write Redux!**  
-  http://www.jamasoftware.com/blog/lets-write-redux/  
-  Walks through writing a miniature version of Redux step-by-step, to help explain the concepts and implementation.
-
-
-## Reducers
-
-*Articles discussing ways to write reducer functions*
-
-- **Taking Advantage of `combineReducers`**  
-  http://randycoulman.com/blog/2016/11/22/taking-advantage-of-combinereducers/  
-  Examples of using `combineReducers` multiple times to produce a state tree, and some thoughts on tradeoffs in various approaches to reducer logic.
-  
-- **The Power of Higher-Order Reducers**  
-  http://slides.com/omnidan/hor#/  
-  A slideshow from the author of redux-undo and other libraries, explaining the concept of higher-order reducers and how they can be used
-  
-- **Reducer composition with Higher Order Reducers**  
-  https://medium.com/@mange_vibration/reducer-composition-with-higher-order-reducers-35c3977ed08f  
-  Some great examples of writing small functions that can be composed together to perform larger specific reducer tasks, such as providing initial state, filtering, updating specific keys, and more.
-  
-- **Higher Order Reducers - It just sounds scary**  
-  https://medium.com/@danielkagan/high-order-reducers-it-just-sounds-scary-2b9e5dbfc705  
-  Explains how reducers can be composed like Lego bricks to create reusable and testable reducer logic.
-  
-  
-## Selectors
-
-*Explanations of how and why to use selector functions to read values from state*
-  
-- **ReactCasts #8: Selectors in Redux**  
-  https://www.youtube.com/watch?v=frT3to2ACCw  
-  A great overview of why and how to use selector functions to retrieve data from the store, and derive additional data from store values
-  
-- **Optimizing React Redux Application Development with Reselect**  
-  https://codebrahma.com/reselect-tutorial-optimizing-react-redux-application-development-with-reselect/  
-  A good tutorial on Reselect.  Covers the concept of "selector functions", how to use Reselect's API, and how to use memoized selectors to improve performance.
-  
-- **Usage of Reselect in a React-Redux Application**  
-  https://dashbouquet.com/blog/frontend-development/usage-of-reselect-in-a-react-redux-application  
-  Discusses the importance of memoized selectors for performance, and good practices for using Reselect.
-  
-- **React, Reselect, and Redux**  
-  https://medium.com/@parkerdan/react-reselect-and-redux-b34017f8194c  
-  An explanation of how Reselect's memoized selector functions are useful in Redux apps, and how to create unique selector instances for each component instance.
-  
-
-## Normalization
-
-*How to structure the Redux store like a database for best performance*
-
-- **Querying a Redux Store**  
-  https://medium.com/@adamrackis/querying-a-redux-store-37db8c7f3b0f  
-  A look at best practices for organizing and storing data in Redux, including normalizing data and use of selector functions.
-  
-- **Normalizing Redux Stores for Maximum Code Reuse**  
-  https://medium.com/@adamrackis/normalizing-redux-stores-for-maximum-code-reuse-ae6e3844ae95  
-  Thoughts on how normalized Redux stores enable some useful data handling approaches, with examples of using selector functions to denormalize hierarchical data.
-  
-- **Redux Normalizr: Improve your State Management**  
-  http://www.robinwieruch.de/the-soundcloud-client-in-react-redux-normalizr/  
-  A tutorial describing how to use Normalizr for improved data management of nested data in Redux
-  
-- **Advanced Redux Entity Normalization**  
-  https://medium.com/@dcousineau/advanced-redux-entity-normalization-f5f1fe2aefc5  
-  Describes a "keyWindow" concept for tracking subsets of entities in state, similar to an SQL "view".  A useful extension to the idea of normalized data.
-
-
-
-## Middleware
-
-*Explanations and examples of how middleware work and how to write them* 
-
-- **Exploring Redux Middlewares**  
-  http://blog.krawaller.se/posts/exploring-redux-middleware/  
-  Understanding middlewares through a series of small experiments
-
-- **Redux Middleware Tutorial**  
-  http://www.pshrmn.com/tutorials/react/redux-middleware/  
-  An overview of what middleware is, how `applyMiddleware` works, and how to write middleware.
-  
-- **ReactCasts #6: Redux Middleware**  
-  https://www.youtube.com/watch?v=T-qtHI1qHIg  
-  A screencast that describes how middleware fit into Redux, their uses, and how to implement a custom middleware 
-  
-- **A Beginner's Guide to Redux Middleware**  
-  https://www.codementor.io/reactjs/tutorial/beginner-s-guide-to-redux-middleware  
-  A useful explanation of middleware use cases, with numerous examples
-
-
-## Side Effects - Basics
-
-*Introductions to handling async behavior in Redux*
-
-- **Stack Overflow: Dispatching Redux Actions with a Timeout**  
-  http://stackoverflow.com/questions/35411423/how-to-dispatch-a-redux-action-with-a-timeout/35415559#35415559  
-  Dan Abramov explains the basics of managing async behavior in Redux, walking through a progressive series of approaches (inline async calls, async action creators, thunk middleware).
-  
-- **Stack Overflow: Why do we need middleware for async flow in Redux?**  
-  http://stackoverflow.com/questions/34570758/why-do-we-need-middleware-for-async-flow-in-redux/34599594#34599594  
-  Dan Abramov gives reasons for using thunks and async middleware, and some useful patterns for using thunks.
-  
-- **What the heck is a "thunk"?**  
-  https://daveceddia.com/what-is-a-thunk/  
-  A quick explanation for what the word "thunk" means in general, and for Redux specifically.
-
-- **Thunks in Redux: The Basics**  
-  https://medium.com/fullstack-academy/thunks-in-redux-the-basics-85e538a3fe60  
-  A detailed look at what thunks are, what they solve, and how to use them.
-
-
-  
-  
-## Side Effects - Advanced
-
-*Advanced tools and techniques for managing async behavior*
-
-- **What is the right way to do asynchronous operations in Redux?**  
-  https://decembersoft.com/posts/what-is-the-right-way-to-do-asynchronous-operations-in-redux/  
-  An excellent look at the most popular libraries for Redux side effects, with comparisons of how each one works.
-  
-- **Redux 4 Ways**  
-  https://medium.com/react-native-training/redux-4-ways-95a130da0cdc  
-  Side-by-side comparisons of implementing some basic data fetching using thunks, sagas, observables, and a promise middleware
-
-- **Idiomatic Redux: Thoughts on Thunks, Sagas, Abstractions, and Reusability**  
-  http://blog.isquaredsoftware.com/2017/01/idiomatic-redux-thoughts-on-thunks-sagas-abstraction-and-reusability/  
-  A response to several "thunks are bad" concerns, arguing that thunks (and sagas) are still a valid approach for managing complex sync logic and async side effects.
-  
-- **Javascript Power Tools: Redux-Saga**  
-  http://formidable.com/blog/2017/javascript-power-tools-redux-saga/  
-  http://formidable.com/blog/2017/composition-patterns-in-redux-saga/  
-  http://formidable.com/blog/2017/real-world-redux-saga-patterns/  
-  A fantastic series that teaches the concepts, implementation, and benefits behind Redux-Saga, including how ES6 generators are used to control function flow, how sagas can be composed together to accomplish concurrency, and practical use cases for sagas.
-  
-- **Exploring Redux Sagas**  
-  https://medium.com/onfido-tech/exploring-redux-sagas-cc1fca2015ee  
-  An excellent article that explores how to use sagas to provide a glue layer to implement decoupled business logic in a Redux application.
-  
-- **Taming Redux with Sagas**  
-  https://objectpartners.com/2017/11/20/taming-redux-with-sagas/  
-  A good overview of Redux-Saga, including info on generator functions, use cases for sagas, using sagas to deal with promises, and testing sagas.
-  
-- **Reactive Redux State with RxJS**  
-  https://ivanjov.com/reactive-redux-state-with-rxjs/  
-  Describes the concept of "Reactive PRogramming" and the RxJS library, and shows how to use redux-observable to fetch data, along with examples of testing.
-  
-- **Using redux-observable to handle asynchronous logic in Redux**  
-  https://medium.com/dailyjs/using-redux-observable-to-handle-asynchronous-logic-in-redux-d49194742522  
-  An extended post that compares a thunk-based implementation of handling a line-drawing example vs an observable-based implementation.
-
-
-## Thinking in Redux
-
-*Deeper looks at how Redux is meant to be used, and why it works the way it does*
-
-- **You Might Not Need Redux**  
-  https://medium.com/@dan_abramov/you-might-not-need-redux-be46360cf367  
-  Dan Abramov discusses the tradeoffs involved in using Redux.
-  
-- **Idiomatic Redux: The Tao of Redux, Part 1 - Implementation and Intent**
-  http://blog.isquaredsoftware.com/2017/05/idiomatic-redux-tao-of-redux-part-1/  
-  A deep dive into how Redux actually works, the constraints it asks you to follow, and the intent behind its design and usage.
-  
-- **Idiomatic Redux: The Tao of Redux, Part 2 - Practice and Philosophy**  
-  http://blog.isquaredsoftware.com/2017/05/idiomatic-redux-tao-of-redux-part-2/  
-  A follow-up look at why common Redux usage patterns exist, other ways that Redux can be used, and thoughts on the pros and cons of those different patterns and approaches.
-  
-- **What's So Great About Redux?**  
-  https://medium.freecodecamp.org/whats-so-great-about-redux-ac16f1cc0f8b  
-  https://storify.com/acemarke/redux-pros-cons-and-limitations  
-  https://twitter.com/modernserf/status/886426115874717697  
-  Deep and fascinating analysis of how Redux compares to OOP and message-passing, how typical Redux usage can devolve towards Java-like "setter" functions with more boilerplate, and something of a plea for a higher-level "blessed" abstraction on top of Redux to make it easier to work with and learn for newbies.  Very worth reading.  The author originally wrote a tweetstorm, which is captured in the Storify link, and wrote the blog post to expand on those thoughts.  Finally, he followed up with a few more thoughts on abstract vs concrete examples in another shorter tweet thread.
-
-
-## Redux Architecture
-
-*Patterns and practices for structuring larger Redux applications*
-
-- **Avoiding Accidental Complexity When Structuring Your App State**  
-  https://hackernoon.com/avoiding-accidental-complexity-when-structuring-your-app-state-6e6d22ad5e2a  
-  An excellent set of guidelines for organizing your Redux store structure.
-  
-- **Redux Step by Step: A Simple and Robust Workflow for Real Life Apps**  
-  https://hackernoon.com/redux-step-by-step-a-simple-and-robust-workflow-for-real-life-apps-1fdf7df46092  
-  A follow-up to the "Accidental Complexity" article, discussing principle
-  
-- **Things I Wish I Knew About Redux**  
-  https://medium.com/horrible-hacks/things-i-wish-i-knew-about-redux-9924abf2f9e0  
-  https://www.reddit.com/r/javascript/comments/4taau2/things_i_wish_i_knew_about_redux/  
-  A number of excellent tips and lessons learned after building an app with Redux.  Includes info on connecting components, selecting data, and app/project structure.  Additional discussion on Reddit.
-
-- **React+Redux: Tips and Best Practices for Clean, Reliable, & Maintainable Code**    
-  https://speakerdeck.com/goopscoop/react-plus-redux-tips-and-best-practices-for-clean-reliable-and-scalable-code  
-  An excellent slideshow with a wide variety of tips and suggestions, including keeping action creators simple and data manipulation in reducers, abstracting away API calls, avoiding spreading props, and more.
-
-- **Redux for state management in large web apps**  
-  https://www.mapbox.com/blog/redux-for-state-management-in-large-web-apps/  
-  Excellent discussion and examples of idiomatic Redux architecture, and how Mapbox applies those approaches to their Mapbox Studio application.
-
-
-## Apps and Examples
-
-- **React-Redux RealWorld Example: TodoMVC for the Real World**  
-  https://github.com/GoThinkster/redux-review  
-  An example full-stack "real world" application built with Redux.  Demos a Medium-like social blogging site that includes JWT authentication, CRUD, favoriting articles, following users, routing, and more.  The RealWorld project also includes many other implementations of the front and back ends of the site, specifically intended to show how different server and client implementations of the same project and API spec compare with each other.
-
-- **Project Mini-Mek**  
-  https://github.com/markerikson/project-minimek  
-  A sample app to demonstrate various useful Redux techniques, accompanying the "Practical Redux" blog series at http://blog.isquaredsoftware.com/series/practical-redux
-  
-- **react-redux-yelp-clone**  
-  https://github.com/mohamed-ismat/react-redux-yelp-clone  
-  An adaptation of the "Yelp Clone" app by FullStackReact.  It extends the original by using Redux and Redux Saga instead of local state, as well as React Router v4, styled-components, and other modern standards.  Based on the React-Boilerplate starter kit.
-  
-- **WordPress-Calypso**  
-  https://github.com/Automattic/wp-calypso  
-  The new JavaScript- and API-powered WordPress.com
-  
-- **Sound-Redux**  
-  https://github.com/andrewngu/sound-redux  
-  A Soundcloud client built with React / Redux
-  
-- **Winamp2-js**  
-  https://jordaneldredge.com/projects/winamp2-js/  
-  https://github.com/captbaritone/winamp2-js  
-  An in-browser recreation of Winamp2, built with React and Redux. Actually plays MP3s, and lets you load in local MP3 files.
-  
-- **Tello**  
-  https://github.com/joshwcomeau/Tello  
-  A simple and delightful way to track and manage TV shows
-  
-- **io-808**  
-  https://github.com/vincentriemer/io-808  
-  An attempt at a fully recreated web-based TR-808 drum machine
-  
-
-  
-## Redux Docs Translations
-
-- [中文文档](http://camsong.github.io/redux-in-chinese/) — Chinese
-- [繁體中文文件](https://github.com/chentsulin/redux) — Traditional Chinese
-- [Redux in Russian](https://github.com/rajdee/redux-in-russian) — Russian
-- [Redux en Español](http://es.redux.js.org/) - Spanish
-
-
-## Books
-
-- **Redux in Action**  
-  https://www.manning.com/books/redux-in-action  
-  A comprehensive book that covers many key aspects of using Redux, including the basics of reducers and actions and use with React, complex middlewares and side effects, application structure, performance, testing, and much more.  Does a great job of explaining the pros, cons, and tradeoffs of many approaches to using Redux.  Personally recommended by Redux co-maintainer Mark Erikson.
-
-- **The Complete Redux Book**  
-  https://leanpub.com/redux-book  
-  How do I manage a large state in production? Why do I need store enhancers? What is the best way to handle form validations?  Get the answers to all these questions and many more using simple terms and sample code. Learn everything you need to use Redux to build complex and production-ready web applications.  (Note: now permanently free!)
-  
-  
-
-## Courses
-
-- **Modern React with Redux, by Stephen Grider (paid)**  
-  https://www.udemy.com/react-redux/  
-  Master the fundamentals of React and Redux with this tutorial as you develop apps with React Router, Webpack, and ES6.  This course will get you up and running quickly, and teach you the core knowledge you need to deeply understand and build React components and structure applications with Redux.
-  
-- **Redux, by Tyler McGinnis (paid)**  
-  https://tylermcginnis.com/courses/redux/  
-  When learning Redux, you need to learn it in the context of an app big enough to see the benefits. That's why this course is huge. A better name might be 'Real World Redux. If you're sick of "todo list" Redux tutorials, you've come to the right place. In this course we'll talk all about what makes Redux special for managing state in your application. We'll build an actual "real world" application so you can see how Redux handles edge cases like optimistic updates and error handling. We'll also cover many other technologies that work well with Redux, Firebase, and CSS Modules.
-  
-- **Learn Redux, by Wes Bos (free)**  
-  https://learnredux.com/  
-  A video course that walks through building 'Reduxstagram' — a simple photo app that will simplify the core ideas behind Redux, React Router and React.js
-
-
-## More Resources
-
-- [React-Redux Links](https://github.com/markerikson/react-redux-links) is a curated list of high-quality articles, tutorials, and related content for React, Redux, ES6, and more.  
-- [Redux Ecosystem Links](https://github.com/markerikson/redux-ecosystem-links) is a categorized collection of Redux-related libraries, addons, and utilities.
+# Learning Resources
+
+The Redux docs are intended to teach the basic concepts of Redux, as well as explain key concepts for use in real-world applications.  However, the docs can't cover everything.  Happily, there's many other great resources available for learning Redux.  We encourage you to check them out.  Many of them cover topics that are beyond the scope of the docs, or describe the same topics in other ways that may work better for your learning style.
+
+This page includes our recommendations for some of the best external resources available to learn Redux.  For an additional extensive list of tutorials, articles, and other resources on React, Redux, Javascript, and related topics, see the [React/Redux Links list](https://github.com/markerikson/react-redux-links).
+
+
+## Basic Introductions
+
+*Tutorials that teach the basic concepts of Redux and how to use it*
+
+- **Getting Started with Redux - Video Series**  
+  https://egghead.io/series/getting-started-with-redux  
+  https://github.com/tayiorbeii/egghead.io_redux_course_notes  
+  Dan Abramov, the creator of Redux, demonstrates various concepts in 30 short (2-5 minute) videos.  The linked Github repo contains notes and transcriptions of the videos.
+
+- **Building React Applications with Idiomatic Redux - Video Series**  
+  https://egghead.io/series/building-react-applications-with-idiomatic-redux  
+  https://github.com/tayiorbeii/egghead.io_idiomatic_redux_course_notes  
+  Dan Abramov's second video tutorial series, continuing directly after the first.  Includes lessons on store initial state, using Redux with React Router, using "selector" functions, normalizing state, use of Redux middleware, async action creators, and more.  The linked Github repo contains notes and transcriptions of the videos.
+  
+- **Live React: Hot Reloading and Time Travel**  
+  http://youtube.com/watch?v=xsSnOQynTHs
+  Dan Abramov's original conference talk that introduced Redux.  See how constraints enforced by Redux make hot reloading with time travel easy
+  
+- **A Cartoon Guide to Redux**  
+  https://code-cartoons.com/a-cartoon-intro-to-redux-3afb775501a6  
+  A high-level description of Redux, with friendly cartoons to help illustrate the ideas. 
+
+- **Leveling Up with React: Redux**  
+  https://css-tricks.com/learning-react-redux/  
+  A very well-written introduction to Redux and its related concepts, with some nifty cartoon-ish diagrams.
+  
+- **An Introduction to Redux**  
+  https://www.smashingmagazine.com/2016/06/an-introduction-to-redux/  
+  An overview and intro to the basic concepts of Redux.  Looks at the benefits of using Redux, how it differs from MVC or Flux, and its relation to functional programming.
+  
+- **Redux Tutorial**  
+  https://www.pshrmn.com/tutorials/react/redux/  
+  A short, clear tutorial that introduces basic Redux terms, shows how to split reducer functions, and describes the Redux store API.
+  
+  
+- **Redux: From Twitter Hype to Production**  
+  http://slides.com/jenyaterpil/redux-from-twitter-hype-to-production#/  
+  An extremely well-produced slideshow that visually steps through core Redux concepts, usage with React, project organization, and side effects with thunks and sagas.  Has some absolutely _fantastic_ animated diagrams demonstrating how data flows through a React+Redux architecture.
+  
+- **DevGuides: Introduction to Redux**  
+  http://devguides.io/redux/  
+  A tutorial that covers several aspects of Redux, including actions, reducers, usage with React, and middleware.
+
+
+
+## Using Redux With React
+
+*Explanations of the React-Redux bindings and the `connect` function*
+
+- **Why Redux is Useful in React Apps**  
+  https://www.fullstackreact.com/articles/redux-with-mark-erikson/  
+  An explanation of some of the benefits of using Redux with React, including sharing data between components and hot module reloading.
+   
+
+- **What Does Redux Do? (and when should you use it?)**  
+  https://daveceddia.com/what-does-redux-do/  
+  An excellent summary of how Redux helps solve data flow problems in a React app.
+  
+- **How Redux Works: A Counter-Example**  
+  https://daveceddia.com/how-does-redux-work/  
+  A great follow-up to the previous article.  It explains how to use Redux and React-Redux, by first showing a React component that stores a value in its internal state, and then refactoring it to use Redux instead.  Along the way, the article explains important Redux terms and concepts, and how they all fit together to make the Redux data flow work properly.
+  
+- **Redux and React: An Introduction**  
+  http://jakesidsmith.com/blog/post/2017-11-18-redux-and-react-an-introduction/  
+  A great introduction to Redux's core concepts, with explanations of how to use the React-Redux package to use Redux with React.
+
+- **React Redux Tutorial**  
+   https://www.pshrmn.com/tutorials/react/react-redux  
+   A clear, easy-to-read explanation of how to use the React-Redux `connect` API. 
+
+
+## Project-Based Tutorials
+
+*Tutorials that teach Redux concepts by building projects, including larger  "real-world"-type applications*
+  
+- **Practical Redux**  
+  http://blog.isquaredsoftware.com/2016/10/practical-redux-part-0-introduction/  
+  http://blog.isquaredsoftware.com/series/practical-redux/  
+  An ongoing series of posts intended to demonstrate a number of specific Redux techniques by building a sample application, based on the MekHQ application for managing Battletech campaigns.  Written by Redux co-maintainer Mark Erikson.  Covers topics like managing relational data, connecting multiple components and lists, complex reducer logic for features, handling forms, showing modal dialogs, and much more.
+
+- **Building a Simple CRUD App with React + Redux**  
+  http://www.thegreatcodeadventure.com/building-a-simple-crud-app-with-react-redux-part-1/  
+  A nifty 8-part series that demonstrates building a CRUD app, including routing, AJAX calls, and the various CRUD aspects.  Very well written, with some useful diagrams as well.
+  
+- **The Soundcloud Client in React + Redux**  
+  http://www.robinwieruch.de/the-soundcloud-client-in-react-redux/  
+  A detailed walkthrough demonstrating project setup, routing, authentication, fetching of remote data, and wrapping of a stateful library.
+  
+- **Full-Stack Redux Tutorial**  
+  http://teropa.info/blog/2015/09/10/full-stack-redux-tutorial.html  
+  A full-blown, in-depth tutorial that builds up a complete client-server application.
+
+- **Getting Started with React, Redux and Immutable: a Test-Driven Tutorial**  
+  http://www.theodo.fr/blog/2016/03/getting-started-with-react-redux-and-immutable-a-test-driven-tutorial-part-1/  
+  http://www.theodo.fr/blog/2016/03/getting-started-with-react-redux-and-immutable-a-test-driven-tutorial-part-2/  
+  Another solid, in-depth tutorial, similar to the "Full-Stack" tutorial.  Builds a client-only TodoMVC app, and demonstrates a good project setup (including a Mocha+JSDOM-based testing configuration).  Well-written, covers many concepts, and very easy to follow.
+  
+- **Redux Hero: An Intro to Redux and Reselect**  
+  https://decembersoft.com/posts/redux-hero-part-1-a-hero-is-born-a-fun-introduction-to-redux-js/  
+  An introduction to Redux and related libraries through building a small RPG-style game
+  
+ 
+## Redux Implementation
+
+*Explanations of how Redux works internally, by writing miniature reimplementations*
+
+- **Build Yourself a Redux**  
+  https://zapier.com/engineering/how-to-build-redux/  
+  An excellent in-depth "build a mini-Redux" article, which covers not only Redux's core, but also `connect` and middleware as well.
+  
+- **Connect.js explained**  
+  https://gist.github.com/gaearon/1d19088790e70ac32ea636c025ba424e  
+  A very simplified version of React Redux's `connect()` function that illustrates the basic implementation
+  
+- **Let's Write Redux!**  
+  http://www.jamasoftware.com/blog/lets-write-redux/  
+  Walks through writing a miniature version of Redux step-by-step, to help explain the concepts and implementation.
+
+
+## Reducers
+
+*Articles discussing ways to write reducer functions*
+
+- **Taking Advantage of `combineReducers`**  
+  http://randycoulman.com/blog/2016/11/22/taking-advantage-of-combinereducers/  
+  Examples of using `combineReducers` multiple times to produce a state tree, and some thoughts on tradeoffs in various approaches to reducer logic.
+  
+- **The Power of Higher-Order Reducers**  
+  http://slides.com/omnidan/hor#/  
+  A slideshow from the author of redux-undo and other libraries, explaining the concept of higher-order reducers and how they can be used
+  
+- **Reducer composition with Higher Order Reducers**  
+  https://medium.com/@mange_vibration/reducer-composition-with-higher-order-reducers-35c3977ed08f  
+  Some great examples of writing small functions that can be composed together to perform larger specific reducer tasks, such as providing initial state, filtering, updating specific keys, and more.
+  
+- **Higher Order Reducers - It just sounds scary**  
+  https://medium.com/@danielkagan/high-order-reducers-it-just-sounds-scary-2b9e5dbfc705  
+  Explains how reducers can be composed like Lego bricks to create reusable and testable reducer logic.
+  
+  
+## Selectors
+
+*Explanations of how and why to use selector functions to read values from state*
+  
+- **ReactCasts #8: Selectors in Redux**  
+  https://www.youtube.com/watch?v=frT3to2ACCw  
+  A great overview of why and how to use selector functions to retrieve data from the store, and derive additional data from store values
+  
+- **Optimizing React Redux Application Development with Reselect**  
+  https://codebrahma.com/reselect-tutorial-optimizing-react-redux-application-development-with-reselect/  
+  A good tutorial on Reselect.  Covers the concept of "selector functions", how to use Reselect's API, and how to use memoized selectors to improve performance.
+  
+- **Usage of Reselect in a React-Redux Application**  
+  https://dashbouquet.com/blog/frontend-development/usage-of-reselect-in-a-react-redux-application  
+  Discusses the importance of memoized selectors for performance, and good practices for using Reselect.
+  
+- **React, Reselect, and Redux**  
+  https://medium.com/@parkerdan/react-reselect-and-redux-b34017f8194c  
+  An explanation of how Reselect's memoized selector functions are useful in Redux apps, and how to create unique selector instances for each component instance.
+  
+
+## Normalization
+
+*How to structure the Redux store like a database for best performance*
+
+- **Querying a Redux Store**  
+  https://medium.com/@adamrackis/querying-a-redux-store-37db8c7f3b0f  
+  A look at best practices for organizing and storing data in Redux, including normalizing data and use of selector functions.
+  
+- **Normalizing Redux Stores for Maximum Code Reuse**  
+  https://medium.com/@adamrackis/normalizing-redux-stores-for-maximum-code-reuse-ae6e3844ae95  
+  Thoughts on how normalized Redux stores enable some useful data handling approaches, with examples of using selector functions to denormalize hierarchical data.
+  
+- **Redux Normalizr: Improve your State Management**  
+  http://www.robinwieruch.de/the-soundcloud-client-in-react-redux-normalizr/  
+  A tutorial describing how to use Normalizr for improved data management of nested data in Redux
+  
+- **Advanced Redux Entity Normalization**  
+  https://medium.com/@dcousineau/advanced-redux-entity-normalization-f5f1fe2aefc5  
+  Describes a "keyWindow" concept for tracking subsets of entities in state, similar to an SQL "view".  A useful extension to the idea of normalized data.
+
+
+
+## Middleware
+
+*Explanations and examples of how middleware work and how to write them* 
+
+- **Exploring Redux Middlewares**  
+  http://blog.krawaller.se/posts/exploring-redux-middleware/  
+  Understanding middlewares through a series of small experiments
+
+- **Redux Middleware Tutorial**  
+  http://www.pshrmn.com/tutorials/react/redux-middleware/  
+  An overview of what middleware is, how `applyMiddleware` works, and how to write middleware.
+  
+- **ReactCasts #6: Redux Middleware**  
+  https://www.youtube.com/watch?v=T-qtHI1qHIg  
+  A screencast that describes how middleware fit into Redux, their uses, and how to implement a custom middleware 
+  
+- **A Beginner's Guide to Redux Middleware**  
+  https://www.codementor.io/reactjs/tutorial/beginner-s-guide-to-redux-middleware  
+  A useful explanation of middleware use cases, with numerous examples
+
+
+## Side Effects - Basics
+
+*Introductions to handling async behavior in Redux*
+
+- **Stack Overflow: Dispatching Redux Actions with a Timeout**  
+  http://stackoverflow.com/questions/35411423/how-to-dispatch-a-redux-action-with-a-timeout/35415559#35415559  
+  Dan Abramov explains the basics of managing async behavior in Redux, walking through a progressive series of approaches (inline async calls, async action creators, thunk middleware).
+  
+- **Stack Overflow: Why do we need middleware for async flow in Redux?**  
+  http://stackoverflow.com/questions/34570758/why-do-we-need-middleware-for-async-flow-in-redux/34599594#34599594  
+  Dan Abramov gives reasons for using thunks and async middleware, and some useful patterns for using thunks.
+  
+- **What the heck is a "thunk"?**  
+  https://daveceddia.com/what-is-a-thunk/  
+  A quick explanation for what the word "thunk" means in general, and for Redux specifically.
+
+- **Thunks in Redux: The Basics**  
+  https://medium.com/fullstack-academy/thunks-in-redux-the-basics-85e538a3fe60  
+  A detailed look at what thunks are, what they solve, and how to use them.
+
+
+  
+  
+## Side Effects - Advanced
+
+*Advanced tools and techniques for managing async behavior*
+
+- **What is the right way to do asynchronous operations in Redux?**  
+  https://decembersoft.com/posts/what-is-the-right-way-to-do-asynchronous-operations-in-redux/  
+  An excellent look at the most popular libraries for Redux side effects, with comparisons of how each one works.
+  
+- **Redux 4 Ways**  
+  https://medium.com/react-native-training/redux-4-ways-95a130da0cdc  
+  Side-by-side comparisons of implementing some basic data fetching using thunks, sagas, observables, and a promise middleware
+
+- **Idiomatic Redux: Thoughts on Thunks, Sagas, Abstractions, and Reusability**  
+  http://blog.isquaredsoftware.com/2017/01/idiomatic-redux-thoughts-on-thunks-sagas-abstraction-and-reusability/  
+  A response to several "thunks are bad" concerns, arguing that thunks (and sagas) are still a valid approach for managing complex sync logic and async side effects.
+  
+- **Javascript Power Tools: Redux-Saga**  
+  http://formidable.com/blog/2017/javascript-power-tools-redux-saga/  
+  http://formidable.com/blog/2017/composition-patterns-in-redux-saga/  
+  http://formidable.com/blog/2017/real-world-redux-saga-patterns/  
+  A fantastic series that teaches the concepts, implementation, and benefits behind Redux-Saga, including how ES6 generators are used to control function flow, how sagas can be composed together to accomplish concurrency, and practical use cases for sagas.
+  
+- **Exploring Redux Sagas**  
+  https://medium.com/onfido-tech/exploring-redux-sagas-cc1fca2015ee  
+  An excellent article that explores how to use sagas to provide a glue layer to implement decoupled business logic in a Redux application.
+  
+- **Taming Redux with Sagas**  
+  https://objectpartners.com/2017/11/20/taming-redux-with-sagas/  
+  A good overview of Redux-Saga, including info on generator functions, use cases for sagas, using sagas to deal with promises, and testing sagas.
+  
+- **Reactive Redux State with RxJS**  
+  https://ivanjov.com/reactive-redux-state-with-rxjs/  
+  Describes the concept of "Reactive PRogramming" and the RxJS library, and shows how to use redux-observable to fetch data, along with examples of testing.
+  
+- **Using redux-observable to handle asynchronous logic in Redux**  
+  https://medium.com/dailyjs/using-redux-observable-to-handle-asynchronous-logic-in-redux-d49194742522  
+  An extended post that compares a thunk-based implementation of handling a line-drawing example vs an observable-based implementation.
+
+
+## Thinking in Redux
+
+*Deeper looks at how Redux is meant to be used, and why it works the way it does*
+
+- **You Might Not Need Redux**  
+  https://medium.com/@dan_abramov/you-might-not-need-redux-be46360cf367  
+  Dan Abramov discusses the tradeoffs involved in using Redux.
+  
+- **Idiomatic Redux: The Tao of Redux, Part 1 - Implementation and Intent**
+  http://blog.isquaredsoftware.com/2017/05/idiomatic-redux-tao-of-redux-part-1/  
+  A deep dive into how Redux actually works, the constraints it asks you to follow, and the intent behind its design and usage.
+  
+- **Idiomatic Redux: The Tao of Redux, Part 2 - Practice and Philosophy**  
+  http://blog.isquaredsoftware.com/2017/05/idiomatic-redux-tao-of-redux-part-2/  
+  A follow-up look at why common Redux usage patterns exist, other ways that Redux can be used, and thoughts on the pros and cons of those different patterns and approaches.
+  
+- **What's So Great About Redux?**  
+  https://medium.freecodecamp.org/whats-so-great-about-redux-ac16f1cc0f8b  
+  https://storify.com/acemarke/redux-pros-cons-and-limitations  
+  https://twitter.com/modernserf/status/886426115874717697  
+  Deep and fascinating analysis of how Redux compares to OOP and message-passing, how typical Redux usage can devolve towards Java-like "setter" functions with more boilerplate, and something of a plea for a higher-level "blessed" abstraction on top of Redux to make it easier to work with and learn for newbies.  Very worth reading.  The author originally wrote a tweetstorm, which is captured in the Storify link, and wrote the blog post to expand on those thoughts.  Finally, he followed up with a few more thoughts on abstract vs concrete examples in another shorter tweet thread.
+
+
+## Redux Architecture
+
+*Patterns and practices for structuring larger Redux applications*
+
+- **Avoiding Accidental Complexity When Structuring Your App State**  
+  https://hackernoon.com/avoiding-accidental-complexity-when-structuring-your-app-state-6e6d22ad5e2a  
+  An excellent set of guidelines for organizing your Redux store structure.
+  
+- **Redux Step by Step: A Simple and Robust Workflow for Real Life Apps**  
+  https://hackernoon.com/redux-step-by-step-a-simple-and-robust-workflow-for-real-life-apps-1fdf7df46092  
+  A follow-up to the "Accidental Complexity" article, discussing principle
+  
+- **Things I Wish I Knew About Redux**  
+  https://medium.com/horrible-hacks/things-i-wish-i-knew-about-redux-9924abf2f9e0  
+  https://www.reddit.com/r/javascript/comments/4taau2/things_i_wish_i_knew_about_redux/  
+  A number of excellent tips and lessons learned after building an app with Redux.  Includes info on connecting components, selecting data, and app/project structure.  Additional discussion on Reddit.
+
+- **React+Redux: Tips and Best Practices for Clean, Reliable, & Maintainable Code**    
+  https://speakerdeck.com/goopscoop/react-plus-redux-tips-and-best-practices-for-clean-reliable-and-scalable-code  
+  An excellent slideshow with a wide variety of tips and suggestions, including keeping action creators simple and data manipulation in reducers, abstracting away API calls, avoiding spreading props, and more.
+
+- **Redux for state management in large web apps**  
+  https://www.mapbox.com/blog/redux-for-state-management-in-large-web-apps/  
+  Excellent discussion and examples of idiomatic Redux architecture, and how Mapbox applies those approaches to their Mapbox Studio application.
+
+
+## Apps and Examples
+
+- **React-Redux RealWorld Example: TodoMVC for the Real World**  
+  https://github.com/GoThinkster/redux-review  
+  An example full-stack "real world" application built with Redux.  Demos a Medium-like social blogging site that includes JWT authentication, CRUD, favoriting articles, following users, routing, and more.  The RealWorld project also includes many other implementations of the front and back ends of the site, specifically intended to show how different server and client implementations of the same project and API spec compare with each other.
+
+- **Project Mini-Mek**  
+  https://github.com/markerikson/project-minimek  
+  A sample app to demonstrate various useful Redux techniques, accompanying the "Practical Redux" blog series at http://blog.isquaredsoftware.com/series/practical-redux
+  
+- **react-redux-yelp-clone**  
+  https://github.com/mohamed-ismat/react-redux-yelp-clone  
+  An adaptation of the "Yelp Clone" app by FullStackReact.  It extends the original by using Redux and Redux Saga instead of local state, as well as React Router v4, styled-components, and other modern standards.  Based on the React-Boilerplate starter kit.
+  
+- **WordPress-Calypso**  
+  https://github.com/Automattic/wp-calypso  
+  The new JavaScript- and API-powered WordPress.com
+  
+- **Sound-Redux**  
+  https://github.com/andrewngu/sound-redux  
+  A Soundcloud client built with React / Redux
+  
+- **Winamp2-js**  
+  https://jordaneldredge.com/projects/winamp2-js/  
+  https://github.com/captbaritone/winamp2-js  
+  An in-browser recreation of Winamp2, built with React and Redux. Actually plays MP3s, and lets you load in local MP3 files.
+  
+- **Tello**  
+  https://github.com/joshwcomeau/Tello  
+  A simple and delightful way to track and manage TV shows
+  
+- **io-808**  
+  https://github.com/vincentriemer/io-808  
+  An attempt at a fully recreated web-based TR-808 drum machine
+  
+
+  
+## Redux Docs Translations
+
+- [中文文档](http://camsong.github.io/redux-in-chinese/) — Chinese
+- [繁體中文文件](https://github.com/chentsulin/redux) — Traditional Chinese
+- [Redux in Russian](https://github.com/rajdee/redux-in-russian) — Russian
+- [Redux en Español](http://es.redux.js.org/) - Spanish
+
+
+## Books
+
+- **Redux in Action**  
+  https://www.manning.com/books/redux-in-action  
+  A comprehensive book that covers many key aspects of using Redux, including the basics of reducers and actions and use with React, complex middlewares and side effects, application structure, performance, testing, and much more.  Does a great job of explaining the pros, cons, and tradeoffs of many approaches to using Redux.  Personally recommended by Redux co-maintainer Mark Erikson.
+
+- **The Complete Redux Book**  
+  https://leanpub.com/redux-book  
+  How do I manage a large state in production? Why do I need store enhancers? What is the best way to handle form validations?  Get the answers to all these questions and many more using simple terms and sample code. Learn everything you need to use Redux to build complex and production-ready web applications.  (Note: now permanently free!)
+  
+  
+
+## Courses
+
+- **Modern React with Redux, by Stephen Grider (paid)**  
+  https://www.udemy.com/react-redux/  
+  Master the fundamentals of React and Redux with this tutorial as you develop apps with React Router, Webpack, and ES6.  This course will get you up and running quickly, and teach you the core knowledge you need to deeply understand and build React components and structure applications with Redux.
+  
+- **Redux, by Tyler McGinnis (paid)**  
+  https://tylermcginnis.com/courses/redux/  
+  When learning Redux, you need to learn it in the context of an app big enough to see the benefits. That's why this course is huge. A better name might be 'Real World Redux. If you're sick of "todo list" Redux tutorials, you've come to the right place. In this course we'll talk all about what makes Redux special for managing state in your application. We'll build an actual "real world" application so you can see how Redux handles edge cases like optimistic updates and error handling. We'll also cover many other technologies that work well with Redux, Firebase, and CSS Modules.
+  
+- **Learn Redux, by Wes Bos (free)**  
+  https://learnredux.com/  
+  A video course that walks through building 'Reduxstagram' — a simple photo app that will simplify the core ideas behind Redux, React Router and React.js
+
+
+## More Resources
+
+- [React-Redux Links](https://github.com/markerikson/react-redux-links) is a curated list of high-quality articles, tutorials, and related content for React, Redux, ES6, and more.  
+- [Redux Ecosystem Links](https://github.com/markerikson/redux-ecosystem-links) is a categorized collection of Redux-related libraries, addons, and utilities.
 - [Awesome Redux](https://github.com/xgrommx/awesome-redux) is an extensive list of Redux-related repositories.  

--- a/docs/introduction/LearningResources.md
+++ b/docs/introduction/LearningResources.md
@@ -1,399 +1,399 @@
-# Learning Resources
-
-The Redux docs are intended to teach the basic concepts of Redux, as well as explain key concepts for use in real-world applications.  However, the docs can't cover everything.  Happily, there's many other great resources available for learning Redux.  We encourage you to check them out.  Many of them cover topics that are beyond the scope of the docs, or describe the same topics in other ways that may work better for your learning style.
-
-This page includes our recommendations for some of the best external resources available to learn Redux.  For an additional extensive list of tutorials, articles, and other resources on React, Redux, Javascript, and related topics, see the [React/Redux Links list](https://github.com/markerikson/react-redux-links).
-
-
-## Basic Introductions
-
-*Tutorials that teach the basic concepts of Redux and how to use it*
-
-- **Getting Started with Redux - Video Series**  
-  https://egghead.io/series/getting-started-with-redux  
-  https://github.com/tayiorbeii/egghead.io_redux_course_notes  
-  Dan Abramov, the creator of Redux, demonstrates various concepts in 30 short (2-5 minute) videos.  The linked Github repo contains notes and transcriptions of the videos.
-
-- **Building React Applications with Idiomatic Redux - Video Series**  
-  https://egghead.io/series/building-react-applications-with-idiomatic-redux  
-  https://github.com/tayiorbeii/egghead.io_idiomatic_redux_course_notes  
-  Dan Abramov's second video tutorial series, continuing directly after the first.  Includes lessons on store initial state, using Redux with React Router, using "selector" functions, normalizing state, use of Redux middleware, async action creators, and more.  The linked Github repo contains notes and transcriptions of the videos.
-  
-- **Live React: Hot Reloading and Time Travel**  
-  http://youtube.com/watch?v=xsSnOQynTHs
-  Dan Abramov's original conference talk that introduced Redux.  See how constraints enforced by Redux make hot reloading with time travel easy
-  
-- **A Cartoon Guide to Redux**  
-  https://code-cartoons.com/a-cartoon-intro-to-redux-3afb775501a6  
-  A high-level description of Redux, with friendly cartoons to help illustrate the ideas. 
-
-- **Leveling Up with React: Redux**  
-  https://css-tricks.com/learning-react-redux/  
-  A very well-written introduction to Redux and its related concepts, with some nifty cartoon-ish diagrams.
-  
-- **An Introduction to Redux**  
-  https://www.smashingmagazine.com/2016/06/an-introduction-to-redux/  
-  An overview and intro to the basic concepts of Redux.  Looks at the benefits of using Redux, how it differs from MVC or Flux, and its relation to functional programming.
-  
-- **Redux Tutorial**  
-  https://www.pshrmn.com/tutorials/react/redux/  
-  A short, clear tutorial that introduces basic Redux terms, shows how to split reducer functions, and describes the Redux store API.
-  
-  
-- **Redux: From Twitter Hype to Production**  
-  http://slides.com/jenyaterpil/redux-from-twitter-hype-to-production#/  
-  An extremely well-produced slideshow that visually steps through core Redux concepts, usage with React, project organization, and side effects with thunks and sagas.  Has some absolutely _fantastic_ animated diagrams demonstrating how data flows through a React+Redux architecture.
-  
-- **DevGuides: Introduction to Redux**  
-  http://devguides.io/redux/  
-  A tutorial that covers several aspects of Redux, including actions, reducers, usage with React, and middleware.
-
-
-
-## Using Redux With React
-
-*Explanations of the React-Redux bindings and the `connect` function*
-
-- **Why Redux is Useful in React Apps**  
-  https://www.fullstackreact.com/articles/redux-with-mark-erikson/  
-  An explanation of some of the benefits of using Redux with React, including sharing data between components and hot module reloading.
-   
-
-- **What Does Redux Do? (and when should you use it?)**  
-  https://daveceddia.com/what-does-redux-do/  
-  An excellent summary of how Redux helps solve data flow problems in a React app.
-  
-- **How Redux Works: A Counter-Example**  
-  https://daveceddia.com/how-does-redux-work/  
-  A great follow-up to the previous article.  It explains how to use Redux and React-Redux, by first showing a React component that stores a value in its internal state, and then refactoring it to use Redux instead.  Along the way, the article explains important Redux terms and concepts, and how they all fit together to make the Redux data flow work properly.
-  
-- **Redux and React: An Introduction**  
-  http://jakesidsmith.com/blog/post/2017-11-18-redux-and-react-an-introduction/  
-  A great introduction to Redux's core concepts, with explanations of how to use the React-Redux package to use Redux with React.
-
-- **React Redux Tutorial**  
-   https://www.pshrmn.com/tutorials/react/react-redux  
-   A clear, easy-to-read explanation of how to use the React-Redux `connect` API. 
-
-
-## Project-Based Tutorials
-
-*Tutorials that teach Redux concepts by building projects, including larger  "real-world"-type applications*
-  
-- **Practical Redux**  
-  http://blog.isquaredsoftware.com/2016/10/practical-redux-part-0-introduction/  
-  http://blog.isquaredsoftware.com/series/practical-redux/  
-  An ongoing series of posts intended to demonstrate a number of specific Redux techniques by building a sample application, based on the MekHQ application for managing Battletech campaigns.  Written by Redux co-maintainer Mark Erikson.  Covers topics like managing relational data, connecting multiple components and lists, complex reducer logic for features, handling forms, showing modal dialogs, and much more.
-
-- **Building a Simple CRUD App with React + Redux**  
-  http://www.thegreatcodeadventure.com/building-a-simple-crud-app-with-react-redux-part-1/  
-  A nifty 8-part series that demonstrates building a CRUD app, including routing, AJAX calls, and the various CRUD aspects.  Very well written, with some useful diagrams as well.
-  
-- **The Soundcloud Client in React + Redux**  
-  http://www.robinwieruch.de/the-soundcloud-client-in-react-redux/  
-  A detailed walkthrough demonstrating project setup, routing, authentication, fetching of remote data, and wrapping of a stateful library.
-  
-- **Full-Stack Redux Tutorial**  
-  http://teropa.info/blog/2015/09/10/full-stack-redux-tutorial.html  
-  A full-blown, in-depth tutorial that builds up a complete client-server application.
-
-- **Getting Started with React, Redux and Immutable: a Test-Driven Tutorial**  
-  http://www.theodo.fr/blog/2016/03/getting-started-with-react-redux-and-immutable-a-test-driven-tutorial-part-1/  
-  http://www.theodo.fr/blog/2016/03/getting-started-with-react-redux-and-immutable-a-test-driven-tutorial-part-2/  
-  Another solid, in-depth tutorial, similar to the "Full-Stack" tutorial.  Builds a client-only TodoMVC app, and demonstrates a good project setup (including a Mocha+JSDOM-based testing configuration).  Well-written, covers many concepts, and very easy to follow.
-  
-- **Redux Hero: An Intro to Redux and Reselect**  
-  https://decembersoft.com/posts/redux-hero-part-1-a-hero-is-born-a-fun-introduction-to-redux-js/  
-  An introduction to Redux and related libraries through building a small RPG-style game
-  
- 
-## Redux Implementation
-
-*Explanations of how Redux works internally, by writing miniature reimplementations*
-
-- **Build Yourself a Redux**  
-  https://zapier.com/engineering/how-to-build-redux/  
-  An excellent in-depth "build a mini-Redux" article, which covers not only Redux's core, but also `connect` and middleware as well.
-  
-- **Connect.js explained**  
-  https://gist.github.com/gaearon/1d19088790e70ac32ea636c025ba424e  
-  A very simplified version of React Redux's `connect()` function that illustrates the basic implementation
-  
-- **Let's Write Redux!**  
-  http://www.jamasoftware.com/blog/lets-write-redux/  
-  Walks through writing a miniature version of Redux step-by-step, to help explain the concepts and implementation.
-
-
-## Reducers
-
-*Articles discussing ways to write reducer functions*
-
-- **Taking Advantage of `combineReducers`**  
-  http://randycoulman.com/blog/2016/11/22/taking-advantage-of-combinereducers/  
-  Examples of using `combineReducers` multiple times to produce a state tree, and some thoughts on tradeoffs in various approaches to reducer logic.
-  
-- **The Power of Higher-Order Reducers**  
-  http://slides.com/omnidan/hor#/  
-  A slideshow from the author of redux-undo and other libraries, explaining the concept of higher-order reducers and how they can be used
-  
-- **Reducer composition with Higher Order Reducers**  
-  https://medium.com/@mange_vibration/reducer-composition-with-higher-order-reducers-35c3977ed08f  
-  Some great examples of writing small functions that can be composed together to perform larger specific reducer tasks, such as providing initial state, filtering, updating specific keys, and more.
-  
-- **Higher Order Reducers - It just sounds scary**  
-  https://medium.com/@danielkagan/high-order-reducers-it-just-sounds-scary-2b9e5dbfc705  
-  Explains how reducers can be composed like Lego bricks to create reusable and testable reducer logic.
-  
-  
-## Selectors
-
-*Explanations of how and why to use selector functions to read values from state*
-  
-- **ReactCasts #8: Selectors in Redux**  
-  https://www.youtube.com/watch?v=frT3to2ACCw  
-  A great overview of why and how to use selector functions to retrieve data from the store, and derive additional data from store values
-  
-- **Optimizing React Redux Application Development with Reselect**  
-  https://codebrahma.com/reselect-tutorial-optimizing-react-redux-application-development-with-reselect/  
-  A good tutorial on Reselect.  Covers the concept of "selector functions", how to use Reselect's API, and how to use memoized selectors to improve performance.
-  
-- **Usage of Reselect in a React-Redux Application**  
-  https://dashbouquet.com/blog/frontend-development/usage-of-reselect-in-a-react-redux-application  
-  Discusses the importance of memoized selectors for performance, and good practices for using Reselect.
-  
-- **React, Reselect, and Redux**  
-  https://medium.com/@parkerdan/react-reselect-and-redux-b34017f8194c  
-  An explanation of how Reselect's memoized selector functions are useful in Redux apps, and how to create unique selector instances for each component instance.
-  
-
-## Normalization
-
-*How to structure the Redux store like a database for best performance*
-
-- **Querying a Redux Store**  
-  https://medium.com/@adamrackis/querying-a-redux-store-37db8c7f3b0f  
-  A look at best practices for organizing and storing data in Redux, including normalizing data and use of selector functions.
-  
-- **Normalizing Redux Stores for Maximum Code Reuse**  
-  https://medium.com/@adamrackis/normalizing-redux-stores-for-maximum-code-reuse-ae6e3844ae95  
-  Thoughts on how normalized Redux stores enable some useful data handling approaches, with examples of using selector functions to denormalize hierarchical data.
-  
-- **Redux Normalizr: Improve your State Management**  
-  http://www.robinwieruch.de/the-soundcloud-client-in-react-redux-normalizr/  
-  A tutorial describing how to use Normalizr for improved data management of nested data in Redux
-  
-- **Advanced Redux Entity Normalization**  
-  https://medium.com/@dcousineau/advanced-redux-entity-normalization-f5f1fe2aefc5  
-  Describes a "keyWindow" concept for tracking subsets of entities in state, similar to an SQL "view".  A useful extension to the idea of normalized data.
-
-
-
-## Middleware
-
-*Explanations and examples of how middleware work and how to write them* 
-
-- **Exploring Redux Middlewares**  
-  http://blog.krawaller.se/posts/exploring-redux-middleware/  
-  Understanding middlewares through a series of small experiments
-
-- **Redux Middleware Tutorial**  
-  http://www.pshrmn.com/tutorials/react/redux-middleware/  
-  An overview of what middleware is, how `applyMiddleware` works, and how to write middleware.
-  
-- **ReactCasts #6: Redux Middleware**  
-  https://www.youtube.com/watch?v=T-qtHI1qHIg  
-  A screencast that describes how middleware fit into Redux, their uses, and how to implement a custom middleware 
-  
-- **A Beginner's Guide to Redux Middleware**  
-  https://www.codementor.io/reactjs/tutorial/beginner-s-guide-to-redux-middleware  
-  A useful explanation of middleware use cases, with numerous examples
-
-
-## Side Effects - Basics
-
-*Introductions to handling async behavior in Redux*
-
-- **Stack Overflow: Dispatching Redux Actions with a Timeout**  
-  http://stackoverflow.com/questions/35411423/how-to-dispatch-a-redux-action-with-a-timeout/35415559#35415559  
-  Dan Abramov explains the basics of managing async behavior in Redux, walking through a progressive series of approaches (inline async calls, async action creators, thunk middleware).
-  
-- **Stack Overflow: Why do we need middleware for async flow in Redux?**  
-  http://stackoverflow.com/questions/34570758/why-do-we-need-middleware-for-async-flow-in-redux/34599594#34599594  
-  Dan Abramov gives reasons for using thunks and async middleware, and some useful patterns for using thunks.
-  
-- **What the heck is a "thunk"?**  
-  https://daveceddia.com/what-is-a-thunk/  
-  A quick explanation for what the word "thunk" means in general, and for Redux specifically.
-
-- **Thunks in Redux: The Basics**  
-  https://medium.com/fullstack-academy/thunks-in-redux-the-basics-85e538a3fe60  
-  A detailed look at what thunks are, what they solve, and how to use them.
-
-
-  
-  
-## Side Effects - Advanced
-
-*Advanced tools and techniques for managing async behavior*
-
-- **What is the right way to do asynchronous operations in Redux?**  
-  https://decembersoft.com/posts/what-is-the-right-way-to-do-asynchronous-operations-in-redux/  
-  An excellent look at the most popular libraries for Redux side effects, with comparisons of how each one works.
-  
-- **Redux 4 Ways**  
-  https://medium.com/react-native-training/redux-4-ways-95a130da0cdc  
-  Side-by-side comparisons of implementing some basic data fetching using thunks, sagas, observables, and a promise middleware
-
-- **Idiomatic Redux: Thoughts on Thunks, Sagas, Abstractions, and Reusability**  
-  http://blog.isquaredsoftware.com/2017/01/idiomatic-redux-thoughts-on-thunks-sagas-abstraction-and-reusability/  
-  A response to several "thunks are bad" concerns, arguing that thunks (and sagas) are still a valid approach for managing complex sync logic and async side effects.
-  
-- **Javascript Power Tools: Redux-Saga**  
-  http://formidable.com/blog/2017/javascript-power-tools-redux-saga/  
-  http://formidable.com/blog/2017/composition-patterns-in-redux-saga/  
-  http://formidable.com/blog/2017/real-world-redux-saga-patterns/  
-  A fantastic series that teaches the concepts, implementation, and benefits behind Redux-Saga, including how ES6 generators are used to control function flow, how sagas can be composed together to accomplish concurrency, and practical use cases for sagas.
-  
-- **Exploring Redux Sagas**  
-  https://medium.com/onfido-tech/exploring-redux-sagas-cc1fca2015ee  
-  An excellent article that explores how to use sagas to provide a glue layer to implement decoupled business logic in a Redux application.
-  
-- **Taming Redux with Sagas**  
-  https://objectpartners.com/2017/11/20/taming-redux-with-sagas/  
-  A good overview of Redux-Saga, including info on generator functions, use cases for sagas, using sagas to deal with promises, and testing sagas.
-  
-- **Reactive Redux State with RxJS**  
-  https://ivanjov.com/reactive-redux-state-with-rxjs/  
-  Describes the concept of "Reactive PRogramming" and the RxJS library, and shows how to use redux-observable to fetch data, along with examples of testing.
-  
-- **Using redux-observable to handle asynchronous logic in Redux**  
-  https://medium.com/dailyjs/using-redux-observable-to-handle-asynchronous-logic-in-redux-d49194742522  
-  An extended post that compares a thunk-based implementation of handling a line-drawing example vs an observable-based implementation.
-
-
-## Thinking in Redux
-
-*Deeper looks at how Redux is meant to be used, and why it works the way it does*
-
-- **You Might Not Need Redux**  
-  https://medium.com/@dan_abramov/you-might-not-need-redux-be46360cf367  
-  Dan Abramov discusses the tradeoffs involved in using Redux.
-  
-- **Idiomatic Redux: The Tao of Redux, Part 1 - Implementation and Intent**
-  http://blog.isquaredsoftware.com/2017/05/idiomatic-redux-tao-of-redux-part-1/  
-  A deep dive into how Redux actually works, the constraints it asks you to follow, and the intent behind its design and usage.
-  
-- **Idiomatic Redux: The Tao of Redux, Part 2 - Practice and Philosophy**  
-  http://blog.isquaredsoftware.com/2017/05/idiomatic-redux-tao-of-redux-part-2/  
-  A follow-up look at why common Redux usage patterns exist, other ways that Redux can be used, and thoughts on the pros and cons of those different patterns and approaches.
-  
-- **What's So Great About Redux?**  
-  https://medium.freecodecamp.org/whats-so-great-about-redux-ac16f1cc0f8b  
-  https://storify.com/acemarke/redux-pros-cons-and-limitations  
-  https://twitter.com/modernserf/status/886426115874717697  
-  Deep and fascinating analysis of how Redux compares to OOP and message-passing, how typical Redux usage can devolve towards Java-like "setter" functions with more boilerplate, and something of a plea for a higher-level "blessed" abstraction on top of Redux to make it easier to work with and learn for newbies.  Very worth reading.  The author originally wrote a tweetstorm, which is captured in the Storify link, and wrote the blog post to expand on those thoughts.  Finally, he followed up with a few more thoughts on abstract vs concrete examples in another shorter tweet thread.
-
-
-## Redux Architecture
-
-*Patterns and practices for structuring larger Redux applications*
-
-- **Avoiding Accidental Complexity When Structuring Your App State**  
-  https://hackernoon.com/avoiding-accidental-complexity-when-structuring-your-app-state-6e6d22ad5e2a  
-  An excellent set of guidelines for organizing your Redux store structure.
-  
-- **Redux Step by Step: A Simple and Robust Workflow for Real Life Apps**  
-  https://hackernoon.com/redux-step-by-step-a-simple-and-robust-workflow-for-real-life-apps-1fdf7df46092  
-  A follow-up to the "Accidental Complexity" article, discussing principle
-  
-- **Things I Wish I Knew About Redux**  
-  https://medium.com/horrible-hacks/things-i-wish-i-knew-about-redux-9924abf2f9e0  
-  https://www.reddit.com/r/javascript/comments/4taau2/things_i_wish_i_knew_about_redux/  
-  A number of excellent tips and lessons learned after building an app with Redux.  Includes info on connecting components, selecting data, and app/project structure.  Additional discussion on Reddit.
-
-- **React+Redux: Tips and Best Practices for Clean, Reliable, & Maintainable Code**    
-  https://speakerdeck.com/goopscoop/react-plus-redux-tips-and-best-practices-for-clean-reliable-and-scalable-code  
-  An excellent slideshow with a wide variety of tips and suggestions, including keeping action creators simple and data manipulation in reducers, abstracting away API calls, avoiding spreading props, and more.
-
-- **Redux for state management in large web apps**  
-  https://www.mapbox.com/blog/redux-for-state-management-in-large-web-apps/  
-  Excellent discussion and examples of idiomatic Redux architecture, and how Mapbox applies those approaches to their Mapbox Studio application.
-
-
-## Apps and Examples
-
-- **React-Redux RealWorld Example: TodoMVC for the Real World**  
-  https://github.com/GoThinkster/redux-review  
-  An example full-stack "real world" application built with Redux.  Demos a Medium-like social blogging site that includes JWT authentication, CRUD, favoriting articles, following users, routing, and more.  The RealWorld project also includes many other implementations of the front and back ends of the site, specifically intended to show how different server and client implementations of the same project and API spec compare with each other.
-
-- **Project Mini-Mek**  
-  https://github.com/markerikson/project-minimek  
-  A sample app to demonstrate various useful Redux techniques, accompanying the "Practical Redux" blog series at http://blog.isquaredsoftware.com/series/practical-redux
-  
-- **react-redux-yelp-clone**  
-  https://github.com/mohamed-ismat/react-redux-yelp-clone  
-  An adaptation of the "Yelp Clone" app by FullStackReact.  It extends the original by using Redux and Redux Saga instead of local state, as well as React Router v4, styled-components, and other modern standards.  Based on the React-Boilerplate starter kit.
-  
-- **WordPress-Calypso**  
-  https://github.com/Automattic/wp-calypso  
-  The new JavaScript- and API-powered WordPress.com
-  
-- **Sound-Redux**  
-  https://github.com/andrewngu/sound-redux  
-  A Soundcloud client built with React / Redux
-  
-- **Winamp2-js**  
-  https://jordaneldredge.com/projects/winamp2-js/  
-  https://github.com/captbaritone/winamp2-js  
-  An in-browser recreation of Winamp2, built with React and Redux. Actually plays MP3s, and lets you load in local MP3 files.
-  
-- **Tello**  
-  https://github.com/joshwcomeau/Tello  
-  A simple and delightful way to track and manage TV shows
-  
-- **io-808**  
-  https://github.com/vincentriemer/io-808  
-  An attempt at a fully recreated web-based TR-808 drum machine
-  
-
-  
-## Redux Docs Translations
-
-- [中文文档](http://camsong.github.io/redux-in-chinese/) — Chinese
-- [繁體中文文件](https://github.com/chentsulin/redux) — Traditional Chinese
-- [Redux in Russian](https://github.com/rajdee/redux-in-russian) — Russian
-- [Redux en Español](http://es.redux.js.org/) - Spanish
-
-
-## Books
-
-- **Redux in Action**  
-  https://www.manning.com/books/redux-in-action  
-  A comprehensive book that covers many key aspects of using Redux, including the basics of reducers and actions and use with React, complex middlewares and side effects, application structure, performance, testing, and much more.  Does a great job of explaining the pros, cons, and tradeoffs of many approaches to using Redux.  Personally recommended by Redux co-maintainer Mark Erikson.
-
-- **The Complete Redux Book**  
-  https://leanpub.com/redux-book  
-  How do I manage a large state in production? Why do I need store enhancers? What is the best way to handle form validations?  Get the answers to all these questions and many more using simple terms and sample code. Learn everything you need to use Redux to build complex and production-ready web applications.  (Note: now permanently free!)
-  
-  
-
-## Courses
-
-- **Modern React with Redux, by Stephen Grider (paid)**  
-  https://www.udemy.com/react-redux/  
-  Master the fundamentals of React and Redux with this tutorial as you develop apps with React Router, Webpack, and ES6.  This course will get you up and running quickly, and teach you the core knowledge you need to deeply understand and build React components and structure applications with Redux.
-  
-- **Redux, by Tyler McGinnis (paid)**  
-  https://tylermcginnis.com/courses/redux/  
-  When learning Redux, you need to learn it in the context of an app big enough to see the benefits. That's why this course is huge. A better name might be 'Real World Redux. If you're sick of "todo list" Redux tutorials, you've come to the right place. In this course we'll talk all about what makes Redux special for managing state in your application. We'll build an actual "real world" application so you can see how Redux handles edge cases like optimistic updates and error handling. We'll also cover many other technologies that work well with Redux, Firebase, and CSS Modules.
-  
-- **Learn Redux, by Wes Bos (free)**  
-  https://learnredux.com/  
-  A video course that walks through building 'Reduxstagram' — a simple photo app that will simplify the core ideas behind Redux, React Router and React.js
-
-
-## More Resources
-
-- [React-Redux Links](https://github.com/markerikson/react-redux-links) is a curated list of high-quality articles, tutorials, and related content for React, Redux, ES6, and more.  
-- [Redux Ecosystem Links](https://github.com/markerikson/redux-ecosystem-links) is a categorized collection of Redux-related libraries, addons, and utilities.
+# Learning Resources
+
+The Redux docs are intended to teach the basic concepts of Redux, as well as explain key concepts for use in real-world applications.  However, the docs can't cover everything.  Happily, there's many other great resources available for learning Redux.  We encourage you to check them out.  Many of them cover topics that are beyond the scope of the docs, or describe the same topics in other ways that may work better for your learning style.
+
+This page includes our recommendations for some of the best external resources available to learn Redux.  For an additional extensive list of tutorials, articles, and other resources on React, Redux, Javascript, and related topics, see the [React/Redux Links list](https://github.com/markerikson/react-redux-links).
+
+
+## Basic Introductions
+
+*Tutorials that teach the basic concepts of Redux and how to use it*
+
+- **Getting Started with Redux - Video Series**  
+  https://egghead.io/series/getting-started-with-redux  
+  https://github.com/tayiorbeii/egghead.io_redux_course_notes  
+  Dan Abramov, the creator of Redux, demonstrates various concepts in 30 short (2-5 minute) videos.  The linked Github repo contains notes and transcriptions of the videos.
+
+- **Building React Applications with Idiomatic Redux - Video Series**  
+  https://egghead.io/series/building-react-applications-with-idiomatic-redux  
+  https://github.com/tayiorbeii/egghead.io_idiomatic_redux_course_notes  
+  Dan Abramov's second video tutorial series, continuing directly after the first.  Includes lessons on store initial state, using Redux with React Router, using "selector" functions, normalizing state, use of Redux middleware, async action creators, and more.  The linked Github repo contains notes and transcriptions of the videos.
+  
+- **Live React: Hot Reloading and Time Travel**  
+  http://youtube.com/watch?v=xsSnOQynTHs
+  Dan Abramov's original conference talk that introduced Redux.  See how constraints enforced by Redux make hot reloading with time travel easy
+  
+- **A Cartoon Guide to Redux**  
+  https://code-cartoons.com/a-cartoon-intro-to-redux-3afb775501a6  
+  A high-level description of Redux, with friendly cartoons to help illustrate the ideas. 
+
+- **Leveling Up with React: Redux**  
+  https://css-tricks.com/learning-react-redux/  
+  A very well-written introduction to Redux and its related concepts, with some nifty cartoon-ish diagrams.
+  
+- **An Introduction to Redux**  
+  https://www.smashingmagazine.com/2016/06/an-introduction-to-redux/  
+  An overview and intro to the basic concepts of Redux.  Looks at the benefits of using Redux, how it differs from MVC or Flux, and its relation to functional programming.
+  
+- **Redux Tutorial**  
+  https://www.pshrmn.com/tutorials/react/redux/  
+  A short, clear tutorial that introduces basic Redux terms, shows how to split reducer functions, and describes the Redux store API.
+  
+  
+- **Redux: From Twitter Hype to Production**  
+  http://slides.com/jenyaterpil/redux-from-twitter-hype-to-production#/  
+  An extremely well-produced slideshow that visually steps through core Redux concepts, usage with React, project organization, and side effects with thunks and sagas.  Has some absolutely _fantastic_ animated diagrams demonstrating how data flows through a React+Redux architecture.
+  
+- **DevGuides: Introduction to Redux**  
+  http://devguides.io/redux/  
+  A tutorial that covers several aspects of Redux, including actions, reducers, usage with React, and middleware.
+
+
+
+## Using Redux With React
+
+*Explanations of the React-Redux bindings and the `connect` function*
+
+- **Why Redux is Useful in React Apps**  
+  https://www.fullstackreact.com/articles/redux-with-mark-erikson/  
+  An explanation of some of the benefits of using Redux with React, including sharing data between components and hot module reloading.
+   
+
+- **What Does Redux Do? (and when should you use it?)**  
+  https://daveceddia.com/what-does-redux-do/  
+  An excellent summary of how Redux helps solve data flow problems in a React app.
+  
+- **How Redux Works: A Counter-Example**  
+  https://daveceddia.com/how-does-redux-work/  
+  A great follow-up to the previous article.  It explains how to use Redux and React-Redux, by first showing a React component that stores a value in its internal state, and then refactoring it to use Redux instead.  Along the way, the article explains important Redux terms and concepts, and how they all fit together to make the Redux data flow work properly.
+  
+- **Redux and React: An Introduction**  
+  http://jakesidsmith.com/blog/post/2017-11-18-redux-and-react-an-introduction/  
+  A great introduction to Redux's core concepts, with explanations of how to use the React-Redux package to use Redux with React.
+
+- **React Redux Tutorial**  
+   https://www.pshrmn.com/tutorials/react/react-redux  
+   A clear, easy-to-read explanation of how to use the React-Redux `connect` API. 
+
+
+## Project-Based Tutorials
+
+*Tutorials that teach Redux concepts by building projects, including larger  "real-world"-type applications*
+  
+- **Practical Redux**  
+  http://blog.isquaredsoftware.com/2016/10/practical-redux-part-0-introduction/  
+  http://blog.isquaredsoftware.com/series/practical-redux/  
+  An ongoing series of posts intended to demonstrate a number of specific Redux techniques by building a sample application, based on the MekHQ application for managing Battletech campaigns.  Written by Redux co-maintainer Mark Erikson.  Covers topics like managing relational data, connecting multiple components and lists, complex reducer logic for features, handling forms, showing modal dialogs, and much more.
+
+- **Building a Simple CRUD App with React + Redux**  
+  http://www.thegreatcodeadventure.com/building-a-simple-crud-app-with-react-redux-part-1/  
+  A nifty 8-part series that demonstrates building a CRUD app, including routing, AJAX calls, and the various CRUD aspects.  Very well written, with some useful diagrams as well.
+  
+- **The Soundcloud Client in React + Redux**  
+  http://www.robinwieruch.de/the-soundcloud-client-in-react-redux/  
+  A detailed walkthrough demonstrating project setup, routing, authentication, fetching of remote data, and wrapping of a stateful library.
+  
+- **Full-Stack Redux Tutorial**  
+  http://teropa.info/blog/2015/09/10/full-stack-redux-tutorial.html  
+  A full-blown, in-depth tutorial that builds up a complete client-server application.
+
+- **Getting Started with React, Redux and Immutable: a Test-Driven Tutorial**  
+  http://www.theodo.fr/blog/2016/03/getting-started-with-react-redux-and-immutable-a-test-driven-tutorial-part-1/  
+  http://www.theodo.fr/blog/2016/03/getting-started-with-react-redux-and-immutable-a-test-driven-tutorial-part-2/  
+  Another solid, in-depth tutorial, similar to the "Full-Stack" tutorial.  Builds a client-only TodoMVC app, and demonstrates a good project setup (including a Mocha+JSDOM-based testing configuration).  Well-written, covers many concepts, and very easy to follow.
+  
+- **Redux Hero: An Intro to Redux and Reselect**  
+  https://decembersoft.com/posts/redux-hero-part-1-a-hero-is-born-a-fun-introduction-to-redux-js/  
+  An introduction to Redux and related libraries through building a small RPG-style game
+  
+ 
+## Redux Implementation
+
+*Explanations of how Redux works internally, by writing miniature reimplementations*
+
+- **Build Yourself a Redux**  
+  https://zapier.com/engineering/how-to-build-redux/  
+  An excellent in-depth "build a mini-Redux" article, which covers not only Redux's core, but also `connect` and middleware as well.
+  
+- **Connect.js explained**  
+  https://gist.github.com/gaearon/1d19088790e70ac32ea636c025ba424e  
+  A very simplified version of React Redux's `connect()` function that illustrates the basic implementation
+  
+- **Let's Write Redux!**  
+  http://www.jamasoftware.com/blog/lets-write-redux/  
+  Walks through writing a miniature version of Redux step-by-step, to help explain the concepts and implementation.
+
+
+## Reducers
+
+*Articles discussing ways to write reducer functions*
+
+- **Taking Advantage of `combineReducers`**  
+  http://randycoulman.com/blog/2016/11/22/taking-advantage-of-combinereducers/  
+  Examples of using `combineReducers` multiple times to produce a state tree, and some thoughts on tradeoffs in various approaches to reducer logic.
+  
+- **The Power of Higher-Order Reducers**  
+  http://slides.com/omnidan/hor#/  
+  A slideshow from the author of redux-undo and other libraries, explaining the concept of higher-order reducers and how they can be used
+  
+- **Reducer composition with Higher Order Reducers**  
+  https://medium.com/@mange_vibration/reducer-composition-with-higher-order-reducers-35c3977ed08f  
+  Some great examples of writing small functions that can be composed together to perform larger specific reducer tasks, such as providing initial state, filtering, updating specific keys, and more.
+  
+- **Higher Order Reducers - It just sounds scary**  
+  https://medium.com/@danielkagan/high-order-reducers-it-just-sounds-scary-2b9e5dbfc705  
+  Explains how reducers can be composed like Lego bricks to create reusable and testable reducer logic.
+  
+  
+## Selectors
+
+*Explanations of how and why to use selector functions to read values from state*
+  
+- **ReactCasts #8: Selectors in Redux**  
+  https://www.youtube.com/watch?v=frT3to2ACCw  
+  A great overview of why and how to use selector functions to retrieve data from the store, and derive additional data from store values
+  
+- **Optimizing React Redux Application Development with Reselect**  
+  https://codebrahma.com/reselect-tutorial-optimizing-react-redux-application-development-with-reselect/  
+  A good tutorial on Reselect.  Covers the concept of "selector functions", how to use Reselect's API, and how to use memoized selectors to improve performance.
+  
+- **Usage of Reselect in a React-Redux Application**  
+  https://dashbouquet.com/blog/frontend-development/usage-of-reselect-in-a-react-redux-application  
+  Discusses the importance of memoized selectors for performance, and good practices for using Reselect.
+  
+- **React, Reselect, and Redux**  
+  https://medium.com/@parkerdan/react-reselect-and-redux-b34017f8194c  
+  An explanation of how Reselect's memoized selector functions are useful in Redux apps, and how to create unique selector instances for each component instance.
+  
+
+## Normalization
+
+*How to structure the Redux store like a database for best performance*
+
+- **Querying a Redux Store**  
+  https://medium.com/@adamrackis/querying-a-redux-store-37db8c7f3b0f  
+  A look at best practices for organizing and storing data in Redux, including normalizing data and use of selector functions.
+  
+- **Normalizing Redux Stores for Maximum Code Reuse**  
+  https://medium.com/@adamrackis/normalizing-redux-stores-for-maximum-code-reuse-ae6e3844ae95  
+  Thoughts on how normalized Redux stores enable some useful data handling approaches, with examples of using selector functions to denormalize hierarchical data.
+  
+- **Redux Normalizr: Improve your State Management**  
+  http://www.robinwieruch.de/the-soundcloud-client-in-react-redux-normalizr/  
+  A tutorial describing how to use Normalizr for improved data management of nested data in Redux
+  
+- **Advanced Redux Entity Normalization**  
+  https://medium.com/@dcousineau/advanced-redux-entity-normalization-f5f1fe2aefc5  
+  Describes a "keyWindow" concept for tracking subsets of entities in state, similar to an SQL "view".  A useful extension to the idea of normalized data.
+
+
+
+## Middleware
+
+*Explanations and examples of how middleware work and how to write them* 
+
+- **Exploring Redux Middlewares**  
+  http://blog.krawaller.se/posts/exploring-redux-middleware/  
+  Understanding middlewares through a series of small experiments
+
+- **Redux Middleware Tutorial**  
+  http://www.pshrmn.com/tutorials/react/redux-middleware/  
+  An overview of what middleware is, how `applyMiddleware` works, and how to write middleware.
+  
+- **ReactCasts #6: Redux Middleware**  
+  https://www.youtube.com/watch?v=T-qtHI1qHIg  
+  A screencast that describes how middleware fit into Redux, their uses, and how to implement a custom middleware 
+  
+- **A Beginner's Guide to Redux Middleware**  
+  https://www.codementor.io/reactjs/tutorial/beginner-s-guide-to-redux-middleware  
+  A useful explanation of middleware use cases, with numerous examples
+
+
+## Side Effects - Basics
+
+*Introductions to handling async behavior in Redux*
+
+- **Stack Overflow: Dispatching Redux Actions with a Timeout**  
+  http://stackoverflow.com/questions/35411423/how-to-dispatch-a-redux-action-with-a-timeout/35415559#35415559  
+  Dan Abramov explains the basics of managing async behavior in Redux, walking through a progressive series of approaches (inline async calls, async action creators, thunk middleware).
+  
+- **Stack Overflow: Why do we need middleware for async flow in Redux?**  
+  http://stackoverflow.com/questions/34570758/why-do-we-need-middleware-for-async-flow-in-redux/34599594#34599594  
+  Dan Abramov gives reasons for using thunks and async middleware, and some useful patterns for using thunks.
+  
+- **What the heck is a "thunk"?**  
+  https://daveceddia.com/what-is-a-thunk/  
+  A quick explanation for what the word "thunk" means in general, and for Redux specifically.
+
+- **Thunks in Redux: The Basics**  
+  https://medium.com/fullstack-academy/thunks-in-redux-the-basics-85e538a3fe60  
+  A detailed look at what thunks are, what they solve, and how to use them.
+
+
+  
+  
+## Side Effects - Advanced
+
+*Advanced tools and techniques for managing async behavior*
+
+- **What is the right way to do asynchronous operations in Redux?**  
+  https://decembersoft.com/posts/what-is-the-right-way-to-do-asynchronous-operations-in-redux/  
+  An excellent look at the most popular libraries for Redux side effects, with comparisons of how each one works.
+  
+- **Redux 4 Ways**  
+  https://medium.com/react-native-training/redux-4-ways-95a130da0cdc  
+  Side-by-side comparisons of implementing some basic data fetching using thunks, sagas, observables, and a promise middleware
+
+- **Idiomatic Redux: Thoughts on Thunks, Sagas, Abstractions, and Reusability**  
+  http://blog.isquaredsoftware.com/2017/01/idiomatic-redux-thoughts-on-thunks-sagas-abstraction-and-reusability/  
+  A response to several "thunks are bad" concerns, arguing that thunks (and sagas) are still a valid approach for managing complex sync logic and async side effects.
+  
+- **Javascript Power Tools: Redux-Saga**  
+  http://formidable.com/blog/2017/javascript-power-tools-redux-saga/  
+  http://formidable.com/blog/2017/composition-patterns-in-redux-saga/  
+  http://formidable.com/blog/2017/real-world-redux-saga-patterns/  
+  A fantastic series that teaches the concepts, implementation, and benefits behind Redux-Saga, including how ES6 generators are used to control function flow, how sagas can be composed together to accomplish concurrency, and practical use cases for sagas.
+  
+- **Exploring Redux Sagas**  
+  https://medium.com/onfido-tech/exploring-redux-sagas-cc1fca2015ee  
+  An excellent article that explores how to use sagas to provide a glue layer to implement decoupled business logic in a Redux application.
+  
+- **Taming Redux with Sagas**  
+  https://objectpartners.com/2017/11/20/taming-redux-with-sagas/  
+  A good overview of Redux-Saga, including info on generator functions, use cases for sagas, using sagas to deal with promises, and testing sagas.
+  
+- **Reactive Redux State with RxJS**  
+  https://ivanjov.com/reactive-redux-state-with-rxjs/  
+  Describes the concept of "Reactive PRogramming" and the RxJS library, and shows how to use redux-observable to fetch data, along with examples of testing.
+  
+- **Using redux-observable to handle asynchronous logic in Redux**  
+  https://medium.com/dailyjs/using-redux-observable-to-handle-asynchronous-logic-in-redux-d49194742522  
+  An extended post that compares a thunk-based implementation of handling a line-drawing example vs an observable-based implementation.
+
+
+## Thinking in Redux
+
+*Deeper looks at how Redux is meant to be used, and why it works the way it does*
+
+- **You Might Not Need Redux**  
+  https://medium.com/@dan_abramov/you-might-not-need-redux-be46360cf367  
+  Dan Abramov discusses the tradeoffs involved in using Redux.
+  
+- **Idiomatic Redux: The Tao of Redux, Part 1 - Implementation and Intent**
+  http://blog.isquaredsoftware.com/2017/05/idiomatic-redux-tao-of-redux-part-1/  
+  A deep dive into how Redux actually works, the constraints it asks you to follow, and the intent behind its design and usage.
+  
+- **Idiomatic Redux: The Tao of Redux, Part 2 - Practice and Philosophy**  
+  http://blog.isquaredsoftware.com/2017/05/idiomatic-redux-tao-of-redux-part-2/  
+  A follow-up look at why common Redux usage patterns exist, other ways that Redux can be used, and thoughts on the pros and cons of those different patterns and approaches.
+  
+- **What's So Great About Redux?**  
+  https://medium.freecodecamp.org/whats-so-great-about-redux-ac16f1cc0f8b  
+  https://storify.com/acemarke/redux-pros-cons-and-limitations  
+  https://twitter.com/modernserf/status/886426115874717697  
+  Deep and fascinating analysis of how Redux compares to OOP and message-passing, how typical Redux usage can devolve towards Java-like "setter" functions with more boilerplate, and something of a plea for a higher-level "blessed" abstraction on top of Redux to make it easier to work with and learn for newbies.  Very worth reading.  The author originally wrote a tweetstorm, which is captured in the Storify link, and wrote the blog post to expand on those thoughts.  Finally, he followed up with a few more thoughts on abstract vs concrete examples in another shorter tweet thread.
+
+
+## Redux Architecture
+
+*Patterns and practices for structuring larger Redux applications*
+
+- **Avoiding Accidental Complexity When Structuring Your App State**  
+  https://hackernoon.com/avoiding-accidental-complexity-when-structuring-your-app-state-6e6d22ad5e2a  
+  An excellent set of guidelines for organizing your Redux store structure.
+  
+- **Redux Step by Step: A Simple and Robust Workflow for Real Life Apps**  
+  https://hackernoon.com/redux-step-by-step-a-simple-and-robust-workflow-for-real-life-apps-1fdf7df46092  
+  A follow-up to the "Accidental Complexity" article, discussing principle
+  
+- **Things I Wish I Knew About Redux**  
+  https://medium.com/horrible-hacks/things-i-wish-i-knew-about-redux-9924abf2f9e0  
+  https://www.reddit.com/r/javascript/comments/4taau2/things_i_wish_i_knew_about_redux/  
+  A number of excellent tips and lessons learned after building an app with Redux.  Includes info on connecting components, selecting data, and app/project structure.  Additional discussion on Reddit.
+
+- **React+Redux: Tips and Best Practices for Clean, Reliable, & Maintainable Code**    
+  https://speakerdeck.com/goopscoop/react-plus-redux-tips-and-best-practices-for-clean-reliable-and-scalable-code  
+  An excellent slideshow with a wide variety of tips and suggestions, including keeping action creators simple and data manipulation in reducers, abstracting away API calls, avoiding spreading props, and more.
+
+- **Redux for state management in large web apps**  
+  https://www.mapbox.com/blog/redux-for-state-management-in-large-web-apps/  
+  Excellent discussion and examples of idiomatic Redux architecture, and how Mapbox applies those approaches to their Mapbox Studio application.
+
+
+## Apps and Examples
+
+- **React-Redux RealWorld Example: TodoMVC for the Real World**  
+  https://github.com/GoThinkster/redux-review  
+  An example full-stack "real world" application built with Redux.  Demos a Medium-like social blogging site that includes JWT authentication, CRUD, favoriting articles, following users, routing, and more.  The RealWorld project also includes many other implementations of the front and back ends of the site, specifically intended to show how different server and client implementations of the same project and API spec compare with each other.
+
+- **Project Mini-Mek**  
+  https://github.com/markerikson/project-minimek  
+  A sample app to demonstrate various useful Redux techniques, accompanying the "Practical Redux" blog series at http://blog.isquaredsoftware.com/series/practical-redux
+  
+- **react-redux-yelp-clone**  
+  https://github.com/mohamed-ismat/react-redux-yelp-clone  
+  An adaptation of the "Yelp Clone" app by FullStackReact.  It extends the original by using Redux and Redux Saga instead of local state, as well as React Router v4, styled-components, and other modern standards.  Based on the React-Boilerplate starter kit.
+  
+- **WordPress-Calypso**  
+  https://github.com/Automattic/wp-calypso  
+  The new JavaScript- and API-powered WordPress.com
+  
+- **Sound-Redux**  
+  https://github.com/andrewngu/sound-redux  
+  A Soundcloud client built with React / Redux
+  
+- **Winamp2-js**  
+  https://jordaneldredge.com/projects/winamp2-js/  
+  https://github.com/captbaritone/winamp2-js  
+  An in-browser recreation of Winamp2, built with React and Redux. Actually plays MP3s, and lets you load in local MP3 files.
+  
+- **Tello**  
+  https://github.com/joshwcomeau/Tello  
+  A simple and delightful way to track and manage TV shows
+  
+- **io-808**  
+  https://github.com/vincentriemer/io-808  
+  An attempt at a fully recreated web-based TR-808 drum machine
+  
+
+  
+## Redux Docs Translations
+
+- [中文文档](http://camsong.github.io/redux-in-chinese/) — Chinese
+- [繁體中文文件](https://github.com/chentsulin/redux) — Traditional Chinese
+- [Redux in Russian](https://github.com/rajdee/redux-in-russian) — Russian
+- [Redux en Español](http://es.redux.js.org/) - Spanish
+
+
+## Books
+
+- **Redux in Action**  
+  https://www.manning.com/books/redux-in-action  
+  A comprehensive book that covers many key aspects of using Redux, including the basics of reducers and actions and use with React, complex middlewares and side effects, application structure, performance, testing, and much more.  Does a great job of explaining the pros, cons, and tradeoffs of many approaches to using Redux.  Personally recommended by Redux co-maintainer Mark Erikson.
+
+- **The Complete Redux Book**  
+  https://leanpub.com/redux-book  
+  How do I manage a large state in production? Why do I need store enhancers? What is the best way to handle form validations?  Get the answers to all these questions and many more using simple terms and sample code. Learn everything you need to use Redux to build complex and production-ready web applications.  (Note: now permanently free!)
+  
+  
+
+## Courses
+
+- **Modern React with Redux, by Stephen Grider (paid)**  
+  https://www.udemy.com/react-redux/  
+  Master the fundamentals of React and Redux with this tutorial as you develop apps with React Router, Webpack, and ES6.  This course will get you up and running quickly, and teach you the core knowledge you need to deeply understand and build React components and structure applications with Redux.
+  
+- **Redux, by Tyler McGinnis (paid)**  
+  https://tylermcginnis.com/courses/redux/  
+  When learning Redux, you need to learn it in the context of an app big enough to see the benefits. That's why this course is huge. A better name might be 'Real World Redux. If you're sick of "todo list" Redux tutorials, you've come to the right place. In this course we'll talk all about what makes Redux special for managing state in your application. We'll build an actual "real world" application so you can see how Redux handles edge cases like optimistic updates and error handling. We'll also cover many other technologies that work well with Redux, Firebase, and CSS Modules.
+  
+- **Learn Redux, by Wes Bos (free)**  
+  https://learnredux.com/  
+  A video course that walks through building 'Reduxstagram' — a simple photo app that will simplify the core ideas behind Redux, React Router and React.js
+
+
+## More Resources
+
+- [React-Redux Links](https://github.com/markerikson/react-redux-links) is a curated list of high-quality articles, tutorials, and related content for React, Redux, ES6, and more.  
+- [Redux Ecosystem Links](https://github.com/markerikson/redux-ecosystem-links) is a categorized collection of Redux-related libraries, addons, and utilities.
 - [Awesome Redux](https://github.com/xgrommx/awesome-redux) is an extensive list of Redux-related repositories.  


### PR DESCRIPTION
Splits the "Ecosystem" docs page into "Learning Resources" and "Ecosystem", and updates both pages with content from my articles list and addons list.

Fixes #2588 .

