### PR TITLE
Change destination's link : learn React Router API

### DIFF
--- a/docs/advanced/UsageWithReactRouter.md
+++ b/docs/advanced/UsageWithReactRouter.md
@@ -209,7 +209,7 @@ const App = ({ match: { params } }) => {
 
 ## Next Steps
 
-Now that you know how to do basic routing, you can learn more about [React Router API](https://github.com/reactjs/react-router/tree/v3/docs/)
+Now that you know how to do basic routing, you can learn more about [React Router API](https://reacttraining.com/react-router/)
 
 >##### Note About Other Routing Libraries
 


### PR DESCRIPTION
Change destination's link to learn React Router API V4 instead of V3