### PR TITLE
Remove dead link from Immutability reading list

### DIFF
--- a/docs/recipes/reducers/PrerequisiteConcepts.md
+++ b/docs/recipes/reducers/PrerequisiteConcepts.md
@@ -67,7 +67,6 @@ Because of these rules, it's important that the following core concepts are full
 **Reading List**:
 
 - [Pros and Cons of Using Immutability With React](http://reactkungfu.com/2015/08/pros-and-cons-of-using-immutability-with-react-js/)
-- [Javascript and Immutability](http://www.t4d.io/javascript-and-immutability/)
 - [Immutable Data using ES6 and Beyond](http://wecodetheweb.com/2016/02/12/immutable-javascript-using-es6-and-beyond/)
 - [Immutable Data from Scratch](https://ryanfunduk.com/articles/immutable-data-from-scratch/)
 - [Redux Docs: Using the Object Spread Operator](../UsingObjectSpreadOperator.md)


### PR DESCRIPTION
http://www.t4d.io/javascript-and-immutability/ results in 404, so I removed it.
I did a few searches to see if the page had moved, but I came up empty.