### PR TITLE
Use same return type for both StoreCreator signatures in TS typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -220,7 +220,7 @@ export type DeepPartial<T> = { [K in keyof T]?: DeepPartial<T[K]> };
  */
 export interface StoreCreator {
   <S, A extends Action, Ext, StateExt>(reducer: Reducer<S, A>, enhancer?: StoreEnhancer<Ext, StateExt>): Store<S & StateExt, A> & Ext;
-  <S, A extends Action, Ext, StateExt>(reducer: Reducer<S, A>, preloadedState: DeepPartial<S>, enhancer?: StoreEnhancer<Ext>): Store<S & StateExt> & Ext;
+  <S, A extends Action, Ext, StateExt>(reducer: Reducer<S, A>, preloadedState: DeepPartial<S>, enhancer?: StoreEnhancer<Ext>): Store<S & StateExt, A> & Ext;
 }
 
 /**

--- a/test/typescript/store.ts
+++ b/test/typescript/store.ts
@@ -12,6 +12,11 @@ type State = {
   };
 }
 
+interface DerivedAction extends Action {
+  type: 'a',
+  b: 'b',
+}
+
 const reducer: Reducer<State> = (state: State | undefined = {
   a: 'a',
   b: {
@@ -22,6 +27,18 @@ const reducer: Reducer<State> = (state: State | undefined = {
   return state;
 };
 
+const reducerWithAction: Reducer<State, DerivedAction> = (state: State | undefined = {
+  a: 'a',
+  b: {
+    c: 'c',
+    d: 'd',
+  },
+}, action: DerivedAction): State => {
+  return state;
+};
+
+const funcWithStore = (store: Store<State, DerivedAction>) => {};
+
 /* createStore */
 
 const store: Store<State> = createStore(reducer);
@@ -29,6 +46,13 @@ const store: Store<State> = createStore(reducer);
 const storeWithPreloadedState: Store<State> = createStore(reducer, {
   b: {c: 'c'}
 });
+
+const storeWithActionReducer = createStore(reducerWithAction);
+const storeWithActionReducerAndPreloadedState = createStore(reducerWithAction, {
+  b: {c: 'c'},
+});
+funcWithStore(storeWithActionReducer);
+funcWithStore(storeWithActionReducerAndPreloadedState);
 
 const enhancer: StoreEnhancer = next => next;
 


### PR DESCRIPTION
When performing a refactor, I noticed that removing the `preloadedState` param from a `createStore` call resulted in a different type than calling `createStore` with `preloadedState`. This is due to the return type of `StoreCreator` being slightly different for each signature. Specifically, the one without `preloadedState` does not include a type param for the action type.

This PR adds the action as a type param for the return type of the `createStore` function without a `preloadedState` param, as well as a couple of additional tests in `tests/typescript/store.ts` that make sure the action type param is included in the return type for both signatures.