### PR TITLE
Remove unneeded chain declaration

### DIFF
--- a/src/applyMiddleware.js
+++ b/src/applyMiddleware.js
@@ -25,13 +25,12 @@ export default function applyMiddleware(...middlewares) {
           `Other middleware would not be applied to this dispatch.`
       )
     }
-    let chain = []
 
     const middlewareAPI = {
       getState: store.getState,
       dispatch: (...args) => dispatch(...args)
     }
-    chain = middlewares.map(middleware => middleware(middlewareAPI))
+    const chain = middlewares.map(middleware => middleware(middlewareAPI))
     dispatch = compose(...chain)(store.dispatch)
 
     return {


### PR DESCRIPTION
Hello - I've been reviewing the Redux source and was trying to figure out what the purpose of assigning`chain` to an empty array was in `applyMiddleware`. There doesn't seem to be a scenario where `chain` is not immediately updated to `middlewares.map(middleware => middleware(middlewareAPI))`. Please let me know if I'm missing something here and thanks for a great library.