### PR TITLE
Async Actions Tutorial: Fix broken Promise in thunk action creator

### DIFF
--- a/docs/advanced/AsyncActions.md
+++ b/docs/advanced/AsyncActions.md
@@ -363,18 +363,19 @@ export function fetchPosts(subreddit) {
 
     return fetch(`https://www.reddit.com/r/${subreddit}.json`)
       .then(
-        response => response.json(),
-        // Do not use catch, because that will also catch
-        // any errors in the dispatch and resulting render,
-        // causing a loop of 'Unexpected batch number' errors.
-        // https://github.com/facebook/react/issues/6895
-        error => console.log('An error occurred.', error)
-      )
-      .then(json =>
-        // We can dispatch many times!
-        // Here, we update the app state with the results of the API call.
-
-        dispatch(receivePosts(subreddit, json))
+        response => {
+          // We can dispatch many times!
+          // Here, we update the app state with the results of the API call.
+          return dispatch(receivePosts(subreddit, response.json())
+        },
+        error => {
+          // Do not use catch, because that will also catch
+          // any errors in the dispatch and resulting render,
+          // causing a loop of 'Unexpected batch number' errors.
+          // https://github.com/facebook/react/issues/6895
+          console.log('An error occurred.', error)
+          return error
+        }
       )
   }
 }


### PR DESCRIPTION
The current `onRejected` function resolves with `undefined` because it returns the `console.log()` expression. This means that if the `fetch()` errors, the `onRejected` in the first `then()` will resolve with `undefined`, causing `json` in the second `then()` to be `undefined`. Calling `receivePosts()` with `json === undefined` will error on `json.data`.

There's no reason to use two `then()` calls. But if two `then()` calls are desired, the second `then()` must happen before the `onRejected` function, because the `onRejected` function should resolve with something so it doesn't have an unhandled Promise rejection. In the fix, the `onRejected` function resolves with the `error`. To have the second `then()`, you could nest the `then()` inside the `onResolved` function like so:
```
.then(
  response => Promise.resolve(response.json)
    .then(
      json => dispatch(receivePosts(subreddit, json))
    )
)
```
But there's no point in doing that.