### PR TITLE
getState is OnlyRead

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -72,7 +72,7 @@ export default function createStore(reducer, preloadedState, enhancer) {
       )
     }
 
-    return currentState
+    return {...currentState}
   }
 
   /**


### PR DESCRIPTION
example:

```
function createStore(preloadedState) {
    let currentState = preloadedState
    function getState() {
        return currentState
    }
    return {
        getState,
    }
}

const store = createStore({test: 1});
store.getState().test = 2;
console.log(store.getState()); // The test value here is 2.
```

The state has changed

I think I should return a new object in getState().

thank you.