### PR TITLE
Remove "Redux itself is very simple"

### DIFF
--- a/docs/introduction/CoreConcepts.md
+++ b/docs/introduction/CoreConcepts.md
@@ -1,7 +1,5 @@
 # Core Concepts
 
-Redux itself is very simple.
-
 Imagine your app’s state is described as a plain object. For example, the state of a todo app might look like this:
 
 ```js


### PR DESCRIPTION
Reflecting a few years later this was a bit of a silly thing to write in the docs.
Of course it's not simple to people learning it.