### PR TITLE
Fix redirects in docs for previous urls

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,4 +1,3 @@
-root: ./docs
 structure:
-  readme: ../README.md
-  summary: README.md
+  readme: README.md
+  summary: docs/README.md


### PR DESCRIPTION
This PR fixes the issue about urls mentioned in #2837 and #2842.

You can test it on the test project (https://redux.gitbook.io/redux-test/) which is synced with my fork `SamyPesse/redux`:

- https://redux.gitbook.io/redux-test/docs/introduction/index.html
- https://redux.gitbook.io/redux-test/docs/basics/index.html
- https://redux.gitbook.io/redux-test/docs/advanced/index.html
- https://redux.gitbook.io/redux-test/docs/recipes/index.html
- https://redux.gitbook.io/redux-test/docs/Glossary.html
