### PR TITLE
README: Fix broken example links

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,16 +189,16 @@ For Offline docs, please see: [devdocs](http://devdocs.io/redux/)
 
 Almost all examples have a corresponding CodeSandbox sandbox. This is an interactive version of the code that you can play with online.
 
-* [Counter Vanilla](http://redux.js.org/docs/introduction/Examples.html#counter-vanilla) ([source](https://github.com/reactjs/redux/tree/master/examples/counter-vanilla))
-* [Counter](http://redux.js.org/docs/introduction/Examples.html#counter) ([source](https://github.com/reactjs/redux/tree/master/examples/counter), [sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/counter))
-* [Todos](http://redux.js.org/docs/introduction/Examples.html#todos) ([source](https://github.com/reactjs/redux/tree/master/examples/todos), [sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/todos))
-* [Todos with Undo](http://redux.js.org/docs/introduction/Examples.html#todos-with-undo) ([source](https://github.com/reactjs/redux/tree/master/examples/todos-with-undo), [sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/todos-with-undo))
-* [TodoMVC](http://redux.js.org/docs/introduction/Examples.html#todomvc) ([source](https://github.com/reactjs/redux/tree/master/examples/todomvc), [sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/todomvc))
-* [Shopping Cart](http://redux.js.org/docs/introduction/Examples.html#shopping-cart) ([source](https://github.com/reactjs/redux/tree/master/examples/shopping-cart), [sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/shopping-cart))
-* [Tree View](http://redux.js.org/docs/introduction/Examples.html#tree-view) ([source](https://github.com/reactjs/redux/tree/master/examples/tree-view), [sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/tree-view))
-* [Async](http://redux.js.org/docs/introduction/Examples.html#async) ([source](https://github.com/reactjs/redux/tree/master/examples/async), [sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/async))
-* [Universal](http://redux.js.org/docs/introduction/Examples.html#universal) ([source](https://github.com/reactjs/redux/tree/master/examples/universal))
-* [Real World](http://redux.js.org/docs/introduction/Examples.html#real-world) ([source](https://github.com/reactjs/redux/tree/master/examples/real-world), [sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/real-world))
+* Counter Vanilla: [Source](https://github.com/reactjs/redux/tree/master/examples/counter-vanilla)
+* Counter: [Source](https://github.com/reactjs/redux/tree/master/examples/counter) / [Sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/counter)
+* Todos: [Source](https://github.com/reactjs/redux/tree/master/examples/todos) / [Sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/todos)
+* Todos with Undo: [Source](https://github.com/reactjs/redux/tree/master/examples/todos-with-undo) / [Sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/todos-with-undo)
+* TodoMVC: [Source](https://github.com/reactjs/redux/tree/master/examples/todomvc) / [Sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/todomvc)
+* Shopping Cart: [Source](https://github.com/reactjs/redux/tree/master/examples/shopping-cart) / [Sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/shopping-cart)
+* Tree View: [Source](https://github.com/reactjs/redux/tree/master/examples/tree-view) / [Sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/tree-view)
+* Async: [Source](https://github.com/reactjs/redux/tree/master/examples/async) / [Sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/async)
+* Universal: [Source](https://github.com/reactjs/redux/tree/master/examples/universal)
+* Real World: [Source](https://github.com/reactjs/redux/tree/master/examples/real-world) / [Sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/real-world)
 
 If you're new to the NPM ecosystem and have troubles getting a project up and running, or aren't sure where to paste the gist above, check out [simplest-redux-example](https://github.com/jackielii/simplest-redux-example) that uses Redux together with React and Browserify.
 

--- a/README.md
+++ b/README.md
@@ -189,16 +189,16 @@ For Offline docs, please see: [devdocs](http://devdocs.io/redux/)
 
 Almost all examples have a corresponding CodeSandbox sandbox. This is an interactive version of the code that you can play with online.
 
-* Counter Vanilla: [Source](https://github.com/reactjs/redux/tree/master/examples/counter-vanilla)
-* Counter: [Source](https://github.com/reactjs/redux/tree/master/examples/counter) / [Sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/counter)
-* Todos: [Source](https://github.com/reactjs/redux/tree/master/examples/todos) / [Sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/todos)
-* Todos with Undo: [Source](https://github.com/reactjs/redux/tree/master/examples/todos-with-undo) / [Sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/todos-with-undo)
-* TodoMVC: [Source](https://github.com/reactjs/redux/tree/master/examples/todomvc) / [Sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/todomvc)
-* Shopping Cart: [Source](https://github.com/reactjs/redux/tree/master/examples/shopping-cart) / [Sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/shopping-cart)
-* Tree View: [Source](https://github.com/reactjs/redux/tree/master/examples/tree-view) / [Sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/tree-view)
-* Async: [Source](https://github.com/reactjs/redux/tree/master/examples/async) / [Sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/async)
-* Universal: [Source](https://github.com/reactjs/redux/tree/master/examples/universal)
-* Real World: [Source](https://github.com/reactjs/redux/tree/master/examples/real-world) / [Sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/real-world)
+* [**Counter Vanilla**](https://redux.js.org/introduction/examples#counter-vanilla): [Source](https://github.com/reactjs/redux/tree/master/examples/counter-vanilla)
+* [**Counter**](https://redux.js.org/introduction/examples#counter): [Source](https://github.com/reactjs/redux/tree/master/examples/counter) | [Sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/counter)
+* [**Todos**](https://redux.js.org/introduction/examples#todos): [Source](https://github.com/reactjs/redux/tree/master/examples/todos) | [Sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/todos)
+* [**Todos with Undo**](https://redux.js.org/introduction/examples#todos-with-undo): [Source](https://github.com/reactjs/redux/tree/master/examples/todos-with-undo) | [Sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/todos-with-undo)
+* [**TodoMVC**](https://redux.js.org/introduction/examples#todomvc): [Source](https://github.com/reactjs/redux/tree/master/examples/todomvc) | [Sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/todomvc)
+* [**Shopping Cart**](https://redux.js.org/introduction/examples#shopping-cart): [Source](https://github.com/reactjs/redux/tree/master/examples/shopping-cart) | [Sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/shopping-cart)
+* [**Tree View**](https://redux.js.org/introduction/examples#tree-view): [Source](https://github.com/reactjs/redux/tree/master/examples/tree-view) | [Sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/tree-view)
+* [**Async**](https://redux.js.org/introduction/examples#async): [Source](https://github.com/reactjs/redux/tree/master/examples/async) | [Sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/async)
+* [**Universal**](https://redux.js.org/introduction/examples#universal): [Source](https://github.com/reactjs/redux/tree/master/examples/universal)
+* [**Real World**](https://redux.js.org/introduction/examples#real-world): [Source](https://github.com/reactjs/redux/tree/master/examples/real-world) | [Sandbox](https://codesandbox.io/s/github/reactjs/redux/tree/master/examples/real-world)
 
 If you're new to the NPM ecosystem and have troubles getting a project up and running, or aren't sure where to paste the gist above, check out [simplest-redux-example](https://github.com/jackielii/simplest-redux-example) that uses Redux together with React and Browserify.
 


### PR DESCRIPTION
In the Examples section, the bulleted titles were linking to non-existing pages. Removed these links  and tweaked the formatting to improve readability a bit.