### PR TITLE
Add return state to visibilityFilter when filter is undefined

### DIFF
--- a/examples/todos-flow/src/reducers/visibilityFilter.js
+++ b/examples/todos-flow/src/reducers/visibilityFilter.js
@@ -8,7 +8,7 @@ const visibilityFilter = (
 ): VisibilityFilter => {
   switch (action.type) {
     case 'SET_VISIBILITY_FILTER':
-      return action.filter;
+      return action.filter || state;
     default:
       return state;
   }

--- a/examples/todos-with-undo/src/reducers/visibilityFilter.js
+++ b/examples/todos-with-undo/src/reducers/visibilityFilter.js
@@ -1,7 +1,7 @@
 const visibilityFilter = (state = 'SHOW_ALL', action) => {
   switch (action.type) {
     case 'SET_VISIBILITY_FILTER':
-      return action.filter
+      return action.filter || state
     default:
       return state
   }

--- a/examples/todos/src/reducers/visibilityFilter.js
+++ b/examples/todos/src/reducers/visibilityFilter.js
@@ -1,7 +1,7 @@
 const visibilityFilter = (state = 'SHOW_ALL', action) => {
   switch (action.type) {
     case 'SET_VISIBILITY_FILTER':
-      return action.filter
+      return action.filter || state
     default:
       return state
   }


### PR DESCRIPTION
Given action "SET_VISIBILITY_FILTER", reducer "visibilityFilter" returned undefined. To ignore an action, you must explicitly return the previous state. If you want this reducer to hold no value, you can return null instead of undefined.