### PR TITLE
[docs] [examples] remove the open localhost cmd from examples

### DIFF
--- a/docs/introduction/Examples.md
+++ b/docs/introduction/Examples.md
@@ -25,8 +25,6 @@ git clone https://github.com/reactjs/redux.git
 cd redux/examples/counter
 npm install
 npm start
-
-open http://localhost:3000/
 ```
 
 Or check out the [sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/counter).
@@ -45,8 +43,6 @@ git clone https://github.com/reactjs/redux.git
 cd redux/examples/todos
 npm install
 npm start
-
-open http://localhost:3000/
 ```
 
 Or check out the [sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/todos).
@@ -65,8 +61,6 @@ git clone https://github.com/reactjs/redux.git
 cd redux/examples/todos-with-undo
 npm install
 npm start
-
-open http://localhost:3000/
 ```
 
 Or check out the [sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/todos-with-undo).
@@ -83,8 +77,6 @@ git clone https://github.com/reactjs/redux.git
 cd redux/examples/todomvc
 npm install
 npm start
-
-open http://localhost:3000/
 ```
 
 Or check out the [sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/todomvc).
@@ -103,8 +95,6 @@ git clone https://github.com/reactjs/redux.git
 cd redux/examples/shopping-cart
 npm install
 npm start
-
-open http://localhost:3000/
 ```
 
 Or check out the [sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/shopping-cart).
@@ -121,8 +111,6 @@ git clone https://github.com/reactjs/redux.git
 cd redux/examples/tree-view
 npm install
 npm start
-
-open http://localhost:3000/
 ```
 
 Or check out the [sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/tree-view).
@@ -141,8 +129,6 @@ git clone https://github.com/reactjs/redux.git
 cd redux/examples/async
 npm install
 npm start
-
-open http://localhost:3000/
 ```
 
 Or check out the [sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/async).
@@ -159,8 +145,6 @@ git clone https://github.com/reactjs/redux.git
 cd redux/examples/universal
 npm install
 npm start
-
-open http://localhost:3000/
 ```
 
 This is a basic demonstration of [server rendering](../recipes/ServerRendering.md) with Redux and React. It shows how to prepare the initial store state on the server, and pass it down to the client so the client store can boot up from an existing state.
@@ -175,8 +159,6 @@ git clone https://github.com/reactjs/redux.git
 cd redux/examples/real-world
 npm install
 npm start
-
-open http://localhost:3000/
 ```
 
 Or check out the [sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/real-world).


### PR DESCRIPTION
IMHO, there is no need to specify this command in the documentation since all the examples are based off `create-react-app` and executing the `npm start` script calls the `openBrowser` method that does this by default. Would love to remove this `open ...` command to avoid confusion.