### PR TITLE
Include `replaceReducer` in middleware store API.

### DIFF
--- a/src/applyMiddleware.js
+++ b/src/applyMiddleware.js
@@ -29,6 +29,7 @@ export default function applyMiddleware(...middlewares) {
 
     const middlewareAPI = {
       getState: store.getState,
+      replaceReducer: store.replaceReducer,
       dispatch: (...args) => dispatch(...args)
     }
     chain = middlewares.map(middleware => middleware(middlewareAPI))

--- a/test/applyMiddleware.spec.js
+++ b/test/applyMiddleware.spec.js
@@ -48,16 +48,18 @@ describe('applyMiddleware', () => {
       }
     }
 
-    const spy = jest.fn();
-    const store = applyMiddleware(test(spy), thunk)(createStore)(reducers.todos);
+    const spy = jest.fn()
+    const store = applyMiddleware(test(spy), thunk)(createStore)(reducers.todos)
 
-    store.dispatch(addTodo('Use Redux'));
-    store.dispatch(addTodo('Flux FTW!'));
+    store.dispatch(addTodo('Use Redux'))
+    store.dispatch(addTodo('Flux FTW!'))
 
-    expect(spy).toHaveBeenCalledWith(expect.objectContaining({
-      replaceReducer: expect.any(Function)
-    }));
-  });
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replaceReducer: expect.any(Function)
+      })
+    )
+  })
 
   it('passes recursive dispatches through the middleware chain', () => {
     function test(spyOnMethods) {

--- a/test/applyMiddleware.spec.js
+++ b/test/applyMiddleware.spec.js
@@ -40,6 +40,25 @@ describe('applyMiddleware', () => {
     ])
   })
 
+  it('should pass store.replaceReducer to middleware', () => {
+    function test(spyOnMethods) {
+      return methods => {
+        spyOnMethods(methods)
+        return next => action => next(action)
+      }
+    }
+
+    const spy = jest.fn();
+    const store = applyMiddleware(test(spy), thunk)(createStore)(reducers.todos);
+
+    store.dispatch(addTodo('Use Redux'));
+    store.dispatch(addTodo('Flux FTW!'));
+
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({
+      replaceReducer: expect.any(Function)
+    }));
+  });
+
   it('passes recursive dispatches through the middleware chain', () => {
     function test(spyOnMethods) {
       return () => next => action => {


### PR DESCRIPTION
At the moment the store that gets passed to middleware does not include the `replaceReducer` function.
It would be really useful to have this for creating middleware that dynamically imports code split reducers.

We also believe this would create a more consistent API for the store object in middleware.