### PR TITLE
Replace <a /> with <button /> in reddit example

### DIFF
--- a/docs/advanced/ExampleRedditAPI.md
+++ b/docs/advanced/ExampleRedditAPI.md
@@ -272,9 +272,9 @@ class AsyncApp extends Component {
               {' '}
             </span>}
           {!isFetching &&
-            <a href="#" onClick={this.handleRefreshClick}>
+            <button onClick={this.handleRefreshClick}>
               Refresh
-            </a>}
+            </button>}
         </p>
         {isFetching && posts.length === 0 && <h2>Loading...</h2>}
         {!isFetching && posts.length === 0 && <h2>Empty.</h2>}


### PR DESCRIPTION
The use of `<a />` with `href="#"` is not compatible with [eslint-plugin-jsx-a11y](https://github.com/evcohen/eslint-plugin-jsx-a11y) which is a part of `create-react-app`. When a developer tries to copy an example and play with it locally, they see next warning:

```
Line 60:  Links must not point to "#". Use a more descriptive href or use a button instead  jsx-a11y/href-no-hash
```

While this being trivial, there still no that much justification for using anchor element as a button.