### PR TITLE
docs: Change lets to const when creating store

### DIFF
--- a/docs/advanced/Middleware.md
+++ b/docs/advanced/Middleware.md
@@ -309,7 +309,7 @@ Here's how to apply it to a Redux store:
 import { createStore, combineReducers, applyMiddleware } from 'redux'
 
 let todoApp = combineReducers(reducers)
-let store = createStore(
+const store = createStore(
   todoApp,
   // applyMiddleware() tells createStore() how to handle middleware
   applyMiddleware(logger, crashReporter)
@@ -474,7 +474,7 @@ const thunk = store => next => action =>
 
 // You can use all of them! (It doesn't mean you should.)
 let todoApp = combineReducers(reducers)
-let store = createStore(
+const store = createStore(
   todoApp,
   applyMiddleware(
     rafScheduler,

--- a/docs/advanced/Middleware.md
+++ b/docs/advanced/Middleware.md
@@ -37,7 +37,7 @@ store.dispatch(addTodo('Use Redux'))
 To log the action and state, you can change it to something like this:
 
 ```js
-let action = addTodo('Use Redux')
+const action = addTodo('Use Redux')
 
 console.log('dispatching', action)
 store.dispatch(action)
@@ -71,7 +71,7 @@ We could end this here, but it's not very convenient to import a special functio
 What if we just replace the `dispatch` function on the store instance? The Redux store is just a plain object with [a few methods](../api/Store.md), and we're writing JavaScript, so we can just monkeypatch the `dispatch` implementation:
 
 ```js
-let next = store.dispatch
+const next = store.dispatch
 store.dispatch = function dispatchAndLog(action) {
   console.log('dispatching', action)
   let result = next(action)
@@ -96,7 +96,7 @@ If logging and crash reporting are separate utilities, they might look like this
 
 ```js
 function patchStoreToAddLogging(store) {
-  let next = store.dispatch
+  const next = store.dispatch
   store.dispatch = function dispatchAndLog(action) {
     console.log('dispatching', action)
     let result = next(action)
@@ -106,7 +106,7 @@ function patchStoreToAddLogging(store) {
 }
 
 function patchStoreToAddCrashReporting(store) {
-  let next = store.dispatch
+  const next = store.dispatch
   store.dispatch = function dispatchAndReportErrors(action) {
     try {
       return next(action)
@@ -139,7 +139,7 @@ Monkeypatching is a hack. “Replace any method you like”, what kind of API is
 
 ```js
 function logger(store) {
-  let next = store.dispatch
+  const next = store.dispatch
 
   // Previously:
   // store.dispatch = function dispatchAndLog(action) {
@@ -183,7 +183,7 @@ Why do we even overwrite `dispatch`? Of course, to be able to call it later, but
 ```js
 function logger(store) {
   // Must point to the function returned by the previous middleware:
-  let next = store.dispatch
+  const next = store.dispatch
 
   return function dispatchAndLog(action) {
     console.log('dispatching', action)
@@ -253,7 +253,7 @@ Instead of `applyMiddlewareByMonkeypatching()`, we could write `applyMiddleware(
 function applyMiddleware(store, middlewares) {
   middlewares = middlewares.slice()
   middlewares.reverse()
-  let dispatch = store.dispatch
+  const dispatch = store.dispatch
   middlewares.forEach(middleware =>
     dispatch = middleware(store)(dispatch)
   )
@@ -308,7 +308,7 @@ Here's how to apply it to a Redux store:
 ```js
 import { createStore, combineReducers, applyMiddleware } from 'redux'
 
-let todoApp = combineReducers(reducers)
+const todoApp = combineReducers(reducers)
 const store = createStore(
   todoApp,
   // applyMiddleware() tells createStore() how to handle middleware
@@ -369,7 +369,7 @@ const timeoutScheduler = store => next => action => {
     return next(action)
   }
 
-  let timeoutId = setTimeout(
+  const timeoutId = setTimeout(
     () => next(action),
     action.meta.delay
   )
@@ -385,7 +385,7 @@ const timeoutScheduler = store => next => action => {
  * this case.
  */
 const rafScheduler = store => next => {
-  let queuedActions = []
+  const queuedActions = []
   let frame = null
 
   function loop() {
@@ -446,7 +446,7 @@ const readyStatePromise = store => next => action => {
   }
 
   function makeAction(ready, data) {
-    let newAction = Object.assign({}, action, { ready }, data)
+    const newAction = Object.assign({}, action, { ready }, data)
     delete newAction.promise
     return newAction
   }
@@ -473,7 +473,7 @@ const thunk = store => next => action =>
     : next(action)
 
 // You can use all of them! (It doesn't mean you should.)
-let todoApp = combineReducers(reducers)
+const todoApp = combineReducers(reducers)
 const store = createStore(
   todoApp,
   applyMiddleware(

--- a/docs/advanced/UsageWithReactRouter.md
+++ b/docs/advanced/UsageWithReactRouter.md
@@ -111,7 +111,7 @@ import { createStore } from 'redux'
 import todoApp from './reducers'
 import Root from './components/Root'
 
-let store = createStore(todoApp)
+const store = createStore(todoApp)
 
 render(
   <Root store={store} />,

--- a/docs/api/Store.md
+++ b/docs/api/Store.md
@@ -63,7 +63,7 @@ To learn how to describe asynchronous API calls, read the current state inside a
 
 ```js
 import { createStore } from 'redux'
-let store = createStore(todos, ['Use Redux'])
+const store = createStore(todos, ['Use Redux'])
 
 function addTodo(text) {
   return {

--- a/docs/api/Store.md
+++ b/docs/api/Store.md
@@ -124,7 +124,7 @@ function handleChange() {
   }
 }
 
-let unsubscribe = store.subscribe(handleChange)
+const unsubscribe = store.subscribe(handleChange)
 unsubscribe()
 ```
 

--- a/docs/api/applyMiddleware.md
+++ b/docs/api/applyMiddleware.md
@@ -37,7 +37,7 @@ function logger({ getState }) {
   }
 }
 
-let store = createStore(
+const store = createStore(
   todos,
   ['Use Redux'],
   applyMiddleware(logger)
@@ -61,7 +61,7 @@ import * as reducers from './reducers'
 
 let reducer = combineReducers(reducers)
 // applyMiddleware supercharges createStore with middleware:
-let store = createStore(reducer, applyMiddleware(thunk))
+const store = createStore(reducer, applyMiddleware(thunk))
 
 function fetchSecretSauce() {
   return fetch('https://www.google.com/search?q=secret+sauce')

--- a/docs/api/applyMiddleware.md
+++ b/docs/api/applyMiddleware.md
@@ -27,7 +27,7 @@ function logger({ getState }) {
     console.log('will dispatch', action)
 
     // Call the next dispatch method in the middleware chain.
-    let returnValue = next(action)
+    const returnValue = next(action)
 
     console.log('state after dispatch', getState())
 
@@ -59,7 +59,7 @@ import { createStore, combineReducers, applyMiddleware } from 'redux'
 import thunk from 'redux-thunk'
 import * as reducers from './reducers'
 
-let reducer = combineReducers(reducers)
+const reducer = combineReducers(reducers)
 // applyMiddleware supercharges createStore with middleware:
 const store = createStore(reducer, applyMiddleware(thunk))
 
@@ -203,10 +203,10 @@ export default connect(state => ({
 * If you want to conditionally apply a middleware, make sure to only import it when it's needed:
 
   ```js
-  let middleware = [a, b]
+  const middleware = [a, b]
   if (process.env.NODE_ENV !== 'production') {
-    let c = require('some-debug-middleware')
-    let d = require('another-debug-middleware')
+    const c = require('some-debug-middleware')
+    const d = require('another-debug-middleware')
     middleware = [...middleware, c, d]
   }
 

--- a/docs/api/combineReducers.md
+++ b/docs/api/combineReducers.md
@@ -102,7 +102,7 @@ export default combineReducers({
 import { createStore } from 'redux'
 import reducer from './reducers/index'
 
-let store = createStore(reducer)
+const store = createStore(reducer)
 console.log(store.getState())
 // {
 //   counter: 0,

--- a/docs/api/createStore.md
+++ b/docs/api/createStore.md
@@ -29,7 +29,7 @@ function todos(state = [], action) {
   }
 }
 
-let store = createStore(todos, ['Use Redux'])
+const store = createStore(todos, ['Use Redux'])
 
 store.dispatch({
   type: 'ADD_TODO',

--- a/docs/basics/Store.md
+++ b/docs/basics/Store.md
@@ -17,13 +17,13 @@ It's easy to create a store if you have a reducer. In the [previous section](Red
 ```js
 import { createStore } from 'redux'
 import todoApp from './reducers'
-let store = createStore(todoApp)
+const store = createStore(todoApp)
 ```
 
 You may optionally specify the initial state as the second argument to [`createStore()`](../api/createStore.md). This is useful for hydrating the state of the client to match the state of a Redux application running on the server.
 
 ```js
-let store = createStore(todoApp, window.STATE_FROM_SERVER)
+const store = createStore(todoApp, window.STATE_FROM_SERVER)
 ```
 
 ## Dispatching Actions
@@ -73,7 +73,7 @@ We specified the behavior of our app before we even started writing the UI. We w
 import { createStore } from 'redux'
 import todoApp from './reducers'
 
-let store = createStore(todoApp)
+const store = createStore(todoApp)
 ```
 
 ## Next Steps

--- a/docs/basics/UsageWithReact.md
+++ b/docs/basics/UsageWithReact.md
@@ -432,7 +432,7 @@ import { createStore } from 'redux'
 import todoApp from './reducers'
 import App from './components/App'
 
-let store = createStore(todoApp)
+const store = createStore(todoApp)
 
 render(
   <Provider store={store}>

--- a/docs/recipes/reducers/InitializingState.md
+++ b/docs/recipes/reducers/InitializingState.md
@@ -38,7 +38,7 @@ Now let's say you create a store with it.
 
 ```js
 import { createStore } from 'redux';
-let store = createStore(counter);
+const store = createStore(counter);
 console.log(store.getState()); // 0
 ```
 
@@ -48,7 +48,7 @@ Let's consider a different scenario:
 
 ```js
 import { createStore } from 'redux';
-let store = createStore(counter, 42);
+const store = createStore(counter, 42);
 console.log(store.getState()); // 42
 ```
 
@@ -86,7 +86,7 @@ If we call `createStore` without the `preloadedState`, it's going to initialize 
 
 ```js
 import { createStore } from 'redux';
-let store = createStore(combined);
+const store = createStore(combined);
 console.log(store.getState()); // { a: 'lol', b: 'wat' }
 ```
 
@@ -94,7 +94,7 @@ Let's consider a different scenario:
 
 ```js
 import { createStore } from 'redux';
-let store = createStore(combined, { a: 'horse' });
+const store = createStore(combined, { a: 'horse' });
 console.log(store.getState()); // { a: 'horse', b: 'wat' }
 ```
 


### PR DESCRIPTION
Noticed that code examples use:

`let store = createStore(...)`

Since store is never reassigned, we should use `const`.