### PR TITLE
Fixed prettier glob pattern under windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   ],
   "scripts": {
     "clean": "rimraf lib dist es coverage",
-    "format": "prettier --write '{src,test}/**/*.js'",
-    "format:check": "prettier --list-different '{src,test}/**/*.js'",
+    "format": "prettier --write \"{src,test}/**/*.js\"",
+    "format:check": "prettier --list-different \"{src,test}/**/*.js\"",
     "lint": "eslint src test build",
     "pretest": "npm run build:commonjs",
     "test": "cross-env BABEL_ENV=commonjs jest",


### PR DESCRIPTION
Use double quotes instead of single quotes for glob patterns. This is explained in the [prettier docs](https://prettier.io/docs/en/cli.html).

Closes #2828