### PR TITLE
Rewrite the README to add more learning resources and clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,34 +5,70 @@ Redux is a predictable state container for JavaScript apps.
 
 It helps you write applications that behave consistently, run in different environments (client, server, and native), and are easy to test. On top of that, it provides a great developer experience, such as [live code editing combined with a time traveling debugger](https://github.com/gaearon/redux-devtools).
 
-You can use Redux together with [React](https://facebook.github.io/react/), or with any other view library.  
+You can use Redux together with [React](https://reactjs.org), or with any other view library.  
 It is tiny (2kB, including dependencies).
 
 [![build status](https://img.shields.io/travis/reactjs/redux/master.svg?style=flat-square)](https://travis-ci.org/reactjs/redux)
 [![npm version](https://img.shields.io/npm/v/redux.svg?style=flat-square)](https://www.npmjs.com/package/redux)
 [![npm downloads](https://img.shields.io/npm/dm/redux.svg?style=flat-square)](https://www.npmjs.com/package/redux)
 [![redux channel on discord](https://img.shields.io/badge/discord-%23redux%20%40%20reactiflux-61dafb.svg?style=flat-square)](https://discord.gg/0ZcbPKXt5bZ6au5t)
-[![#rackt on freenode](https://img.shields.io/badge/irc-%23rackt%20%40%20freenode-61DAFB.svg?style=flat-square)](https://webchat.freenode.net/)
 [![Changelog #187](https://img.shields.io/badge/changelog-%23187-lightgrey.svg?style=flat-square)](https://changelog.com/187)
 
->**Learn Redux from its creator:**  
->**[Part 1: Getting Started with Redux](https://egghead.io/series/getting-started-with-redux) (30 free videos)**<br>
->**[Part 2: Building React Applications with Idiomatic Redux](https://egghead.io/courses/building-react-applications-with-idiomatic-redux) (27 free videos)**
 
-## Testimonials
+## Learn Redux
 
->[“Love what you're doing with Redux”](https://twitter.com/jingc/status/616608251463909376)  
->Jing Chen, creator of Flux
+We have a variety of resources available to help you learn Redux, no matter what your background or learning style is.
 
->[“I asked for comments on Redux in FB's internal JS discussion group, and it was universally praised. Really awesome work.”](https://twitter.com/fisherwebdev/status/616286955693682688)  
->Bill Fisher, author of Flux documentation
+### Just the Basics
 
->[“It's cool that you are inventing a better Flux by not doing Flux at all.”](https://twitter.com/andrestaltz/status/616271392930201604)  
->André Staltz, creator of Cycle
+If you're brand new to Redux and want to understand the basic concepts, see:
+
+- The **[basic tutorial in the Redux docs](https://redux.js.org/basics)**
+- Redux creator Dan Abramov's **free ["Getting Started with Redux" video series](https://egghead.io/series/getting-started-with-redux)** on Egghead.io
+- Redux co-maintainer Mark Erikson's **["Redux Fundamentals" slideshow](http://blog.isquaredsoftware.com/2018/03/presentation-reactathon-redux-fundamentals/)** and **[list of suggested resources for learning Redux](http://blog.isquaredsoftware.com/2017/12/blogged-answers-learn-redux/)**
+- If you learn best by looking at code and playing with it, check out our list of **[Redux example applications](https://redux.js.org/introduction/examples)**, available as separate projects in the Redux repo, and also as interactive online examples on CodeSandbox.
+- The **[Redux Tutorials](https://github.com/markerikson/react-redux-links/blob/master/redux-tutorials.md)** section of the **[React/Redux links list](https://github.com/markerikson/react-redux-links)**.  Here's a top list of our recommended tutorials:
+    - Dave Ceddia's posts [What Does Redux Do? (and when should you use it?)](https://daveceddia.com/what-does-redux-do/) and [How Redux Works: A Counter-Example](https://daveceddia.com/how-does-redux-work/) are a great intro to the basics of Redux and how to use it with React, as is this post on [React and Redux: An Introduction](http://jakesidsmith.com/blog/post/2017-11-18-redux-and-react-an-introduction/).
+    - Valentino Gagliardi's post [React Redux Tutorial for Beginners: Learning Redux in 2018](https://www.valentinog.com/blog/react-redux-tutorial-beginners/) is an excellent extended introduction to many aspects of using Redux.
+    - The CSS Tricks article [Leveling Up with React: Redux](https://css-tricks.com/learning-react-redux/) covers the Redux basics well.
+    - This [DevGuides: Introduction to Redux](http://devguides.io/redux/) tutorial covers several aspects of Redux, including actions, reducers, usage with React, and middleware.
+
+
+### Intermediate Concepts
+
+Once you've picked up the basics of working with actions, reducers, and the store, you may have questions about topics like working with asynchronous logic and AJAX requests, connecting a UI framework like React to your Redux store, and setting up an application to use Redux:
+
+- The **["Advanced" docs section](https://redux.js.org/advanced)** covers working with async logic, middleware, routing.
+- The Redux docs **["Learning Resources"](https://redux.js.org/introduction/learning-resources)** page points to recommended articles on a variety of Redux-related topics.
+- Sophie DeBenedetto's 8-part **[Building a Simple CRUD App with React + Redux](http://www.thegreatcodeadventure.com/building-a-simple-crud-app-with-react-redux-part-1/)** series shows how to put together a basic CRUD app from scratch.
+
+
+### Real-World Usage
+
+Going from a TodoMVC app to a real production application can be a big jump, but we've got plenty of resources to help:
+
+- Redux creator Dan Abramov's **[free "Building React Applications with Idiomatic Redux" video series](https://egghead.io/courses/building-react-applications-with-idiomatic-redux)** builds on his first video series and covers topics like middleware, routing, and persistence.
+- The **[Redux FAQ](https://redux.js.org/faq)** answers many common questions about how to use Redux, and the **["Recipes" docs section](https://redux.js.org/recipes)** has information on handling derived data, testing, structuring reducer logic, and reducing boilerplate.
+- Redux co-maintainer Mark Erikson's **["Practical Redux" tutorial series](http://blog.isquaredsoftware.com/series/practical-redux/)** demonstrates real-world intermediate and advanced techniques for working with React and Redux (also available as **[an interactive course on Educative.io](https://www.educative.io/collection/5687753853370368/5707702298738688)**).  
+- The **[React/Redux links list](https://github.com/markerikson/react-redux-links)** has categorized articles on working with [reducers and selectors](https://github.com/markerikson/react-redux-links/blob/master/redux-reducers-selectors.md), [managing side effects](https://github.com/markerikson/react-redux-links/blob/master/redux-side-effects.md), [Redux architecture and best practices](https://github.com/markerikson/react-redux-links/blob/master/redux-architecture.md), and more.
+- Our community has created thousands of Redux-related libraries, addons, and tools.  The **["Ecosystem" docs page](https://redux.js.org/introduction/ecosystem)** lists our recommendations, and there's a complete listing available in the **[Redux addons catalog](https://github.com/markerikson/redux-ecosystem-links)**.
+- If you're looking to learn from actual application codebases, the addons catalog also has a list of **[purpose-built examples and real-world applications](https://github.com/markerikson/redux-ecosystem-links/blob/master/apps-and-examples.md)**.
+
+Finally, Mark Erikson is teaching a series of **[Redux workshops through Workshop.me](#redux-workshops)**.  Check the [workshop schedule](https://workshop.me/?a=mark) for upcoming dates and locations.
+
+
+### Help and Discussion
+
+The **[#redux channel](https://discord.gg/0ZcbPKXt5bZ6au5t)** of the **[Reactiflux Discord community](http://www.reactiflux.com)** is our official resource for all questions related to learning and using Redux.  Reactiflux is a great place to hang out, ask questions, and learn - come join us!
+
+
+
 
 ## Before Proceeding Further
 
-Redux is a valuable tool for organizing your state, but you should also consider whether it's appropriate for your situation.  Here's some suggestions on when it makes sense to use Redux:
+Redux is a valuable tool for organizing your state, but you should also consider whether it's appropriate for your situation.  Don't use Redux just because someone said you should - take some time to understand the potential benefits and tradeoffs of using it.
+
+Here's some suggestions on when it makes sense to use Redux:
 * You have reasonable amounts of data changing over time
 * You need a single source of truth for your state
 * You find that keeping all your state in a top-level component is no longer sufficient
@@ -145,9 +181,12 @@ If you're coming from Flux, there is a single important difference you need to u
 
 This architecture might seem like an overkill for a counter app, but the beauty of this pattern is how well it scales to large and complex apps. It also enables very powerful developer tools, because it is possible to trace every mutation to the action that caused it. You can record user sessions and reproduce them just by replaying every action.
 
-## Learn Redux from Its Creator
+## Learn Redux from Its Authors
 
-[Getting Started with Redux](https://egghead.io/series/getting-started-with-redux) is a video course consisting of 30 videos narrated by Dan Abramov, author of Redux. It is designed to complement the “Basics” part of the docs while bringing additional insights about immutability, testing, Redux best practices, and using Redux with React. **This course is free and will always be.**
+### Redux Video Tutorials by Dan Abramov
+
+#### Getting Started with Redux
+**[Getting Started with Redux](https://egghead.io/series/getting-started-with-redux)** is a video course consisting of 30 videos narrated by [Dan Abramov](https://twitter.com/dan_abramov), author of Redux. It is designed to complement the “Basics” part of the docs while bringing additional insights about immutability, testing, Redux best practices, and using Redux with React. **This course is free and will always be.**
 
 >[“Great course on egghead.io by @dan_abramov - instead of just showing you how to use #redux, it also shows how and why redux was built!”](https://twitter.com/sandrinodm/status/670548531422326785)  
 >Sandrino Di Mattia
@@ -166,9 +205,53 @@ This architecture might seem like an overkill for a counter app, but the beauty 
 
 So, what are you waiting for?
 
-### [Watch the 30 Free Videos!](https://egghead.io/series/getting-started-with-redux)
+#### [Watch the free "Getting Started with Redux" video series](https://egghead.io/series/getting-started-with-redux)
 
-If you enjoyed my course, consider supporting Egghead by [buying a subscription](https://egghead.io/pricing). Subscribers have access to the source code of every example in my videos and tons of advanced lessons on other topics, including JavaScript in depth, React, Angular, and more. Many [Egghead instructors](https://egghead.io/instructors) are also open source library authors, so buying a subscription is a nice way to thank them for the work that they've done.
+> Note: If you enjoyed Dan's course, consider supporting Egghead by [buying a subscription](https://egghead.io/pricing). Subscribers have access to the source code of every example in my videos and tons of advanced lessons on other topics, including JavaScript in depth, React, Angular, and more. Many [Egghead instructors](https://egghead.io/instructors) are also open source library authors, so buying a subscription is a nice way to thank them for the work that they've done.
+
+
+#### Building React Applications with Idiomatic Redux
+
+The **[Building React Applications with Idiomatic Redux](https://egghead.io/courses/building-react-applications-with-idiomatic-redux)** course is a second free video series by Dan Abramov.  It picks up where the first series left off, and covers practical production ready techniques for building your React and Redux applications: advanced state management, middleware, React Router integration, and other common problems you are likely to encounter while building applications for your clients and customers.  As with the first series, **this course will always be free**.
+
+
+#### [Watch the free "Idiomatic Redux" video series](https://egghead.io/courses/building-react-applications-with-idiomatic-redux)
+
+
+
+### Practical Redux course
+
+**[Practical Redux](https://www.educative.io/collection/5687753853370368/5707702298738688/)** is a paid interactive course by Redux co-maintainer [Mark Erikson](https://twitter.com/acemarke).  The course is designed to show how to apply the basic concepts of Redux to building something larger than a TodoMVC application.  It includes real-world topics like:
+
+
+- Adding Redux to a new Create-React-App project and configuring Hot Module Replacement for faster development 
+- Controling your UI behavior with Redux 
+- Using the Redux-ORM library to manage relational data in your Redux store 
+- Building a master/detail view to display and edit data 
+- Writing custom advanced Redux reducer logic to solve specific problems 
+- Optimizing performance of Redux-connected form inputs 
+
+And much more!  
+
+The course is based on Mark's original free **["Practical Redux" blog tutorial series](http://blog.isquaredsoftware.com/series/practical-redux/)**, but with updated and improved content.
+
+
+### Redux Workshops
+
+Redux co-maintainer [Mark Erikson](https://twitter.com/acemarke) has partnered with [Workshop.me](https://workshop.me/) to teach a series of Redux workshops.
+
+The first [**Redux Fundamentals** workshop will be held in New York City, April 19-20](https://workshop.me/2018-04-react-redux?a=mark), and will cover:
+
+- The history and purpose of Redux
+- Reducers, actions, and working with a Redux store
+- Using Redux with React
+- Using and writing Redux middleware
+- Working with AJAX calls and other side effects
+- Unit testing Redux apps
+- Real-world Redux app structure and development
+
+Tickets are still available, and [can be purchased through Workshop.me](https://workshop.me/2018-04-react-redux?a=mark).
+
 
 ## Documentation
 
@@ -202,9 +285,16 @@ Almost all examples have a corresponding CodeSandbox sandbox. This is an interac
 
 If you're new to the NPM ecosystem and have troubles getting a project up and running, or aren't sure where to paste the gist above, check out [simplest-redux-example](https://github.com/jackielii/simplest-redux-example) that uses Redux together with React and Browserify.
 
-## Discussion
+## Testimonials
 
-Join the [#redux](https://discord.gg/0ZcbPKXt5bZ6au5t) channel of the [Reactiflux](http://www.reactiflux.com) Discord community.
+>[“Love what you're doing with Redux”](https://twitter.com/jingc/status/616608251463909376)  
+>Jing Chen, creator of Flux
+
+>[“I asked for comments on Redux in FB's internal JS discussion group, and it was universally praised. Really awesome work.”](https://twitter.com/fisherwebdev/status/616286955693682688)  
+>Bill Fisher, author of Flux documentation
+
+>[“It's cool that you are inventing a better Flux by not doing Flux at all.”](https://twitter.com/andrestaltz/status/616271392930201604)  
+>André Staltz, creator of Cycle
 
 ## Thanks
 

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -10,5 +10,6 @@ These are some use cases and code snippets to get you started with Redux in a re
 * [Computing Derived Data](ComputingDerivedData.md)
 * [Implementing Undo History](ImplementingUndoHistory.md)
 * [Isolating Subapps](IsolatingSubapps.md)
+* [Structuring Reducers](StructuringReducers.md)
 * [Using Immutable.JS with Redux](UsingImmutableJS.md)
 


### PR DESCRIPTION
Added a large "Learn Redux" section near the front

Changed "Learn from the Creator" to "Learn from the Authors", and
expanded it to cover Dan's second video course, my "Practical
Redux" course, and my workshops

Misc cleanup:
Updated the React docs link
Removed the outdated IRC badge
Moved the "Testimonials" section