### PR TITLE
Optimize plain object check function

### DIFF
--- a/src/utils/isPlainObject.js
+++ b/src/utils/isPlainObject.js
@@ -5,10 +5,6 @@
 export default function isPlainObject(obj) {
   if (typeof obj !== 'object' || obj === null) return false
 
-  let proto = obj
-  while (Object.getPrototypeOf(proto) !== null) {
-    proto = Object.getPrototypeOf(proto)
-  }
-
-  return Object.getPrototypeOf(obj) === proto
+  const proto = Object.getPrototypeOf(obj)
+  return proto === Object.prototype || proto === null
 }


### PR DESCRIPTION
Optimized isPlainObject(obj) function, skipping while loop.
Working well with test `test/utils/isPlainObject.spec.js`

Update not passing test for `expect(isPlainObject(sandbox.fromAnotherRealm)).toBe(true)`