### PR TITLE
Remove validator.js suggestion

### DIFF
--- a/docs/recipes/ServerRendering.md
+++ b/docs/recipes/ServerRendering.md
@@ -280,7 +280,7 @@ Because we have introduced more code that relies on user generated content (UGC)
 
 In our example, we take a rudimentary approach to security. When we obtain the parameters from the request, we use `parseInt` on the `counter` parameter to ensure this value is a number. If we did not do this, you could easily get dangerous data into the rendered HTML by providing a script tag in the request. That might look like this: `?counter=</script><script>doSomethingBad();</script>`
 
-For our simplistic example, coercing our input into a number is sufficiently secure. If you're handling more complex input, such as freeform text, then you should run that input through an appropriate sanitization function.
+For our simplistic example, coercing our input into a number is sufficiently secure. If you're handling more complex input, such as freeform text, then you should run that input through an appropriate sanitization function, such as [xss-filters](https://github.com/yahoo/xss-filters).
 
 Furthermore, you can add additional layers of security by sanitizing your state output. `JSON.stringify` can be subject to script injections. To counter this, you can scrub the JSON string of HTML tags and other dangerous characters. This can be done with either a simple text replacement on the string, e.g. `JSON.stringify(state).replace(/</g, '\\u003c')`, or via more sophisticated libraries such as [serialize-javascript](https://github.com/yahoo/serialize-javascript).
 

--- a/docs/recipes/ServerRendering.md
+++ b/docs/recipes/ServerRendering.md
@@ -280,7 +280,7 @@ Because we have introduced more code that relies on user generated content (UGC)
 
 In our example, we take a rudimentary approach to security. When we obtain the parameters from the request, we use `parseInt` on the `counter` parameter to ensure this value is a number. If we did not do this, you could easily get dangerous data into the rendered HTML by providing a script tag in the request. That might look like this: `?counter=</script><script>doSomethingBad();</script>`
 
-For our simplistic example, coercing our input into a number is sufficiently secure. If you're handling more complex input, such as freeform text, then you should run that input through an appropriate sanitization function, such as [validator.js](https://www.npmjs.com/package/validator).
+For our simplistic example, coercing our input into a number is sufficiently secure. If you're handling more complex input, such as freeform text, then you should run that input through an appropriate sanitization function.
 
 Furthermore, you can add additional layers of security by sanitizing your state output. `JSON.stringify` can be subject to script injections. To counter this, you can scrub the JSON string of HTML tags and other dangerous characters. This can be done with either a simple text replacement on the string, e.g. `JSON.stringify(state).replace(/</g, '\\u003c')`, or via more sophisticated libraries such as [serialize-javascript](https://github.com/yahoo/serialize-javascript).
 


### PR DESCRIPTION
According to the [validator.js documentation](https://github.com/chriso/validator.js), XSS sanitization was removed from the library in late 2013. Because of this, I believe it makes sense to remove it as a suggestion from the SSR recipe. At the time, the maintainer suggested checking out [Google Caja](https://code.google.com/archive/p/google-caja/source/default/source). I also did some searching on NPM and found the following two packages, both of which seem full featured and popular:

https://www.npmjs.com/package/xss
https://www.npmjs.com/package/xss-filters

Should we replace the suggestion with one of the alternatives above? Definitely open to suggestions — thanks! 