### PR TITLE
Update Footer to use to use VisibilityFilters from actions

### DIFF
--- a/docs/basics/UsageWithReact.md
+++ b/docs/basics/UsageWithReact.md
@@ -204,20 +204,21 @@ export default Link
 ```js
 import React from 'react'
 import FilterLink from '../containers/FilterLink'
+import { VisibilityFilters } from '../actions'
 
 const Footer = () => (
   <p>
     Show:
     {' '}
-    <FilterLink filter="SHOW_ALL">
+    <FilterLink filter={VisibilityFilters.SHOW_ALL}>
       All
     </FilterLink>
     {', '}
-    <FilterLink filter="SHOW_ACTIVE">
+    <FilterLink filter={VisibilityFilters.SHOW_ACTIVE}>
       Active
     </FilterLink>
     {', '}
-    <FilterLink filter="SHOW_COMPLETED">
+    <FilterLink filter={VisibilityFilters.SHOW_COMPLETED}>
       Completed
     </FilterLink>
   </p>


### PR DESCRIPTION
Import and use the VisibilityFilters const from the actions file in the
documentation instead of using a hardcoded string.

I believe this will make things easier for the reader (as it did for me). Also, it doesn't seem to be a good practice to keep repeating constants throughout the codebase.

Some other places in the docs could benefit from this change. I didn't update them yet because I would like some feedback first.