### PR TITLE
Add a sideEffects: false flag for Webpack 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,5 +105,6 @@
   },
   "jest": {
     "testRegex": "(/test/.*\\.spec.js)$"
-  }
+  },
+  "sideEffects": false
 }


### PR DESCRIPTION
See https://github.com/webpack/webpack/tree/master/examples/side-effects

Webpack 4 can more effectively tree shake when a module defines itself as having no side effects (aka, doesn't talk to things external to the module at the top level). I believe we qualify, but I'm putting this in as a PR just to be sure. Looks like it can easily net some byte savings for end users 👍 