### PR TITLE
fix links on home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,14 +162,14 @@ If you enjoyed my course, consider supporting Egghead by [buying a subscription]
 
 ## Documentation
 
-* [Introduction](http://redux.js.org/docs/introduction/index.html)
-* [Basics](http://redux.js.org/docs/basics/index.html)
-* [Advanced](http://redux.js.org/docs/advanced/index.html)
-* [Recipes](http://redux.js.org/docs/recipes/index.html)
-* [FAQ](http://redux.js.org/docs/FAQ.html)
-* [Troubleshooting](http://redux.js.org/docs/Troubleshooting.html)
-* [Glossary](http://redux.js.org/docs/Glossary.html)
-* [API Reference](http://redux.js.org/docs/api/index.html)
+* [Introduction](http://redux.js.org/introduction)
+* [Basics](http://redux.js.org/basics)
+* [Advanced](http://redux.js.org/advanced)
+* [Recipes](http://redux.js.org/recipes)
+* [FAQ](http://redux.js.org/FAQ.html)
+* [Troubleshooting](http://redux.js.org/Troubleshooting.html)
+* [Glossary](http://redux.js.org/Glossary.html)
+* [API Reference](http://redux.js.org/api/index.html)
 
 For PDF, ePub, and MOBI exports for offline reading, and instructions on how to create them, please see: [paulkogel/redux-offline-docs](https://github.com/paulkogel/redux-offline-docs).
 


### PR DESCRIPTION
The links are broken. I'm brand new to this project and the link to 'introduction' shows page not found. Yes these links are also still broken. Just trying to point out that there are broken links on the home page which affects the learning experience.