### PR TITLE
Todos example: Always use VisibilityFilters instead of strings

### DIFF
--- a/examples/todos/src/containers/VisibleTodoList.js
+++ b/examples/todos/src/containers/VisibleTodoList.js
@@ -1,14 +1,15 @@
 import { connect } from 'react-redux'
 import { toggleTodo } from '../actions'
 import TodoList from '../components/TodoList'
+import { VisibilityFilters } from '../actions'
 
 const getVisibleTodos = (todos, filter) => {
   switch (filter) {
-    case 'SHOW_ALL':
+    case VisibilityFilters.SHOW_ALL:
       return todos
-    case 'SHOW_COMPLETED':
+    case VisibilityFilters.SHOW_COMPLETED:
       return todos.filter(t => t.completed)
-    case 'SHOW_ACTIVE':
+    case VisibilityFilters.SHOW_ACTIVE:
       return todos.filter(t => !t.completed)
     default:
       throw new Error('Unknown filter: ' + filter)

--- a/examples/todos/src/reducers/visibilityFilter.js
+++ b/examples/todos/src/reducers/visibilityFilter.js
@@ -1,4 +1,6 @@
-const visibilityFilter = (state = 'SHOW_ALL', action) => {
+import { VisibilityFilters } from '../actions'
+
+const visibilityFilter = (state = VisibilityFilters.SHOW_ALL, action) => {
   switch (action.type) {
     case 'SET_VISIBILITY_FILTER':
       return action.filter


### PR DESCRIPTION
Two months ago the VisibilityFilters export was created. This commit removes the missed places where strings were still used and replaces it with VisibilityFilters