### PR TITLE
Update doc: advanced/Middleware

### DIFF
--- a/docs/advanced/Middleware.md
+++ b/docs/advanced/Middleware.md
@@ -257,7 +257,7 @@ function applyMiddleware(store, middlewares) {
   middlewares.forEach(middleware =>
     dispatch = middleware(store)(dispatch)
   )
-  return Object.assign({}, store, { dispatch })
+  return Object.assign(store, { dispatch })
 }
 ```
 


### PR DESCRIPTION
* Naïve implementation of the applyMiddleware api

Details: the `applyMiddleware` function returns a new `store` object, leaving the original one unmodified, which may cause confusions due to its inconsistence with the previous attempts.