### PR TITLE
Fix missed case in "observe" type check

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -234,7 +234,7 @@ export default function createStore(reducer, preloadedState, enhancer) {
        * emission of values from the observable.
        */
       subscribe(observer) {
-        if (typeof observer !== 'object') {
+        if (typeof observer !== 'object' || observer === null) {
           throw new TypeError('Expected the observer to be an object.')
         }
 

--- a/test/createStore.spec.js
+++ b/test/createStore.spec.js
@@ -629,11 +629,11 @@ describe('createStore', () => {
 
         expect(function() {
           obs.subscribe()
-        }).toThrow()
+        }).toThrowError(new TypeError('Expected the observer to be an object.'))
 
         expect(function() {
           obs.subscribe(() => {})
-        }).toThrow()
+        }).toThrowError(new TypeError('Expected the observer to be an object.'))
 
         expect(function() {
           obs.subscribe({})

--- a/test/createStore.spec.js
+++ b/test/createStore.spec.js
@@ -632,6 +632,10 @@ describe('createStore', () => {
         }).toThrowError(new TypeError('Expected the observer to be an object.'))
 
         expect(function() {
+          obs.subscribe(null)
+        }).toThrowError(new TypeError('Expected the observer to be an object.'))
+
+        expect(function() {
           obs.subscribe(() => {})
         }).toThrowError(new TypeError('Expected the observer to be an object.'))
 


### PR DESCRIPTION
Redux briefly checks that observer received in observe function is a valid object and throw TypeError with useful user message if is not. 
However, it missed null case, as `typeof null === 'object'` (well-known js issue) and then failed with the obscure error message `Cannot read property 'next' of null`.  I'm sure that there is no reason to not to show the correct error message in all relevant cases
https://github.com/reactjs/redux/blob/master/src/createStore.js#L237


This PR fixes that inconsistency by throwing TypeError with the same useful message in case of null observer 

Note that this PR is not a breaking change in any way
