### PR TITLE
Fix rm unexpectedKeyCache prototype property

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -135,7 +135,7 @@ export default function combineReducers(reducers) {
 
   let unexpectedKeyCache
   if (process.env.NODE_ENV !== 'production') {
-    unexpectedKeyCache = {}
+    unexpectedKeyCache = Object.create(null)
   }
 
   let shapeAssertionError

--- a/test/combineReducers.spec.js
+++ b/test/combineReducers.spec.js
@@ -277,6 +277,11 @@ describe('Utils', () => {
       reducer({ ...state, baz: 5 }, {})
       reducer({ ...state, baz: 5 }, {})
       expect(spy.mock.calls.length).toBe(2)
+      reducer({ ...state, toString: 6 }, {})
+      reducer({ ...state, toString: 6 }, {})
+      reducer({ ...state, toString: 6 }, {})
+      reducer({ ...state, toString: 6 }, {})
+      expect(spy.mock.calls.length).toBe(3)
 
       spy.mockClear()
       console.error = preSpy


### PR DESCRIPTION
some protoytpe property(eg, `toString` `valueOf` ) may affect the unexpectedKeyCache, using `object.create(null)` instead of `{}` will be more robust