### PR TITLE
update fetch error handling documentation

### DIFF
--- a/docs/advanced/AsyncActions.md
+++ b/docs/advanced/AsyncActions.md
@@ -40,7 +40,7 @@ Or you can define separate types for them:
 
 Choosing whether to use a single action type with flags, or multiple action types, is up to you. It's a convention you need to decide with your team. Multiple types leave less room for a mistake, but this is not an issue if you generate action creators and reducers with a helper library like [redux-actions](https://github.com/acdlite/redux-actions).
 
-Whatever convention you choose, stick with it throughout the application.  
+Whatever convention you choose, stick with it throughout the application.
 We'll use separate types in this tutorial.
 
 ## Synchronous Action Creators
@@ -363,18 +363,20 @@ export function fetchPosts(subreddit) {
 
     return fetch(`https://www.reddit.com/r/${subreddit}.json`)
       .then(
-        response => response.json(),
-        // Do not use catch, because that will also catch
-        // any errors in the dispatch and resulting render,
-        // causing a loop of 'Unexpected batch number' errors.
-        // https://github.com/facebook/react/issues/6895
-        error => console.log('An error occurred.', error)
+        response => response.json()
       )
-      .then(json =>
-        // We can dispatch many times!
-        // Here, we update the app state with the results of the API call.
+      .then(
+        successJson =>
+          // We can dispatch many times!
+          // Here, we update the app state with the results of the API call.
+          dispatch(receivePosts(subreddit, successJson)),
 
-        dispatch(receivePosts(subreddit, json))
+         errorJson =>
+          // Do not use catch, because that will also catch
+          // any errors in the dispatch and resulting render,
+          // causing a loop of 'Unexpected batch number' errors.
+          // https://github.com/facebook/react/issues/6895
+          console.log('An error occurred.', errorJson)
       )
   }
 }


### PR DESCRIPTION
errors are not separated into their own callback in the first `then`, all responses (success or error) must go through response.json()