### PR TITLE
Fixes breaking toggle example

### DIFF
--- a/examples/todos/src/containers/VisibleTodoList.js
+++ b/examples/todos/src/containers/VisibleTodoList.js
@@ -20,7 +20,9 @@ const mapStateToProps = (state) => ({
 })
 
 const mapDispatchToProps = {
-  onTodoClick: toggleTodo
+  onTodoClick: id => {
+      dispatch(toggleTodo(id))
+    }
 }
 
 const VisibleTodoList = connect(


### PR DESCRIPTION
Todo toggle was not working because `toggleTodo` action was never dispatched. Took a while to figure out as a react beginner. Has been fixed in the example given here: https://redux.js.org/docs/basics/ExampleTodoList.html