### PR TITLE
Fix example: todos-with-undo

### DIFF
--- a/examples/todos-with-undo/src/reducers/todos.js
+++ b/examples/todos-with-undo/src/reducers/todos.js
@@ -1,4 +1,4 @@
-import undoable from 'redux-undo'
+import undoable, { includeAction } from 'redux-undo'
 
 const todo = (state, action) => {
   switch (action.type) {
@@ -38,6 +38,6 @@ const todos = (state = [], action) => {
   }
 }
 
-const undoableTodos = undoable(todos)
+const undoableTodos = undoable(todos, { filter: includeAction(['ADD_TODO', 'TOGGLE_TODO']) })
 
 export default undoableTodos


### PR DESCRIPTION
* Add action filter to reducer undoableTodos

Details: In the example `todos-with-undo`, currently the reducer `undoableTodos` would respond to every single action, including the action(s) related to the reducer `visibilityFilter`, which should not be what to be expected.